### PR TITLE
Scheduled livestreams sections for tv

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -9,6 +9,7 @@
   "playServiceURL": "https://www.rsi.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite",
+  "tvLiveHomeSections": "tvLive,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioWatchLater",
   "minimumSocialViewCount": 50,
   "termsAndConditionsURL": "https://www.rsi.ch/la-rsi/Condizioni-generali-di-uso-del-sito-RSI-8585464.html",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -8,6 +8,7 @@
   "playServiceURL": "https://www.rtr.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvScheduledLivestreams",
+  "tvLiveHomeSections": "tvLive,tvScheduledLivestreams,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioLatestEpisodes,radioWatchLater",
   "minimumSocialViewCount": 50,
   "dataProtectionURL": "https://www.rtr.ch/article/7872047",

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -13,6 +13,7 @@
   "userDataServiceURL": "https://profil.rts.ch/api",
   "supportEmailAddress": "support.play@rts.ch",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvScheduledLivestreams",
+  "tvLiveHomeSections": "tvLive,tvScheduledLivestreams,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioLatestEpisodes,radioLatestVideos,radioWatchLater",
   "minimumSocialViewCount": 50,
   "termsAndConditionsURL": "https://www.rts.ch/article/8994021",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -9,6 +9,7 @@
   "playServiceURL": "https://www.srf.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvLiveCenterScheduledLivestreams,tvLiveCenterEpisodes",
+  "tvLiveHomeSections": "tvLive,tvLiveCenterScheduledLivestreams,tvLiveCenterEpisodes,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioLatestEpisodes,radioWatchLater",
   "minimumSocialViewCount": 50,
   "dataProtectionURL": "https://www.srf.ch/article/617762",

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -32,7 +32,6 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly) NSInteger analyticsContainer;
 
 @property (nonatomic, readonly, copy) NSString *siteName;
-@property (nonatomic, readonly, copy) NSString *tvSiteName;
 
 // Might be nil for "exotic" languages like Rumantsch
 @property (nonatomic, readonly, copy, nullable) NSString *voiceOverLanguageCode;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -366,7 +366,11 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];
     self.posterImagesEnabled = [firebaseConfiguration boolForKey:@"posterImagesEnabled"];
     
+#if TARGET_OS_IOS
     self.liveHomeSections = [firebaseConfiguration homeSectionsForKey:@"liveHomeSections"];
+#else
+    self.liveHomeSections = [firebaseConfiguration homeSectionsForKey:@"tvLiveHomeSections"];
+#endif
     
     self.audioHomeSections = [firebaseConfiguration homeSectionsForKey:@"audioHomeSections"];
     

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -97,7 +97,6 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic) NSInteger analyticsContainer;
 
 @property (nonatomic, copy) NSString *siteName;
-@property (nonatomic, copy) NSString *tvSiteName;
 
 @property (nonatomic, copy) NSString *voiceOverLanguageCode;
 
@@ -309,8 +308,11 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.vendor = vendor;
     self.analyticsBusinessUnitIdentifier = analyticsBusinessUnitIdentifier;
     self.analyticsContainer = analyticsContainer.integerValue;
+#if TARGET_OS_IOS
     self.siteName = siteName;
-    self.tvSiteName = tvSiteName;
+#else
+    self.siteName = tvSiteName;
+#endif
     
     self.playURL = playURL;
     self.playServiceURL = playServiceURL;

--- a/TV Application/Sources/AppDelegate.swift
+++ b/TV Application/Sources/AppDelegate.swift
@@ -96,7 +96,7 @@ extension AppDelegate: UIApplicationDelegate {
         
         let analyticsConfiguration = SRGAnalyticsConfiguration(businessUnitIdentifier: configuration.analyticsBusinessUnitIdentifier,
                                                                container: configuration.analyticsContainer,
-                                                               siteName: configuration.tvSiteName)
+                                                               siteName: configuration.siteName)
 #if DEBUG || NIGHTLY || BETA
         analyticsConfiguration.environmentMode = .preProduction
 #endif

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -40,7 +40,7 @@ If a remote configuration is found to be invalid (usually a mandatory parameter 
 
 ## Analytics
 
-* `siteName` (mandatory, string): The iOS site name to send events to.
+* `siteName` (mandatory, string): The iOS and iPadOS site name to send events to.
 * `tvSiteName` (mandatory, string): The tvOS site name to send events to.
 
 ## Channel configuration
@@ -97,7 +97,8 @@ User data
 
 ## Livestream homepage
 
-`liveHomeSections` (optional, string, multiple): The sections to be displayed on the live homepage, in the order they must appear.
+* `liveHomeSections` (optional, string, multiple): The sections to be displayed on the live homepage on iOS and iPadOS, in the order they must appear.
+* `tvLiveHomeSections` (optional, string, multiple): The sections to be displayed on the live homepage on tvOS, in the order they must appear.
 
 ### Home sections
 


### PR DESCRIPTION
### Motivation and Context

After review and tests of #246, separate iOS and tvOS live home sections order.

### Description

New remote configuration property added.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
