### PR TITLE
Update unplayable downloaded media

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -131,9 +131,9 @@ static void *s_kvoContext = &s_kvoContext;
     [Download removeUnusedDownloadedFiles];
     
     PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
-        [Download removeUnplayableDownloads];
+        [Download updateUnplayableDownloads];
         completionHandler(YES);
-    }, @"ClearUnplayableDownloads");
+    }, @"updateUnplayableDownloads");
     
     [self checkForForcedUpdates];
     

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -130,6 +130,11 @@ static void *s_kvoContext = &s_kvoContext;
     // Clean downloaded folder
     [Download removeUnusedDownloadedFiles];
     
+    PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
+        [Download removeUnplayableDownloads];
+        completionHandler(YES);
+    }, @"ClearUnplayableDownloads");
+    
     [self checkForForcedUpdates];
     
     __block BOOL firstLaunchDone = YES;

--- a/Application/Sources/Model/Download+Private.h
+++ b/Application/Sources/Model/Download+Private.h
@@ -18,11 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)addDownload:(Download *)download;
 
 /**
- *  Clean a folder to ununsed downloaded files
- */
-+ (void)removeUnusedDownloadedFilesInFolderPath:(NSString *)folderPath;
-
-/**
  *  Create a download from a dictionary of its fields
  */
 - (nullable instancetype)initWithDictionary:(NSDictionary *)dictionary;

