### PR TITLE
Fastlane builds ignore bitcode

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -11,15 +11,15 @@
 | Check version and build numbers. Bump if needed ||||||
 | Update what's new JSON for betas ||||||
 | [iOS] Update what's new on Github pages (with fastlane\*) ||||||
+| Build betas for TestFlight (with fastlane\*) ||||||
 | Create new version on App Store Connect (with fastlane\*) ||||||
 | Update screenshots if needed (with fastlane\*\*) ||||||
-| Build betas for TestFlight (with fastlane\*) ||||||
-| Build App Store versions + collect DSYMs (with fastlane\*) ||||||
+| Build App Store builds (with fastlane\*) ||||||
 | Update production remote configuration on Firebase ||||||
-| Distribute public TestFlight versions (with fastane\*) ||||||
+| Distribute App Store builds to public TestFlight groups (with fastane\*) ||||||
 | Collect translations and update App Store Connect (with fastlane\*) ||||||
 | [iOS] Collect translations and update Github pages (with fastlane\*) ||||||
-| Check what's new in betas or TestFlight versions ||||||
+| Check what's new in betas or TestFlight builds ||||||
 | Ask the PO to approve the version ||||||
 | Submit to Apple review (with fastlane\*) ||||||
 | Update status page on Confluence (Up coming status, statistics changes) ||||||

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1002,7 +1002,7 @@ platform :ios do
       clean: true,
       xcargs: srg_xcargs(options),
       export_method: options[:export_to_appstore] ? 'app-store' : 'enterprise',
-      include_bitcode: options[:export_to_appstore],
+      include_bitcode: false,
       export_team_id: options[:team_id],
       destination: destination,
       derived_data_path: derived_data_path,
@@ -1350,18 +1350,18 @@ def update_options_to_appstore(options)
 end
 
 def srg_xcargs(options)
-  export_to_appstore = options[:export_to_appstore] || false
-  xcargs = export_to_appstore ? 'ENABLE_BITCODE=YES' : 'ENABLE_BITCODE=NO'
+  xcargs = 'ENABLE_BITCODE=NO'
   xcargs += " BUNDLE_DISPLAY_NAME_SUFFIX='#{options[:display_name_suffix]}'"
   xcargs += " MARKETING_VERSION='#{options[:version]}'"
   xcargs += " MARKETING_VERSION_SUFFIX='#{options[:version_suffix]}'"
   xcargs += " BUILD_NAME='#{options[:build_name]}'"
   xcargs += " DEVELOPMENT_TEAM='#{options[:team_id]}'"
-  xcargs + srg_xcargs_code_signing(export_to_appstore)
+  xcargs + srg_xcargs_code_signing(options)
 end
 
 # Use cloud signing if available
-def srg_xcargs_code_signing(export_to_appstore)
+def srg_xcargs_code_signing(options)
+  export_to_appstore = options[:export_to_appstore] || false
   asc_api_key = srg_app_store_connect_api_key if export_to_appstore
 
   xcargs = ''

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,27 +90,9 @@ platform :ios do
     testflight_nightlies(platform: 'tvOS')
   end
 
-  desc 'Sends latest tvOS nightly dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :tvOSnightlyDSYMs do |options|
-    tvos_application_schemes.each_index do |index|
-      app_identifier = appstore_nightly_identifiers[index]
-      appcenter_appname = appcenter_tv_nightly_names[index]
-      update_dsyms(app_identifier, 'tvOS', appcenter_appname, options)
-    end
-  end
-
   desc 'Builds a new iOS nightly on App Store Connect and waits for build processing.'
   lane :iOSnightlies do
     testflight_nightlies(platform: 'iOS')
-  end
-
-  desc 'Sends latest iOS nightly dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :iOSnightlyDSYMs do |options|
-    ios_application_schemes.each_index do |index|
-      app_identifier = appstore_nightly_identifiers[index]
-      appcenter_appname = appcenter_ios_nightly_names[index]
-      update_dsyms(app_identifier, 'iOS', appcenter_appname, options)
-    end
   end
 
   desc 'Adds a nightly TestFlight tester (email required)'
