### PR TITLE
Expand text on tvOS show page

### DIFF
--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -94,14 +94,14 @@ struct ShowHeaderView: View {
                     .foregroundColor(.srgGrayC7)
                 if let lead = model.lead {
 #if os(iOS)
-                    LeadView(lead: lead)
+                    LeadView(lead)
                         // See above
                         .fixedSize(horizontal: false, vertical: true)
 #else
                     Button {
                         navigateToText(lead)
                     } label: {
-                        LeadView(lead: lead)
+                        LeadView(lead)
                             // See above
                             .fixedSize(horizontal: false, vertical: true)
                             .onParentFocusChange { isFocused = $0 }
@@ -149,14 +149,18 @@ struct ShowHeaderView: View {
         
         /// Behavior: h-exp, v-hug
         private struct LeadView: View {
-            let lead: String
+            let content: String
             
             var body: some View {
-                Text(lead)
+                Text(content)
                     .srgFont(.body)
                     .lineLimit(6)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.srgGray96)
+            }
+            
+            init(_ content: String) {
+                self.content = content
             }
         }
     }

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -71,19 +71,6 @@ struct ShowHeaderView: View {
         }
     }
     
-    /// Behavior: h-exp, v-hug
-    private struct LeadView: View {
-        let lead: String
-        
-        var body: some View {
-            Text(lead)
-                .srgFont(.body)
-                .lineLimit(6)
-                .multilineTextAlignment(.center)
-                .foregroundColor(.srgGray96)
-        }
-    }
-    
     /// Behavior: h-hug, v-hug
     private struct DescriptionView: View {
         @ObservedObject var model: ShowHeaderViewModel
@@ -159,6 +146,19 @@ struct ShowHeaderView: View {
             model.toggleSubscription()
         }
 #endif
+        
+        /// Behavior: h-exp, v-hug
+        private struct LeadView: View {
+            let lead: String
+            
+            var body: some View {
+                Text(lead)
+                    .srgFont(.body)
+                    .lineLimit(6)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.srgGray96)
+            }
+        }
     }
 }
 

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -192,7 +192,7 @@ enum ShowHeaderViewSize {
 struct ShowHeaderView_Previews: PreviewProvider {
     private static let model: ShowHeaderViewModel = {
         let model = ShowHeaderViewModel()
-        model.show = Mock.show(.overflow)
+        model.show = Mock.show()
         return model
     }()
     


### PR DESCRIPTION
### Motivation and Context

Resolves #222 

### Description

Allow the tvOS user to read the full show description in the show page.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