--- a/Application/Sources/Model/Download.h
+++ b/Application/Sources/Model/Download.h
@@ -173,6 +173,11 @@ typedef NS_ENUM(NSInteger, DownloadState) {
 + (void)removeUnusedDownloadedFiles;
 
 /**
+ *  Clean the unplayable downloads and their files
+ */
++ (void)removeUnplayableDownloads;
+
+/**
  *  The currently known download progress for a download
  */
 + (nullable NSProgress *)currentlyKnownProgressForDownload:(Download *)download;

--- a/Application/Sources/Model/Download.h
+++ b/Application/Sources/Model/Download.h
@@ -173,9 +173,9 @@ typedef NS_ENUM(NSInteger, DownloadState) {
 + (void)removeUnusedDownloadedFiles;
 
 /**
- *  Clean the unplayable downloads and their files
+ *  Update the unplayable downloads and their files (or remove if no solutions)
  */
-+ (void)removeUnplayableDownloads;
++ (void)updateUnplayableDownloads;
 
 /**
  *  The currently known download progress for a download

--- a/Application/Sources/Model/Download.m
+++ b/Application/Sources/Model/Download.m
@@ -512,6 +512,11 @@ static NSArray<Download *> *s_sortedDownloads;
     NSString *type = types.firstObject;
     NSString *extension = types.lastObject ?: @"mov";
     
+    // Fix the default arbitrary binary data response
+    if ([type.lowercaseString isEqualToString:@"application"] && [extension.lowercaseString isEqualToString:@"octet-stream"] && self.downloadMediaURL.pathExtension != nil) {
+        extension = self.downloadMediaURL.pathExtension;
+    }
+    
     // For audio, mpeg type extension don't work with AVPlayer
     if ([type.lowercaseString isEqualToString:@"audio"] && [extension.lowercaseString isEqualToString:@"mpeg"]) {
         extension = @"mp3";

--- a/Application/Sources/Model/Download.m
+++ b/Application/Sources/Model/Download.m
@@ -253,7 +253,17 @@ static NSArray<Download *> *s_sortedDownloads;
 
 + (void)removeUnusedDownloadedFiles
 {
-    [self removeUnusedDownloadedFilesInFolderPath:[self downloadsDirectoryURLString]];
+    NSArray *downloadedMediaFilesURLs = [Download.downloads valueForKey:@keypath(Download.new, localMediaFileURL)];
+    NSArray *downloadedImageFilesURLs = [Download.downloads valueForKey:@keypath(Download.new, localImageFileURL)];
+    NSArray *allDownloadedFilesURLs = [[@[] arrayByAddingObjectsFromArray:downloadedMediaFilesURLs] arrayByAddingObjectsFromArray:downloadedImageFilesURLs];
+    NSString *folderPath = [self downloadsDirectoryURLString];
+    NSError *error;
+    for (NSString *fileName in [NSFileManager.defaultManager contentsOfDirectoryAtPath:folderPath error:&error]) {
+        NSURL *fileURL = [NSURL fileURLWithPath:[folderPath stringByAppendingPathComponent:fileName]];
+        if (! [allDownloadedFilesURLs containsObject:fileURL]) {
+            [NSFileManager.defaultManager removeItemAtURL:fileURL error:&error];
+        }
+    }
 }
 
 #pragma mark Public class methods
@@ -363,20 +373,6 @@ static NSArray<Download *> *s_sortedDownloads;
     }];
     
     [UserInteractionEvent removeFromDownloads:downloads];
-}
-
-+ (void)removeUnusedDownloadedFilesInFolderPath:(NSString *)folderPath
-{
-    NSArray *downloadedMediaFilesURLs = [Download.downloads valueForKey:@keypath(Download.new, localMediaFileURL)];
-    NSArray *downloadedImageFilesURLs = [Download.downloads valueForKey:@keypath(Download.new, localImageFileURL)];
-    NSArray *allDownloadedFilesURLs = [[@[] arrayByAddingObjectsFromArray:downloadedMediaFilesURLs] arrayByAddingObjectsFromArray:downloadedImageFilesURLs];
-    NSError *error;
-    for (NSString *fileName in [NSFileManager.defaultManager contentsOfDirectoryAtPath:folderPath error:&error]) {
-        NSURL *fileURL = [NSURL fileURLWithPath:[folderPath stringByAppendingPathComponent:fileName]];
-        if (! [allDownloadedFilesURLs containsObject:fileURL]) {
-            [NSFileManager.defaultManager removeItemAtURL:fileURL error:&error];
-        }
-    }
 }
 
 + (nullable NSProgress *)currentlyKnownProgressForDownload:(Download *)download

--- a/Application/Sources/Model/Download.m
+++ b/Application/Sources/Model/Download.m
@@ -266,6 +266,17 @@ static NSArray<Download *> *s_sortedDownloads;
     }
 }
 
++ (void)removeUnplayableDownloads
+{
+    NSMutableArray<Download *> *unplayableDownloadeds = NSMutableArray.array;
+    for (Download *download in Download.downloads) {
+        if (download.state == DownloadStateDownloaded && [download.localMediaFileURL.pathExtension isEqualToString:@"octet-stream"]) {
+            [unplayableDownloadeds addObject:download];
+        }
+    }
+    [Download removeDownloads:unplayableDownloadeds.copy];
+}
+
 #pragma mark Public class methods
 
 + (NSArray<Download *> *)downloads

--- a/Application/Sources/Model/Download.m
+++ b/Application/Sources/Model/Download.m
@@ -519,9 +519,15 @@ static NSArray<Download *> *s_sortedDownloads;
     NSString *type = types.firstObject;
     NSString *extension = types.lastObject ?: @"mov";
     
-    // Fix the default arbitrary binary data response
-    if ([type.lowercaseString isEqualToString:@"application"] && [extension.lowercaseString isEqualToString:@"octet-stream"] && self.downloadMediaURL.pathExtension != nil) {
-        extension = self.downloadMediaURL.pathExtension;
+    // Try to fix the default arbitrary binary data response with the url file extension
+    if ([type.lowercaseString isEqualToString:@"application"] && [extension.lowercaseString isEqualToString:@"octet-stream"]) {
+        if (self.downloadMediaURL.pathExtension != nil) {
+            extension = self.downloadMediaURL.pathExtension;
+        }
+        else {
+            PlayLogError(@"download", @"Could not find a downloaded file extension for media %@.\nMIMEType: %@", self.URN, MIMEType);
+            return NO;
+        }
     }
     
     // For audio, mpeg type extension don't work with AVPlayer


### PR DESCRIPTION
### Motivation and Context

Resolves #229.

### Description

For files already downloaded, the migration code run once, try to rename the file with the download url extension, if any.
Otherwise, it removes the file and the download item.

### How to test

 * Download few audio content fin Play RTS with a `develop` blanch build.
 * Run this branch build. It runs the `updateUnplayableDownloads` method
 * Downloaded audio content  can play again.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
