### PR TITLE
Publish beta release notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1202,7 +1202,7 @@ end
 def release_notes_version_to_html(platform, version, text, is_preprod)
   build_number = build_number_for_version(platform, version)
   attribute = is_preprod ? ' preprod' : ''
-  div = "<div id=\"build_#{build_number}\"#{attribute}>\n<h2>#{version}</h2>\n"
+  div = "<div id=\"build_#{build_number}\"#{attribute}>\n<h2 id=\"#{version}\">#{version}</h2>\n"
   div += release_notes_to_html(text)
   div += "\n</div>\n"
   div

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,6 +320,20 @@ platform :ios do
     index_html_file = 'fastlane/gh-pages/index.html'
     Dir.chdir('..') { FileUtils.cp(index_html_file, output_directory) }
 
+    ['iOS', 'tvOS'].map do |platform|
+      UI.message "Preparing Play #{platform} beta release notes. 📝"
+
+      json = what_s_new_for_beta_json(platform)
+      divs = beta_release_notes_table_to_html_divs(json)
+      html = beta_release_notes_html(platform, divs)
+
+      release_html_file = "release_notes-#{platform.downcase}-beta.html"
+      Dir.chdir('..') { File.write("#{releases_directory}/#{release_html_file}", html) }
+
+      latest_version = json.keys.last
+      UI.success "Computed Play #{platform} beta release notes (latest beta: #{latest_version}). ✅"
+    end
+
     business_units.map do |business_unit|
       spaceship_login_with_api_key(business_unit)
       app = spaceship_bu_appstore_build_app(business_unit)
@@ -1184,8 +1198,17 @@ def release_notes_html_devices(platform)
 end
 
 def release_notes_html(platform, business_unit, divs)
-  input_file = "release_notes-#{business_unit.downcase}.html"
+  release_notes_html_export(business_unit.downcase, platform, divs)
+end
+
+def beta_release_notes_html(platform, divs)
+  release_notes_html_export('beta', platform, divs)
+end
+
+def release_notes_html_export(file_suffix, platform, divs)
+  input_file = "release_notes-#{file_suffix}.html"
   html = File.read("gh-pages/releases/#{input_file}")
+  html = html.gsub('<!-- platform -->', platform)
   html = html.gsub('<!-- devices -->', release_notes_html_devices(platform))
   html.sub('<!-- versions -->', divs.strip)
 end
@@ -1199,8 +1222,26 @@ def release_notes_table_to_html_divs(platform, table, live_version)
   divs.strip
 end
 
+def beta_release_notes_table_to_html_divs(json)
+  divs = ''
+  json.keys.reverse.map do |key|
+    divs += beta_release_notes_version_to_html(key, json[key])
+  end
+  divs.strip
+end
+
 def release_notes_version_to_html(platform, version, text, is_preprod)
   build_number = build_number_for_version(platform, version)
+  release_notes_version_to_html_export(build_number, version, text, is_preprod)
+end
+
+def beta_release_notes_version_to_html(tag_version, text)
+  build_number = build_number_from_tag_version(tag_version)
+  version = "#{marketing_version_from_tag_version(tag_version)} (#{build_number})"
+  release_notes_version_to_html_export(build_number, version, text, false)
+end
+
+def release_notes_version_to_html_export(build_number, version, text, is_preprod)
   attribute = is_preprod ? ' preprod' : ''
   div = "<div id=\"build_#{build_number}\"#{attribute}>\n<h2 id=\"#{version}\">#{version}</h2>\n"
   div += release_notes_to_html(text)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1179,14 +1179,14 @@ def what_s_new_for_beta_json(platform)
   json
 end
 
-def release_notes_html_platform(platform)
+def release_notes_html_devices(platform)
   platform == 'iOS' ? 'iPhone & iPad' : 'Apple TV'
 end
 
 def release_notes_html(platform, business_unit, divs)
   input_file = "release_notes-#{business_unit.downcase}.html"
   html = File.read("gh-pages/releases/#{input_file}")
-  html = html.gsub('<!-- platform -->', release_notes_html_platform(platform))
+  html = html.gsub('<!-- devices -->', release_notes_html_devices(platform))
   html.sub('<!-- versions -->', divs.strip)
 end
 

