### PR TITLE
Update page after a while and when configuration is updated

### DIFF
--- a/Application/Sources/CarPlay/CarPlayTemplateListController.swift
+++ b/Application/Sources/CarPlay/CarPlayTemplateListController.swift
@@ -44,20 +44,16 @@ final class CarPlayTemplateListController {
     }
     
     private func reloadSignal() -> AnyPublisher<Void, Never> {
-        return Publishers.Merge3(
-            Self.foreground(),
-            ApplicationSignal.reachable(),
-            trigger.signal(activatedBy: TriggerId.reload)
+        return Publishers.Merge(
+            trigger.signal(activatedBy: TriggerId.reload),
+            ApplicationSignal.wokenUp(.scene(filter: notificationFilter.self))
         )
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: false)
         .eraseToAnyPublisher()
     }
     
-    private static func foreground() -> AnyPublisher<Void, Never> {
-        return NotificationCenter.default.weakPublisher(for: UIScene.willEnterForegroundNotification)
-            .filter { $0.object is CPTemplateApplicationScene }
-            .map { _ in }
-            .eraseToAnyPublisher()
+    private func notificationFilter(notification: Notification) -> Bool {
+        return notification.object is CPTemplateApplicationScene
     }
 }
 

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -257,8 +257,9 @@ NSArray<NSNumber *> *FirebaseConfigurationHomeSections(NSString *string)
 #endif
     
     [self.remoteConfig fetchWithExpirationDuration:kExpirationDuration completionHandler:^(FIRRemoteConfigFetchStatus status, NSError * _Nullable error) {
-        [self.remoteConfig activateWithCompletion:nil];
-        self.updateBlock(self);
+        [self.remoteConfig activateWithCompletion:^(BOOL changed, NSError * _Nullable error) {
+            self.updateBlock(self);
+        }];
     }];
 }
 

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -258,7 +258,9 @@ NSArray<NSNumber *> *FirebaseConfigurationHomeSections(NSString *string)
     
     [self.remoteConfig fetchWithExpirationDuration:kExpirationDuration completionHandler:^(FIRRemoteConfigFetchStatus status, NSError * _Nullable error) {
         [self.remoteConfig activateWithCompletion:^(BOOL changed, NSError * _Nullable error) {
-            self.updateBlock(self);
+            if (changed) {
+                self.updateBlock(self);
+            }
         }];
     }];
 }

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -70,7 +70,7 @@ final class PageViewModel: Identifiable, ObservableObject {
         .receive(on: DispatchQueue.main)
         .assign(to: &$serviceMessage)
         
-        Publishers.Publish(onOutputFrom: ApplicationSignal.lieDown()) {
+        Publishers.Publish(onOutputFrom: ApplicationSignal.background()) {
             return Just(Date())
         }
         .assign(to: &$inactiveApplicationDate)

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -95,7 +95,7 @@ final class PageViewModel: Identifiable, ObservableObject {
                     guard let self else { return false }
                     return self.state.sections.isEmpty
                 },
-            ApplicationSignal.foregroundRefresh(),
+            ApplicationSignal.foregroundAfterTimeInBackground(),
             ApplicationSignal.applicationConfigurationUpdate()
                 .filter { [weak self] in
                     guard let self else { return false }

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -94,7 +94,7 @@ final class PageViewModel: Identifiable, ObservableObject {
     }
     
     private func reloadSignal() -> AnyPublisher<Void, Never> {
-        return Publishers.Merge(
+        return Publishers.Merge3(
             trigger.signal(activatedBy: TriggerId.reload),
             ApplicationSignal.wokenUp()
                 .filter { [weak self] in
@@ -102,6 +102,11 @@ final class PageViewModel: Identifiable, ObservableObject {
                     guard let inactiveApplicationDate = self.inactiveApplicationDate,
                           let minute = Calendar.current.dateComponents([.minute], from: inactiveApplicationDate, to: Date()).minute else { return true }
                     return self.state.sections.isEmpty || minute > 0
+                },
+            ApplicationSignal.applicationConfigurationUpdate()
+                .filter { [weak self] in
+                    guard let self else { return false }
+                    return self.id.isConfigured
                 }
         )
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: false)
@@ -167,6 +172,15 @@ extension PageViewModel {
         var supportsCastButton: Bool {
             switch self {
             case .video, .audio, .live:
+                return true
+            default:
+                return false
+            }
+        }
+        
+        var isConfigured: Bool {
+            switch self {
+            case .audio, .live:
                 return true
             default:
                 return false

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -60,7 +60,7 @@ final class SectionViewModel: ObservableObject {
         .receive(on: DispatchQueue.main)
         .assign(to: &$state)
         
-        Publishers.Publish(onOutputFrom: ApplicationSignal.lieDown()) {
+        Publishers.Publish(onOutputFrom: ApplicationSignal.background()) {
             return Just(Date())
         }
         .assign(to: &$inactiveApplicationDate)

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -107,7 +107,7 @@ final class SectionViewModel: ObservableObject {
                     guard let self else { return false }
                     return !self.state.hasContent
                 },
-            ApplicationSignal.foregroundRefresh()
+            ApplicationSignal.foregroundAfterTimeInBackground()
         )
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: false)
         .eraseToAnyPublisher()

--- a/Application/Sources/Helpers/Signals.swift
+++ b/Application/Sources/Helpers/Signals.swift
@@ -200,6 +200,15 @@ enum ApplicationSignal {
             .map { _ in }
             .eraseToAnyPublisher()
     }
+    
+    /**
+     *  Emits a signal when the application configuration is updated.
+     */
+    static func applicationConfigurationUpdate() -> AnyPublisher<Void, Never> {
+        return NotificationCenter.default.weakPublisher(for: NSNotification.Name.ApplicationConfigurationDidChange)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
 }
 
 // MARK: Notifications

--- a/Application/Sources/Helpers/Signals.swift
+++ b/Application/Sources/Helpers/Signals.swift
@@ -118,7 +118,7 @@ enum ApplicationSignal {
      */
     static func wokenUp() -> AnyPublisher<Void, Never> {
         return Publishers.Merge(reachable(), foreground())
-            .throttle(for: 10, scheduler: DispatchQueue.main, latest: false)
+            .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: true)
             .eraseToAnyPublisher()
     }
     

--- a/Application/Sources/Helpers/Signals.swift
+++ b/Application/Sources/Helpers/Signals.swift
@@ -114,19 +114,10 @@ enum ThrottledSignal {
 
 enum ApplicationSignal {
     /**
-     *  Emits a signal when the application is woken up (network reachable again, will move to the foreground or becomes active).
+     *  Emits a signal when the application is woken up (network reachable again or will move to the foreground).
      */
     static func wokenUp() -> AnyPublisher<Void, Never> {
-        return Publishers.Merge3(reachable(), foreground(), becomeActive())
-            .throttle(for: 10, scheduler: DispatchQueue.main, latest: false)
-            .eraseToAnyPublisher()
-    }
-    
-    /**
-     *  Emits a signal when the application is lie down to sleep (moved to the background or resignes ative).
-     */
-    static func lieDown() -> AnyPublisher<Void, Never> {
-        return Publishers.Merge(background(), resignActive())
+        return Publishers.Merge(reachable(), foreground())
             .throttle(for: 10, scheduler: DispatchQueue.main, latest: false)
             .eraseToAnyPublisher()
     }
@@ -155,24 +146,6 @@ enum ApplicationSignal {
      */
     static func background() -> AnyPublisher<Void, Never> {
         return NotificationCenter.default.weakPublisher(for: UIApplication.didEnterBackgroundNotification)
-            .map { _ in }
-            .eraseToAnyPublisher()
-    }
-    
-    /**
-     *  Emits a signal when the application becomes active.
-     */
-    static func becomeActive() -> AnyPublisher<Void, Never> {
-        return NotificationCenter.default.weakPublisher(for: UIApplication.didBecomeActiveNotification)
-            .map { _ in }
-            .eraseToAnyPublisher()
-    }
-    
-    /**
-     *  Emits a signal when the application resignes active.
-     */
-    static func resignActive() -> AnyPublisher<Void, Never> {
-        return NotificationCenter.default.weakPublisher(for: UIApplication.willResignActiveNotification)
             .map { _ in }
             .eraseToAnyPublisher()
     }

--- a/Application/Sources/Helpers/Signals.swift
+++ b/Application/Sources/Helpers/Signals.swift
@@ -123,6 +123,25 @@ enum ApplicationSignal {
     }
     
     /**
+     *  Emits a signal when the application will move to the foreground after moved to the background and need a refresh.
+     */
+    static func foregroundRefresh() -> AnyPublisher<Void, Never> {
+        return Publishers.Zip(
+            background()
+                .map { _ in Date() },
+            foreground()
+                .dropFirst()
+                .map { _ in Date() }
+        )
+        .filter {
+            guard let minute = Calendar.current.dateComponents([.minute], from: $0, to: $1).minute else { return false }
+            return minute > 0
+        }
+        .map { _ in }
+        .eraseToAnyPublisher()
+    }
+    
+    /**
      *  Emits a signal when the network is reachable again.
      */
     static func reachable() -> AnyPublisher<Void, Never> {

--- a/Application/Sources/Helpers/Signals.swift
+++ b/Application/Sources/Helpers/Signals.swift
@@ -155,9 +155,9 @@ enum ApplicationSignal {
     }
     
     /**
-     *  Emits a signal when the application (or scene) will move to the foreground after moved to the background and need a refresh.
+     *  Emits a signal when the application (or scene) will move to the foreground after some  time in background.
      */
-    static func foregroundRefresh(_ type: NotificationType = .application) -> AnyPublisher<Void, Never> {
+    static func foregroundAfterTimeInBackground(_ type: NotificationType = .application) -> AnyPublisher<Void, Never> {
         return Publishers.Zip(
             background(type)
                 .map { _ in Date() },

--- a/Application/Sources/Search/SearchViewModel.swift
+++ b/Application/Sources/Search/SearchViewModel.swift
@@ -58,13 +58,14 @@ final class SearchViewModel: ObservableObject {
     }
     
     private func reloadSignal() -> AnyPublisher<Void, Never> {
-        return Publishers.Merge(
+        return Publishers.Merge3(
             trigger.signal(activatedBy: TriggerId.reload),
             ApplicationSignal.wokenUp()
                 .filter { [weak self] in
                     guard let self else { return false }
                     return !self.state.hasContent
-                }
+                },
+            ApplicationSignal.foregroundAfterTimeInBackground()
         )
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: false)
         .eraseToAnyPublisher()


### PR DESCRIPTION
### Motivation and Context

Resolves #181.

### Description

- Refresh content when entering in foreground after a while (1 minute).
- Updated remote configuration without launching the app, killing it, and reloading it.


### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