@@ -161,29 +143,6 @@ platform :ios do
     testflight_betas(platform: 'tvOS')
   end
 
-  desc 'Sends latest tvOS beta dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :tvOSbetaDSYMs do |options|
-    tvos_application_schemes.each_index do |index|
-      app_identifier = appstore_beta_identifiers[index]
-      appcenter_appname = appcenter_tv_beta_names[index]
-      update_dsyms(app_identifier, 'tvOS', appcenter_appname, options)
-    end
-  end
-
-  desc 'Builds an iOS beta on App Store Connect with the current build number and waits for build processing. On the develop branch attempts to tag the current version, then bumps the build number and pushes.'
-  lane :iOSbetas do
-    testflight_betas(platform: 'iOS')
-  end
-
-  desc 'Sends latest iOS beta dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :iOSbetaDSYMs do |options|
-    ios_application_schemes.each_index do |index|
-      app_identifier = appstore_beta_identifiers[index]
-      appcenter_appname = appcenter_ios_beta_names[index]
-      update_dsyms(app_identifier, 'iOS', appcenter_appname, options)
-    end
-  end
-
   desc 'Adds a beta TestFlight tester (email required)'
   lane :betaTester do |options|
     addTestFlightTester(
@@ -197,7 +156,7 @@ platform :ios do
 
   # App Store builds
 
-  desc 'Applies iOSUploadAppStoreBuilds, iOSDistributePrivateAppStoreBuilds (or iOSDistributePublicAppStoreBuilds) and iOSAppStoreBuildDSYMs. Optional `public_testflight_distribution` parameter.'
+  desc 'Applies iOSUploadAppStoreBuilds and iOSDistributePrivateAppStoreBuilds (or iOSDistributePublicAppStoreBuilds). Optional `public_testflight_distribution` parameter.'
   lane :iOSAppStoreBuilds do |options|
     public_testflight_distribution = options[:public_testflight_distribution] || false
     distribution_scope = public_testflight_distribution ? 'Public' : 'Private'
@@ -206,7 +165,6 @@ platform :ios do
 
     sh 'bundle exec fastlane ios iOSUploadAppStoreBuilds'
     sh "bundle exec fastlane ios iOSDistribute#{distribution_scope}AppStoreBuilds"
-    sh 'bundle exec fastlane ios iOSAppStoreBuildDSYMs'
   end
 
   desc 'Uploads an iOS App Store build on App Store Connect with the current build number.'
@@ -242,22 +200,6 @@ platform :ios do
     end
   end
 
-  desc 'Sends latest iOS App Store build dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :iOSAppStoreBuildDSYMs do |options|
-    min_version = options[:min_version]
-    version = options[:version]
-    build_number = options[:build_number]
-
-    options = ''
-    options += " min_version:#{min_version}" if min_version
-    options += " version:#{version}" if version
-    options += " build_number:#{build_number}" if build_number
-
-    business_units.map do |business_unit|
-      sh "bundle exec fastlane ios iOS#{business_unit.downcase}AppStoreBuildDSYMs#{options}"
-    end
-  end
-
   desc 'Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.'
   lane :iOSPrepareAppStoreReleases do |options|
     tag_version = options[:tag_version]
@@ -273,7 +215,7 @@ platform :ios do
     end
   end
 
-  desc 'Applies tvOSUploadAppStoreBuilds, tvOSDistributePrivateAppStoreBuilds (or tvOSDistributePublicAppStoreBuilds) and tvOSAppStoreBuildDSYMs. Optional `public_testflight_distribution` parameter.'
+  desc 'Applies tvOSUploadAppStoreBuilds and tvOSDistributePrivateAppStoreBuilds (or tvOSDistributePublicAppStoreBuilds). Optional `public_testflight_distribution` parameter.'
   lane :tvOSAppStoreBuilds do |options|
     public_testflight_distribution = options[:public_testflight_distribution] || false
     distribution_scope = public_testflight_distribution ? 'Public' : 'Private'
@@ -282,7 +224,6 @@ platform :ios do
 
     sh 'bundle exec fastlane ios tvOSUploadAppStoreBuilds'
     sh "bundle exec fastlane ios tvOSDistribute#{distribution_scope}AppStoreBuilds"
-    sh 'bundle exec fastlane ios tvOSAppStoreBuildDSYMs'
   end
 
   desc 'Uploads a tvOS build on App Store Connect with the current build number.'
@@ -315,22 +256,6 @@ platform :ios do
     business_units.map do |business_unit|
       business_unit = business_unit.downcase
       sh "bundle exec fastlane ios tvOS#{business_unit}DistributePublicAppStoreBuild#{options}"
-    end
-  end
-
-  desc 'Sends latest tvOS App Store build dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.'
-  lane :tvOSAppStoreBuildDSYMs do |options|
-    min_version = options[:min_version]
-    version = options[:version]
-    build_number = options[:build_number]
-
-    options = ''
-    options += " min_version:#{min_version}" if min_version
-    options += " version:#{version}" if version
-    options += " build_number:#{build_number}" if build_number
-
-    business_units.map do |business_unit|
-      sh "bundle exec fastlane ios tvOS#{business_unit.downcase}AppStoreBuildDSYMs#{options}"
     end
   end
 
@@ -560,33 +485,6 @@ platform :ios do
     )
   end
 