--- a/fastlane/gh-pages/index.html
+++ b/fastlane/gh-pages/index.html
@@ -38,6 +38,10 @@ a {
 <p><a href="releases/release_notes-tvos-rts.html">Play RTS</a></p>
 <p><a href="releases/release_notes-tvos-srf.html">Play SRF</a></p>
 <p><a href="releases/release_notes-tvos-swi.html">Play SWI</a></p>
+<br/>
+<h4>Beta (TestFlight) release notes</h4>
+<p><a href="releases/release_notes-ios-beta.html">Play iOS beta</a></p>
+<p><a href="releases/release_notes-tvos-beta.html">Play tvOS beta</a></p>
 </div>
 </body>
 </html>

--- a/fastlane/gh-pages/releases/release_notes-beta.html
+++ b/fastlane/gh-pages/releases/release_notes-beta.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Play <!-- platform --> beta</title>
+</head>
+<meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
+<style>
+@font-face {
+  font-family: "SRG SSR Type Regular";
+  src: url("https://play.swissinfo.ch/play/v3/fonts/SRGSSRTypeVF_Text_W_Wght.woff2") format("woff2"); 
+}
+body {
+  font-family: "SRG SSR Type Regular";
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -webkit-text-size-adjust: 100%;
+  color: #ffffff;
+  background-color: #161616;
+}
+hr {
+    display: block;
+    height: 1px;
+    border: 0;
+    border-top: 2px solid #9d0018; /* Red */
+    margin: 1em 0;
+    padding: 0; 
+}
+.button {
+    background-color: #0f5acb; /* Blue */
+    border: none;
+    border-radius: 2px;
+    color: white;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 16px;
+    margin: 4px 2px;
+    cursor: pointer;
+}
+</style>
+<body>
+<div style="text-align: center;">
+<h2 style="line-height: 0;">Play <!-- platform --> beta</h2>
+<p style="line-height: 2;"><!-- devices --></p>
+</div>
+<!-- versions -->
+</body>
+</html>

--- a/fastlane/gh-pages/releases/release_notes-rsi.html
+++ b/fastlane/gh-pages/releases/release_notes-rsi.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Play RSI (<!-- platform -->)</title>
+<title>Play RSI (<!-- devices -->)</title>
 </head>
 <meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 <style>
@@ -118,7 +118,7 @@ function addHighlightFooter (highlightDiv) {
 <body onload="highlightElement()">
 <div style="text-align: center;">
 <h2 style="line-height: 0;">Play RSI</h2>
-<p style="line-height: 2;"><!-- platform --></p>
+<p style="line-height: 2;"><!-- devices --></p>
 </div>
 <!-- versions -->
 </body>

--- a/fastlane/gh-pages/releases/release_notes-rtr.html
+++ b/fastlane/gh-pages/releases/release_notes-rtr.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Play RTR (<!-- platform -->)</title>
+<title>Play RTR (<!-- devices -->)</title>
 </head>
 <meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 <style>
@@ -118,7 +118,7 @@ function addHighlightFooter (highlightDiv) {
 <body onload="highlightElement()">
 <div style="text-align: center;">
 <h2 style="line-height: 0;">Play RTR</h2>
-<p style="line-height: 2;"><!-- platform --></p>
+<p style="line-height: 2;"><!-- devices --></p>
 </div>
 <!-- versions -->
 </body>

--- a/fastlane/gh-pages/releases/release_notes-rts.html
+++ b/fastlane/gh-pages/releases/release_notes-rts.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Play RTS (<!-- platform -->)</title>
+<title>Play RTS (<!-- devices -->)</title>
 </head>
 <meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 <style>
@@ -118,7 +118,7 @@ function addHighlightFooter (highlightDiv) {
 <body onload="highlightElement()">
 <div style="text-align: center;">
 <h2 style="line-height: 0;">Play RTS</h2>
-<p style="line-height: 2;"><!-- platform --></p>
+<p style="line-height: 2;"><!-- devices --></p>
 </div>
 <!-- versions -->
 </body>

--- a/fastlane/gh-pages/releases/release_notes-srf.html
+++ b/fastlane/gh-pages/releases/release_notes-srf.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Play SRF (<!-- platform -->)</title>
+<title>Play SRF (<!-- devices -->)</title>
 </head>
 <meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 <style>
@@ -118,7 +118,7 @@ function addHighlightFooter (highlightDiv) {
 <body onload="highlightElement()">
 <div style="text-align: center;">
 <h2 style="line-height: 0;">Play SRF</h2>
-<p style="line-height: 2;"><!-- platform --></p>
+<p style="line-height: 2;"><!-- devices --></p>
 </div>
 <div>
 <p>Wir freuen uns über Ihr Feedback. Bei Fragen zur Play SRF App wenden Sie sich bitte an den SRF Kundendienst via srf.ch/kontakt oder per Telefon unter 0848 80 80 80.</p>

--- a/fastlane/gh-pages/releases/release_notes-swi.html
+++ b/fastlane/gh-pages/releases/release_notes-swi.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Play SWI (<!-- platform -->)</title>
+<title>Play SWI (<!-- devices -->)</title>
 </head>
 <meta charset="UTF-8" content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
 <style>
@@ -118,7 +118,7 @@ function addHighlightFooter (highlightDiv) {
 <body onload="highlightElement()">
 <div style="text-align: center;">
 <h2 style="line-height: 0;">Play SWI</h2>
-<p style="line-height: 2;"><!-- platform --></p>
+<p style="line-height: 2;"><!-- devices --></p>
 </div>
 <!-- versions -->
 </body>


### PR DESCRIPTION
### Motivation and Context

Like the AppStore release notes for iOS and tvOS, add the beta release notes, used by TestFlight public builds.

### Description

Publish on the GitHub page, using the `WhatsNew-iOS-beta.json` and `WhatsNew-tvOS-beta.json` files on the repository.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [ ] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [ ] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.
