### PR TITLE
Alignment and padding adjustments for TV program grid and list layouts

### DIFF
--- a/Application/Sources/ProgramGuide/ProgramCell.swift
+++ b/Application/Sources/ProgramGuide/ProgramCell.swift
@@ -65,11 +65,7 @@ struct ProgramCell: View {
             return direction == .horizontal ? 16 : 12
         }
         
-        private var topPadding: CGFloat {
-            return direction == .horizontal ? 0 : constant(iOS: 12, tvOS: 16)
-        }
-        
-        private var bottomPadding: CGFloat {
+        private var verticalPadding: CGFloat {
             return direction == .horizontal ? 0 : constant(iOS: 4, tvOS: 8)
         }
         
@@ -97,15 +93,16 @@ struct ProgramCell: View {
                                 .frame(maxWidth: timeRangeWidth, alignment: .leading)
                         }
                         TitleView(model: model, compact: isCompact)
-                        Spacer()
+                        if direction == .horizontal {
+                            Spacer()
+                        }
                     }
                     else {
                         Color.clear
                     }
                 }
                 .padding(.horizontal, isDisplayable ? horizontalPadding : 0)
-                .padding(.top, topPadding)
-                .padding(.bottom, bottomPadding)
+                .padding(.vertical, verticalPadding)
                 .frame(maxHeight: .infinity)
                 .background(!isFocused ? Color.srgGray23 : Color.srgGray33)
                 

--- a/Application/Sources/ProgramGuide/ProgramCell.swift
+++ b/Application/Sources/ProgramGuide/ProgramCell.swift
@@ -93,9 +93,7 @@ struct ProgramCell: View {
                                 .frame(maxWidth: timeRangeWidth, alignment: .leading)
                         }
                         TitleView(model: model, compact: isCompact)
-                        if direction == .horizontal {
-                            Spacer()
-                        }
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     else {
                         Color.clear


### PR DESCRIPTION
### Motivation and Context

#249 TV program iteration reduced grid cell height. But the texts vertical alignement didn't follow correctly the Figma project.

### Description

- Vertical alignment for program texts in cells for the grid layout.
- Adjust right padding on list layout.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
