### PR TITLE
Set recommended playlist to content playback with CarPlay

### DIFF
--- a/Application/Sources/Bridges/PlaySRG-ObjectiveC.h
+++ b/Application/Sources/Bridges/PlaySRG-ObjectiveC.h
@@ -31,6 +31,7 @@
 #import "PlayApplicationNavigation.h"
 #import "PlayDurationFormatter.h"
 #import "PlayErrors.h"
+#import "Playlist.h"
 #import "PushService.h"
 #import "Reachability.h"
 #import "RefreshControl.h"

--- a/Application/Sources/CarPlay/CarPlay+Extensions.swift
+++ b/Application/Sources/CarPlay/CarPlay+Extensions.swift
@@ -31,6 +31,12 @@ extension CPInterfaceController {
             SRGLetterboxService.shared.enable(with: controller, pictureInPictureDelegate: nil)
         }
         
+        if let controller = SRGLetterboxService.shared.controller {
+            let playlist = PlaylistForURN(media.urn)
+            controller.playlistDataSource = playlist
+            controller.playbackTransitionDelegate = playlist
+        }
+        
         let nowPlayingTemplate = CPNowPlayingTemplate.shared
         pushTemplate(nowPlayingTemplate, animated: true) { _, _ in
             completion()


### PR DESCRIPTION
### Motivation and Context

Resolves #224 

### Description

Missing playlist when start playback with CarPlay.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