-  # Individual iOS App Store build dSYMs uploads
-
-  desc 'RSI only: See `iOSAppStoreBuildDSYMs` lane.'
-  lane :iOSrsiAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'iOS', ENV['PLAY_RSI_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'RTR only: See `iOSAppStoreBuildDSYMs` lane.'
-  lane :iOSrtrAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'iOS', ENV['PLAY_RTR_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'RTS only: See `iOSAppStoreBuildDSYMs` lane.'
-  lane :iOSrtsAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'iOS', ENV['PLAY_RTS_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'SFR only: See `iOSAppStoreBuildDSYMs` lane.'
-  lane :iOSsrfAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'iOS', ENV['PLAY_SRF_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'SWI only: See `iOSAppStoreBuildDSYMs` lane.'
-  lane :iOSswiAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'iOS', ENV['PLAY_SWI_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
   # Individual iOS AppStore releases
 
   desc 'RSI only: See `iOSPrepareAppStoreRelease` lane.'
@@ -757,33 +655,6 @@ platform :ios do
     )
   end
 
-  # Individual tvOS App Store build dSYMs uploads
-
-  desc 'RSI only: See `tvOSAppStoreBuildDSYMs` lane.'
-  lane :tvOSrsiAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'tvOS', ENV['PLAY_RSI_TV_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'RTR only: See `tvOSAppStoreBuildDSYMs` lane.'
-  lane :tvOSrtrAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'tvOS', ENV['PLAY_RTR_TV_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'RTS only: See `tvOSAppStoreBuildDSYMs` lane.'
-  lane :tvOSrtsAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'tvOS', ENV['PLAY_RTS_TV_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'SFR only: See `tvOSAppStoreBuildDSYMs` lane.'
-  lane :tvOSsrfAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'tvOS', ENV['PLAY_SRF_TV_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
-  desc 'SWI only: See `tvOSAppStoreBuildDSYMs` lane.'
-  lane :tvOSswiAppStoreBuildDSYMs do |options|
-    update_dsyms(nil, 'tvOS', ENV['PLAY_SWI_TV_APPSTORE_APPCENTER_APPNAME'], options)
-  end
-
   # Individual tvOS AppStore releases
 
   desc 'RSI only: See `tvOSPrepareAppStoreRelease` lane.'
@@ -845,13 +716,17 @@ platform :ios do
 
       pilot_fast_upload(app_identifier, platform)
 
-      clean_build_artifacts
-
       UI.success "#{schemes[index]} (#{platform} Nightly #{tag_version}) uploaded. ✅"
+
+      appcenter_appname = appcenter_testflight_nightly_names(platform)[index]
+      upload_appcenter_dsyms(appcenter_appname)
+
+      UI.success "#{schemes[index]} (#{platform} Nightly #{tag_version}) dSYM file OK. ✅"
+
+      clean_build_artifacts
     end
 
     changelog = nightly_changelog(platform, service)
-    dsyms_options = { build_number: build_number_from_tag_version(tag_version) }
 
     schemes.each_index do |index|
       app_identifier = appstore_nightly_identifiers[index]
@@ -859,11 +734,6 @@ platform :ios do
       pilot_distribute(app_identifier, platform, tag_version, changelog, false)
 
       UI.success "#{schemes[index]} (#{platform} Nightly #{tag_version}) distributed. ✅"
-
-      appcenter_appname = appcenter_testflight_nightly_names(platform)[index]
-      update_dsyms(app_identifier, platform, appcenter_appname, dsyms_options)
-
-      UI.success "#{schemes[index]} (#{platform} Nightly #{tag_version}) dSYM file OK. ✅"
     end
 
     save_last_nightlies_success_git_commit_hash(platform, service)
@@ -894,13 +764,17 @@ platform :ios do
 
       pilot_fast_upload(app_identifier, platform)
 
-      clean_build_artifacts
-
       UI.success "#{schemes[index]} (#{platform} Beta #{tag_version}) uploaded. ✅"
+
+      appcenter_appname = appcenter_testflight_beta_names(platform)[index]
+      upload_appcenter_dsyms(appcenter_appname)
+
+      UI.success "#{schemes[index]} (#{platform} Beta #{tag_version}) dSYM file OK. ✅"
+
+      clean_build_artifacts
     end
 
     changelog = what_s_new_for_beta(platform, nil)
-    dsyms_options = { build_number: build_number_from_tag_version(tag_version) }
 
     schemes.each_index do |index|
       app_identifier = appstore_beta_identifiers[index]
@@ -908,11 +782,6 @@ platform :ios do
       pilot_distribute(app_identifier, platform, tag_version, changelog, false)
 
       UI.success "#{schemes[index]} (#{platform} Beta #{tag_version}) distributed. ✅"
-
-      appcenter_appname = appcenter_testflight_beta_names(platform)[index]
-      update_dsyms(app_identifier, platform, appcenter_appname, dsyms_options)
-
-      UI.success "#{schemes[index]} (#{platform} Beta #{tag_version}) dSYM file OK. ✅"
     end
 
     bump_build_number_beta_workflow(platform)
@@ -921,7 +790,8 @@ platform :ios do
   desc 'Builds a new App Store build on App Store Connect with the current build number and and skips build processing.'
   private_lane :testflight_appstore_build_upload do |options|
     platform = options[:platform] || 'iOS'
-    scheme = application_scheme(platform, options[:bu])
+    business_unit = options[:bu]
+    scheme = application_scheme(platform, business_unit)
 
     UI.important 'A valid bu option is required to build an App Store build. Skipping build. ⚠️' unless scheme
     next unless scheme
@@ -941,9 +811,14 @@ platform :ios do
 
     pilot_fast_upload(nil, platform)
 
-    clean_build_artifacts
-
     UI.success "#{scheme} (#{platform} App Store #{tag_version}) uploaded ✅"
+
+    appcenter_appname = appcenter_appstore_build_names(platform)[business_unit_index(business_unit)]
+    upload_appcenter_dsyms(appcenter_appname)
+
+    UI.success "#{scheme} (#{platform} App Store #{tag_version}) dSYM file OK. ✅"
+
+    clean_build_artifacts
   end
 
   desc 'Distributes the App Store build on App Store Connect with the current build number to private group.'
@@ -1147,7 +1022,7 @@ def what_s_new_condition(lane)
 end
 
 def cleaned_lane_condition(lane)
-  excluded_lanes = ['distribute', 'dsym', 'screenshots', 'appstorerelease', 'status', 'tester']
+  excluded_lanes = ['distribute', 'screenshots', 'appstorerelease', 'status', 'tester']
   (lane.to_s != 'devLane') &&
     excluded_lanes.all? { |i| !lane.to_s.downcase.include? i }
 end
@@ -1206,6 +1081,24 @@ def appcenter_testflight_beta_names(platform)
     appcenter_ios_beta_names
   else
     appcenter_tv_beta_names
+  end
+end
+
+def appcenter_tv_appstore_build_names
+  business_units.map { |business_unit| ENV["PLAY_#{business_unit}_TV_APPSTORE_APPCENTER_APPNAME"] }
+end
+
+def appcenter_ios_appstore_build_names
+  business_units.map { |business_unit| ENV["PLAY_#{business_unit}_APPSTORE_APPCENTER_APPNAME"] }
+end
+
+def appcenter_appstore_build_names(platform)
+  platform ||= 'iOS'
+
+  if platform == 'iOS'
+    appcenter_ios_appstore_build_names
+  else
+    appcenter_tv_appstore_build_names
   end
 end
 
@@ -1541,46 +1434,14 @@ def srg_pilot_distribute(app_identifier, platform, tag_version, changelog, is_pu
   )
 end
 
-# Update dSYMs from App Store Connect to App Center.
-def update_dsyms(app_identifier, platform, appcenter_appname, options)
-  app_identifier ||= app_config.try_fetch_value(:app_identifier)
-  platform ||= 'iOS'
-
-  output_directory = "fastlane/export/#{lane_context[SharedValues::LANE_NAME]}"
-  Dir.chdir('..') { FileUtils.mkdir_p(output_directory) }
-
-  download_appstore_dsyms(app_identifier, platform, options, output_directory)
-  upload_appcenter_dsyms(appcenter_appname)
-
-  lane_context.delete(SharedValues::DSYM_PATHS)
-end
-
-def download_appstore_dsyms(app_identifier, platform, options, output_directory)
-  app_identifier ||= app_config.try_fetch_value(:app_identifier)
-  platform ||= 'iOS'
-  options[:version] ||= 'latest'
-
-  login_with_app_store_connect_api_key
-  download_dsyms(
-    app_identifier: app_identifier,
-    platform: appstore_platform(platform),
-    min_version: options[:build_number] ? nil : options[:min_version],
-    version: options[:min_version] || options[:build_number] ? nil : options[:version],
-    build_number: options[:build_number],
-    output_directory: output_directory,
-    wait_for_dsym_processing: true,
-    wait_timeout: 90
-  )
-end
-
 def upload_appcenter_dsyms(appcenter_appname)
-  lane_context[SharedValues::DSYM_PATHS]&.each do |dsym|
-    appcenter_lane(
-      appname: appcenter_appname,
-      notes: 'DSYMs from App Store Connect (via fastlane).',
-      upload_dsym: dsym
-    )
-  end
+  dsym = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+  appcenter_lane(
+    appname: appcenter_appname,
+    notes: 'DSYMs from local build (via fastlane).',
+    upload_dsym: dsym
+  )
+  lane_context.delete(SharedValues::DSYM_OUTPUT_PATH)
 end
 
 # Share build version and number to the continuous integration

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1044,7 +1044,7 @@ def appcenter_ios_nightly_appcenter_names
   business_units.map { |business_unit| ENV["PLAY_#{business_unit}_NIGHTLY_APPCENTER_APPNAME"] }
 end
 
-def appcenter_tv_nightly_names
+def appcenter_tvos_nightly_names
   business_units.map { |business_unit| ENV["PLAY_#{business_unit}_TV_NIGHTLY_APPCENTER_APPNAME"] }
 end
 
@@ -1058,7 +1058,7 @@ def appcenter_testflight_nightly_names(platform)
   if platform == 'iOS'
     appcenter_ios_nightly_names
   else
-    appcenter_tv_nightly_names
+    appcenter_tvos_nightly_names
   end
 end
 
@@ -1066,7 +1066,7 @@ def appcenter_ios_beta_appcenter_names
   business_units.map { |business_unit| ENV["PLAY_#{business_unit}_BETA_APPCENTER_APPNAME"] }
 end
 
-def appcenter_tv_beta_names
+def appcenter_tvos_beta_names
   business_units.map { |business_unit| ENV["PLAY_#{business_unit}_TV_BETA_APPCENTER_APPNAME"] }
 end
 
@@ -1080,11 +1080,11 @@ def appcenter_testflight_beta_names(platform)
   if platform == 'iOS'
     appcenter_ios_beta_names
   else
-    appcenter_tv_beta_names
+    appcenter_tvos_beta_names
   end
 end
 
-def appcenter_tv_appstore_build_names
+def appcenter_tvos_appstore_build_names
   business_units.map { |business_unit| ENV["PLAY_#{business_unit}_TV_APPSTORE_APPCENTER_APPNAME"] }
 end
 
@@ -1098,7 +1098,7 @@ def appcenter_appstore_build_names(platform)
   if platform == 'iOS'
     appcenter_ios_appstore_build_names
   else
-    appcenter_tv_appstore_build_names
+    appcenter_tvos_appstore_build_names
   end
 end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,14 +31,6 @@ Builds a new iOS nightly on App Center.
 
 Builds a new tvOS nightly on App Store Connect and waits for build processing.
 
-### ios tvOSnightlyDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSnightlyDSYMs
-```
-
-Sends latest tvOS nightly dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
-
 ### ios iOSnightlies
 
 ```sh
@@ -46,14 +38,6 @@ Sends latest tvOS nightly dSYMs to App Center. Optional `build_number`, `version
 ```
 
 Builds a new iOS nightly on App Store Connect and waits for build processing.
-
-### ios iOSnightlyDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSnightlyDSYMs
-```
-
-Sends latest iOS nightly dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
 
 ### ios nightlyTester
 
@@ -79,30 +63,6 @@ Builds an iOS beta on App Center with the current build number. On the develop b
 
 Builds a tvOS beta on App Store Connect with the current build number and waits for build processing. On the develop branch attempts to tag the current version, then bumps the build number and pushes.
 
-### ios tvOSbetaDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSbetaDSYMs
-```
-
-Sends latest tvOS beta dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
-
-### ios iOSbetas
-
-```sh
-[bundle exec] fastlane ios iOSbetas
-```
-
-Builds an iOS beta on App Store Connect with the current build number and waits for build processing. On the develop branch attempts to tag the current version, then bumps the build number and pushes.
-
-### ios iOSbetaDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSbetaDSYMs
-```
-
-Sends latest iOS beta dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
-
 ### ios betaTester
 
 ```sh
@@ -117,7 +77,7 @@ Adds a beta TestFlight tester (email required)
 [bundle exec] fastlane ios iOSAppStoreBuilds
 ```
 
-Applies iOSUploadAppStoreBuilds, iOSDistributePrivateAppStoreBuilds (or iOSDistributePublicAppStoreBuilds) and iOSAppStoreBuildDSYMs. Optional `public_testflight_distribution` parameter.
+Applies iOSUploadAppStoreBuilds and iOSDistributePrivateAppStoreBuilds (or iOSDistributePublicAppStoreBuilds). Optional `public_testflight_distribution` parameter.
 
 ### ios iOSUploadAppStoreBuilds
 
@@ -143,14 +103,6 @@ Distributes to private groups an iOS App Store build on App Store Connect with t
 
 Distributes to public groups an iOS App Store build on App Store Connect with the current version and build numbers. Optional `tag_version` parameter (`X.Y.Z-build_number`).
 
-### ios iOSAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSAppStoreBuildDSYMs
-```
-
-Sends latest iOS App Store build dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
-
 ### ios iOSPrepareAppStoreReleases
 
 ```sh
@@ -165,7 +117,7 @@ Prepare AppStore iOS releases on App Store Connect with the current version and 
 [bundle exec] fastlane ios tvOSAppStoreBuilds
 ```
 
-Applies tvOSUploadAppStoreBuilds, tvOSDistributePrivateAppStoreBuilds (or tvOSDistributePublicAppStoreBuilds) and tvOSAppStoreBuildDSYMs. Optional `public_testflight_distribution` parameter.
+Applies tvOSUploadAppStoreBuilds and tvOSDistributePrivateAppStoreBuilds (or tvOSDistributePublicAppStoreBuilds). Optional `public_testflight_distribution` parameter.
 
 ### ios tvOSUploadAppStoreBuilds
 
@@ -190,14 +142,6 @@ Distributes to private groups a tvOS App Store build on App Store Connect with t
 ```
 
 Distributes to public groups a tvOS App Store build on App Store Connect with the current version and build numbers. Optional `tag_version` parameter (`X.Y.Z-build_number`).
-
-### ios tvOSAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSAppStoreBuildDSYMs
-```
-
-Sends latest tvOS App Store build dSYMs to App Center. Optional `build_number`, `version` or `min_version` parameters.
 
 ### ios tvOSPrepareAppStoreReleases
 
@@ -382,46 +326,6 @@ SRF only: See `iOSDistributePublicAppStoreBuild` lane.
 ```
 
 SWI only: See `iOSDistributePublicAppStoreBuild` lane.
-
-### ios iOSrsiAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSrsiAppStoreBuildDSYMs
-```
-
-RSI only: See `iOSAppStoreBuildDSYMs` lane.
-
-### ios iOSrtrAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSrtrAppStoreBuildDSYMs
-```
-
-RTR only: See `iOSAppStoreBuildDSYMs` lane.
-
-### ios iOSrtsAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSrtsAppStoreBuildDSYMs
-```
-
-RTS only: See `iOSAppStoreBuildDSYMs` lane.
-
-### ios iOSsrfAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSsrfAppStoreBuildDSYMs
-```
-
-SFR only: See `iOSAppStoreBuildDSYMs` lane.
-
-### ios iOSswiAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios iOSswiAppStoreBuildDSYMs
-```
-
-SWI only: See `iOSAppStoreBuildDSYMs` lane.
 
 ### ios iOSrsiPrepareAppStoreRelease
 
@@ -622,46 +526,6 @@ SRF only: See `tvOSDistributePublicAppStoreBuilds` lane.
 ```
 
 SWI only: See `tvOSDistributePublicAppStoreBuilds` lane.
-
-### ios tvOSrsiAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSrsiAppStoreBuildDSYMs
-```
-
-RSI only: See `tvOSAppStoreBuildDSYMs` lane.
-
-### ios tvOSrtrAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSrtrAppStoreBuildDSYMs
-```
-
-RTR only: See `tvOSAppStoreBuildDSYMs` lane.
-
-### ios tvOSrtsAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSrtsAppStoreBuildDSYMs
-```
-
-RTS only: See `tvOSAppStoreBuildDSYMs` lane.
-
-### ios tvOSsrfAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSsrfAppStoreBuildDSYMs
-```
-
-SFR only: See `tvOSAppStoreBuildDSYMs` lane.
-
-### ios tvOSswiAppStoreBuildDSYMs
-
-```sh
-[bundle exec] fastlane ios tvOSswiAppStoreBuildDSYMs
-```
-
-SWI only: See `tvOSAppStoreBuildDSYMs` lane.
 
 ### ios tvOSrsiPrepareAppStoreRelease
 


### PR DESCRIPTION
### Motivation and Context

Starting with [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes), Apple deprecated bitcode.

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.

- Uploading on AppStoreConnect does not create anymore dSYMs server side.
- The CI waits for dSYMs without any findings and skill after a while.  

### Description

- Remove asynchronous lane to download dSYMs from AppStoreConnect and upload its to AppCenter.
- Upload local dSYMs to AppCenter after the build and build upload to AppStoreConnect.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [ ] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [ ] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.
