### PR TITLE
Feature/update recommendation after a user interaction

### DIFF
--- a/Application/Sources/Downloads/DownloadSession.m
+++ b/Application/Sources/Downloads/DownloadSession.m
@@ -100,7 +100,8 @@ NSString * const DownloadProgressKey = @"DownloadProgress";
 
 - (BOOL)addDownload:(Download *)download
 {
-    if ([[self.downloads.allValues valueForKeyPath:@"@distinctUnionOfObjects.URN"] containsObject:download.URN]) {
+    NSString *keyPath = [NSString stringWithFormat:@"@distinctUnionOfObjects.%@", @keypath(Download.new, URN)];
+    if ([[self.downloads.allValues valueForKeyPath:keyPath] containsObject:download.URN]) {
         return NO;
     }
     

--- a/Application/Sources/Helpers/Playlist.h
+++ b/Application/Sources/Helpers/Playlist.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithURN:(NSString *)URN;
 
 @property (nonatomic, nullable, readonly) NSString *recommendationUid;
+@property (nonatomic, nullable, readonly) NSArray<SRGMedia *> *medias;
 
 @end
 

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -1660,8 +1660,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         SRGLetterboxController *letterboxController = letterboxView.controller;
         Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
         
-        NSString *keyPath = [NSString stringWithFormat:@"@distinctUnionOfObjects.%@", @keypath(SRGMedia.new, URN)];
-        if (! [[playlist.medias valueForKeyPath:keyPath] containsObject:subdivision.URN]) {
+        if (! [[playlist.medias valueForKeyPath:@keypath(SRGMedia.new, URN)] containsObject:subdivision.URN]) {
             Playlist *playlist = PlaylistForURN(subdivision.URN);
             letterboxController.playlistDataSource = playlist;
             letterboxController.playbackTransitionDelegate = playlist;

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -1656,14 +1656,16 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         });
     }
     
-    SRGLetterboxController *letterboxController = letterboxView.controller;
-    Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
-    
-    NSString *keyPath = [NSString stringWithFormat:@"@distinctUnionOfObjects.%@", @keypath(SRGMedia.new, URN)];
-    if (! [[playlist.medias valueForKeyPath:keyPath] containsObject:subdivision.URN]) {
-        Playlist *playlist = PlaylistForURN(subdivision.URN);
-        letterboxController.playlistDataSource = playlist;
-        letterboxController.playbackTransitionDelegate = playlist;
+    if ([subdivision isKindOfClass:SRGChapter.class]) {
+        SRGLetterboxController *letterboxController = letterboxView.controller;
+        Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
+        
+        NSString *keyPath = [NSString stringWithFormat:@"@distinctUnionOfObjects.%@", @keypath(SRGMedia.new, URN)];
+        if (! [[playlist.medias valueForKeyPath:keyPath] containsObject:subdivision.URN]) {
+            Playlist *playlist = PlaylistForURN(subdivision.URN);
+            letterboxController.playlistDataSource = playlist;
+            letterboxController.playbackTransitionDelegate = playlist;
+        }
     }
 }
 

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -1655,6 +1655,16 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
             [letterboxView setUserInterfaceHidden:! UIAccessibilityIsVoiceOverRunning() animated:YES];
         });
     }
+    
+    SRGLetterboxController *letterboxController = letterboxView.controller;
+    Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
+    
+    NSString *keyPath = [NSString stringWithFormat:@"@distinctUnionOfObjects.%@", @keypath(SRGMedia.new, URN)];
+    if (! [[playlist.medias valueForKeyPath:keyPath] containsObject:subdivision.URN]) {
+        Playlist *playlist = PlaylistForURN(subdivision.URN);
+        letterboxController.playlistDataSource = playlist;
+        letterboxController.playbackTransitionDelegate = playlist;
+    }
 }
 
 - (void)letterboxView:(SRGLetterboxView *)letterboxView didSelectAudioLanguageCode:(NSString *)languageCode


### PR DESCRIPTION
### Motivation and Context

Resolves #213.

SRF audio user switch to the first subject to skip introduction.
The recommendation is still based on full length content.

### Description

The change is done with the Player timeline view. Proposed to update the playlist.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
