### PR TITLE
Add SAM servers in settings

### DIFF
--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -44,7 +44,25 @@ struct Service: Identifiable, Equatable {
         return URL(string: mmfUrlString)!
     }()
     
-    static var services: [Service] = [production, stage, test, mmf]
+    static var samProduction = Service(
+        id: "sam production",
+        name: "SAM \(NSLocalizedString("Production", comment: "Server setting name"))",
+        url: SRGIntegrationLayerProductionServiceURL().appendingPathComponent("sam")
+    )
+    
+    static var samStage = Service(
+        id: "sam stage",
+        name: "SAM \(NSLocalizedString("Stage", comment: "Server setting name"))",
+        url: SRGIntegrationLayerStagingServiceURL().appendingPathComponent("sam")
+    )
+    
+    static var samTest = Service(
+        id: "sam test",
+        name: "SAM \(NSLocalizedString("Test", comment: "Server setting name"))",
+        url: SRGIntegrationLayerTestServiceURL().appendingPathComponent("sam")
+    )
+    
+    static var services: [Service] = [production, stage, test, mmf, samProduction, samStage, samTest]
     
     static func service(forId id: String?) -> Service {
 #if DEBUG || NIGHTLY || BETA


### PR DESCRIPTION
### Motivation and Context

The Zurich team works on a new backend and would like to test it. 

### Description

They will add end points in the future. for now, only `MediaComposition` and some `PAC` end points are implemented.

Example:
 `xcrun simctl openurl booted "playsrf-debug://media/urn:srf:video:fadbc1b6-f613-4836-b8c8-65c39a2e42b9?server=sam%20test"`

### Checklist

- [] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
