### PR TITLE
Fastlane release status

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1148,14 +1148,21 @@ def appstore_beta_identifiers
   end
 end
 
-def appstore_team_api_key_prefixes
-  {
-    ENV['RSI_ITUNES_CONNECT_TEAM_ID'] => 'RSI',
-    ENV['RTS_ITUNES_CONNECT_TEAM_ID'] => 'RTS',
-    ENV['SRF_ITUNES_CONNECT_TEAM_ID'] => 'SRF',
-    ENV['SRGSSR_ITUNES_CONNECT_TEAM_ID'] => 'SRGSSR', # RTR is in SRG SSR ASC team
-    ENV['SWI_ITUNES_CONNECT_TEAM_ID'] => 'SWI'
-  }
+def itc_business_units
+  # RTR is in SRG SSR ASC team
+  business_units.map do |business_unit|
+    business_unit == 'RTR' ? 'SRGSSR' : business_unit
+  end
+end
+
+def itc_team_ids
+  itc_business_units.map do |itc_business_unit|
+    ENV["#{itc_business_unit}_ITUNES_CONNECT_TEAM_ID"]
+  end
+end
+
+def itc_team_id_index(itc_team_id)
+  itc_team_ids.index(itc_team_id)
 end
 
 # Returns current tag version
@@ -1317,9 +1324,9 @@ def appstore_platform(platform)
   appstore_platforms[platform]
 end
 
-def srg_app_store_connect_api_key
-  itc_team_id = app_config.try_fetch_value(:itc_team_id)
-  key_prefix = appstore_team_api_key_prefixes[itc_team_id]
+def srg_app_store_connect_api_key(business_unit = nil)
+  business_unit ||= business_units[itc_team_id_index(app_config.try_fetch_value(:itc_team_id))]
+  key_prefix = itc_business_units[business_unit_index(business_unit)]
   return unless key_prefix
 
   folder_path = Dir.chdir('..') { Dir.pwd }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -363,14 +363,15 @@ platform :ios do
       ['iOS', 'tvOS'].map do |platform|
         spaceship_platform = spaceship_platform(platform)
         live_version = app.get_live_app_store_version(platform: spaceship_platform)
-        UI.success "Play #{business_unit} #{platform} live version #{live_version.version_string} is #{live_version.app_store_state}." if live_version
+        UI.success "Play #{business_unit} #{platform} live version #{live_version.version_string} (#{live_version.build.version}) is #{live_version.app_store_state}." if live_version
         UI.important "Play #{business_unit} #{platform} has no live version." unless live_version
 
         latest_version = app.get_latest_app_store_version(platform: spaceship_platform)
         if !latest_version || latest_version.version_string == live_version.version_string
-          UI.message "Play #{business_unit} #{platform} version #{latest_version.version_string} is the latest one."
+          UI.message "Play #{business_unit} #{platform} version #{live_version.version_string} (#{live_version.build.version}) is the latest one."
         else
-          UI.important "Play #{business_unit} #{platform} latest version #{latest_version.version_string} is #{latest_version.app_store_state}."
+          build_version = latest_version.build ? latest_version.build.version : 'NaN'
+          UI.important "Play #{business_unit} #{platform} latest version #{latest_version.version_string} (#{build_version}) is #{latest_version.app_store_state}."
         end
         UI.message '-----'
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -350,6 +350,34 @@ platform :ios do
     end
   end
 
+  desc 'Get AppStore release status for iOS and tvOS'
+  lane :appStoreReleaseStatus do
+    UI.message '-----'
+    business_units.map do |business_unit|
+      spaceship_login_with_api_key(business_unit)
+      app_identifier = appstore_build_identifiers[business_unit_index(business_unit)]
+      app = spaceship_app(app_identifier)
+      next unless app
+
+      UI.message '-----'
+      ['iOS', 'tvOS'].map do |platform|
+        spaceship_platform = spaceship_platform(platform)
+        live_version = app.get_live_app_store_version(platform: spaceship_platform)
+        UI.success "Play #{business_unit} #{platform} live version #{live_version.version_string} is #{live_version.app_store_state}." if live_version
+        UI.important "Play #{business_unit} #{platform} has no live version." unless live_version
+
+        latest_version = app.get_latest_app_store_version(platform: spaceship_platform)
+        if !latest_version || latest_version.version_string == live_version.version_string
+          UI.message "Play #{business_unit} #{platform} version #{latest_version.version_string} is the latest one."
+        else
+          UI.important "Play #{business_unit} #{platform} latest version #{latest_version.version_string} is #{latest_version.app_store_state}."
+        end
+        UI.message '-----'
+      end
+    end
+    UI.message '-----'
+  end
+
   # Individual iOS screenshots
 
   desc 'RSI: Makes iOS screenshots and replaces current ones on App Store Connect.'
@@ -1148,6 +1176,10 @@ def appstore_beta_identifiers
   end
 end
 
+def appstore_build_identifiers
+  business_units.map { |business_unit| ENV["#{business_unit}_APP_IDENTIFIER"] }
+end
+
 def itc_business_units
   # RTR is in SRG SSR ASC team
   business_units.map do |business_unit|
@@ -1624,7 +1656,7 @@ def crowdin_language(business_unit)
 end
 
 def pull_translations_lane_condition(lane)
-  lane.to_s.downcase.include? 'release'
+  lane.to_s.downcase.include? 'prepareappstorerelease'
 end
 
 def skip_pull_translations
@@ -1711,6 +1743,24 @@ def spaceship_login
   ENV['FASTLANE_ITC_TEAM_ID'] = app_config.try_fetch_value(:itc_team_id)
   Spaceship::Tunes.login
   Spaceship::Tunes.select_team
+end
+
+def spaceship_login_with_api_key(business_unit = nil)
+  asc_api_key = srg_app_store_connect_api_key(business_unit)
+  return unless asc_api_key
+
+  token = Spaceship::ConnectAPI::Token.create(
+    key_id: asc_api_key[:id],
+    issuer_id: asc_api_key[:issuerId],
+    filepath: asc_api_key[:filePath]
+  )
+
+  Spaceship::ConnectAPI.token = token
+end
+
+def spaceship_platform(platform)
+  spaceship_platforms = { 'iOS' => 'IOS', 'tvOS' => 'TV_OS' }
+  spaceship_platforms[platform]
 end
 
 def spaceship_email_required(email)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -207,6 +207,14 @@ Sends latest tvOS App Store build dSYMs to App Center. Optional `build_number`, 
 
 Prepare AppStore tvOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.
 
+### ios appStoreReleaseStatus
+
+```sh
+[bundle exec] fastlane ios appStoreReleaseStatus
+```
+
+Get AppStore release status for iOS and tvOS
+
 ### ios iOSrsiScreenshots
 
 ```sh


### PR DESCRIPTION
### Motivation and Context

Get the 10 applications release status on AppStore Connect in the CLI.

### Description

The project have 5 AppStore Connect teams for each business units.
For each one, 2 builds, iOS and tvOS.

The idea is to get the Apple review status with one command line:

`bundle exec fastlane ios appStoreReleaseStatus`

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
