### PR TITLE
Add show promotion representation and update highlight

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -163,7 +163,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 17.0.1, source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -163,7 +163,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 17.0.0, source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -286,7 +286,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>srgdataprovider-apple</string>
+			<string>SRGDataProvider (17.0.1)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -286,7 +286,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>SRGDataProvider (17.0.0)</string>
+			<string>srgdataprovider-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -328,7 +328,7 @@ private extension Content {
         }
         
         var rowHighlight: Highlight? {
-            guard presentation.type == .highlight else { return nil }
+            guard presentation.type == .highlight || presentation.type == .showPromotion else { return nil }
             return Highlight(from: contentSection)
         }
         
@@ -354,13 +354,15 @@ private extension Content {
                 return (0..<kDefaultNumberOfLivestreamPlaceholders).map { .mediaPlaceholder(index: $0) }
             case .highlight:
                 return (rowHighlight != nil) ? [] : (0..<kDefaultNumberOfPlaceholders).map { .mediaPlaceholder(index: $0) }
+            case .showPromotion:
+                return (rowHighlight != nil) ? [] : (0..<kDefaultNumberOfPlaceholders).map { .showPlaceholder(index: $0) }
             default:
                 return []
             }
         }
         
         var displaysRowHeader: Bool {
-            return contentSection.presentation.type != .highlight
+            return contentSection.presentation.type != .highlight && contentSection.presentation.type != .showPromotion
         }
         
         func publisher(pageSize: UInt, paginatedBy paginator: Trigger.Signal?, filter: SectionFiltering?) -> AnyPublisher<[Content.Item], Error> {

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -42,6 +42,7 @@ enum Content {
         case showAccess(radioChannel: RadioChannel?)
 #endif
         
+        case highlightPlaceholder(index: Int)
         case highlight(_ highlight: Highlight)
         
         case transparent
@@ -353,9 +354,9 @@ private extension Content {
             case .livestreams:
                 return (0..<kDefaultNumberOfLivestreamPlaceholders).map { .mediaPlaceholder(index: $0) }
             case .highlight:
-                return (rowHighlight != nil) ? [] : (0..<kDefaultNumberOfPlaceholders).map { .mediaPlaceholder(index: $0) }
+                return (rowHighlight != nil) ? [.highlightPlaceholder(index: 0)] : (0..<kDefaultNumberOfPlaceholders).map { .mediaPlaceholder(index: $0) }
             case .showPromotion:
-                return (rowHighlight != nil) ? [] : (0..<kDefaultNumberOfPlaceholders).map { .showPlaceholder(index: $0) }
+                return (rowHighlight != nil) ? [.highlightPlaceholder(index: 0)] : (0..<kDefaultNumberOfPlaceholders).map { .showPlaceholder(index: $0) }
             default:
                 return []
             }

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -26,7 +26,7 @@ enum Content {
         }
     }
     
-    enum Item: Hashable {
+    indirect enum Item: Hashable {
         case mediaPlaceholder(index: Int)
         case media(_ media: SRGMedia)
         
@@ -43,7 +43,7 @@ enum Content {
 #endif
         
         case highlightPlaceholder(index: Int)
-        case highlight(_ highlight: Highlight)
+        case highlight(_ highlight: Highlight, item: Item?)
         
         case transparent
         
@@ -61,7 +61,7 @@ enum Content {
             case let .notification(notification):
                 return notification.title
 #endif
-            case let .highlight(highlight):
+            case let .highlight(highlight, _):
                 return highlight.title
             default:
                 return nil
@@ -139,6 +139,7 @@ protocol SectionProperties {
     var displaysTitle: Bool { get }
     var supportsEdition: Bool { get }
     var emptyType: EmptyContentView.`Type` { get }
+    var hasHighlightedItem: Bool { get }
     
 #if os(iOS)
     var sharingItem: SharingItem? { get }
@@ -272,6 +273,10 @@ private extension Content {
             default:
                 return .generic
             }
+        }
+        
+        var hasHighlightedItem: Bool {
+            return presentation.type == .showPromotion
         }
         
 #if os(iOS)
@@ -620,6 +625,10 @@ private extension Content {
             }
         }
         
+        var hasHighlightedItem: Bool {
+            return false
+        }
+        
 #if os(iOS)
         var sharingItem: SharingItem? {
             switch configuredSection {
@@ -691,14 +700,14 @@ private extension Content {
                 let level1 = (show.transmission == .radio) ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
                 return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
             case let .radioAllShows(channelUid),
-                 let .radioFavoriteShows(channelUid: channelUid),
-                 let .radioLatest(channelUid: channelUid),
-                 let .radioLatestEpisodes(channelUid: channelUid),
-                 let .radioLatestEpisodesFromFavorites(channelUid: channelUid),
-                 let .radioLatestVideos(channelUid: channelUid),
-                 let .radioMostPopular(channelUid: channelUid),
-                 let .radioResumePlayback(channelUid: channelUid),
-                 let .radioWatchLater(channelUid: channelUid):
+                let .radioFavoriteShows(channelUid: channelUid),
+                let .radioLatest(channelUid: channelUid),
+                let .radioLatestEpisodes(channelUid: channelUid),
+                let .radioLatestEpisodesFromFavorites(channelUid: channelUid),
+                let .radioLatestVideos(channelUid: channelUid),
+                let .radioMostPopular(channelUid: channelUid),
+                let .radioResumePlayback(channelUid: channelUid),
+                let .radioWatchLater(channelUid: channelUid):
                 if let channel = ApplicationConfiguration.shared.radioChannel(forUid: channelUid) {
                     return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.audio.rawValue, channel.name]
                 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -341,8 +341,14 @@ extension PageViewController: UICollectionViewDelegate {
                 }
             case .highlight:
                 if let navigationController {
-                    let sectionViewController = SectionViewController(section: section.wrappedValue, filter: model.id)
-                    navigationController.pushViewController(sectionViewController, animated: true)
+                    if case let .show(show) = item.sectionUniqueItem {
+                        let showViewController = SectionViewController.showViewController(for: show)
+                        navigationController.pushViewController(showViewController, animated: true)
+                    }
+                    else {
+                        let sectionViewController = SectionViewController(section: section.wrappedValue, filter: model.id)
+                        navigationController.pushViewController(sectionViewController, animated: true)
+                    }
                 }
             default:
                 ()
@@ -713,7 +719,7 @@ private extension PageViewController {
                     }
 #endif
                 case let .highlight(highlight):
-                    HighlightCell(highlight: highlight, section: item.section.wrappedValue, filter: id)
+                    HighlightCell(highlight: highlight, section: item.section.wrappedValue, sectionUniqueItem: item.sectionUniqueItem, filter: id)
                 case .transparent:
                     Color.clear
                 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -339,9 +339,9 @@ extension PageViewController: UICollectionViewDelegate {
                     let pageViewController = PageViewController(id: .topic(topic))
                     navigationController.pushViewController(pageViewController, animated: true)
                 }
-            case .highlight:
+            case let .highlight(_, highlightedItem):
                 if let navigationController {
-                    if case let .show(show) = item.sectionUniqueItem {
+                    if case let .show(show) = highlightedItem {
                         let showViewController = SectionViewController.showViewController(for: show)
                         navigationController.pushViewController(showViewController, animated: true)
                     }
@@ -719,9 +719,9 @@ private extension PageViewController {
                     }
 #endif
                 case .highlightPlaceholder:
-                    HighlightCell(highlight: nil, section: item.section.wrappedValue, sectionUniqueItem: item.sectionUniqueItem, filter: id)
-                case let .highlight(highlight):
-                    HighlightCell(highlight: highlight, section: item.section.wrappedValue, sectionUniqueItem: item.sectionUniqueItem, filter: id)
+                    HighlightCell(highlight: nil, section: item.section.wrappedValue, item: nil, filter: id)
+                case let .highlight(highlight, highlightedItem):
+                    HighlightCell(highlight: highlight, section: item.section.wrappedValue, item: highlightedItem, filter: id)
                 case .transparent:
                     Color.clear
                 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -718,6 +718,8 @@ private extension PageViewController {
                         ShowAccessCell(style: .calendar)
                     }
 #endif
+                case .highlightPlaceholder:
+                    HighlightCell(highlight: nil, section: item.section.wrappedValue, sectionUniqueItem: item.sectionUniqueItem, filter: id)
                 case let .highlight(highlight):
                     HighlightCell(highlight: highlight, section: item.section.wrappedValue, sectionUniqueItem: item.sectionUniqueItem, filter: id)
                 case .transparent:

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -279,12 +279,10 @@ extension PageViewModel {
         
         let wrappedValue: WrappedValue
         let section: Section
-        let sectionUniqueItem: Content.Item?
         
-        init(_ wrappedValue: WrappedValue, in section: Section, uniqueItem: Content.Item? = nil) {
+        init(_ wrappedValue: WrappedValue, in section: Section) {
             self.wrappedValue = wrappedValue
             self.section = section
-            self.sectionUniqueItem = uniqueItem
         }
     }
     
@@ -325,9 +323,10 @@ private extension PageViewModel {
         if let highlight = section.properties.rowHighlight {
             return section.properties.publisher(pageSize: pageSize, paginatedBy: paginator, filter: id)
                 .map { items in
-                    guard let item = items.first else { return Row(section: section, items: []) }
-                    let highlightItem = Item(.item(.highlight(highlight)), in: section, uniqueItem: items.count > 1 ? nil : item)
-                    return Row(section: section, items: [highlightItem])
+                    guard let firstItem = items.first else { return Row(section: section, items: []) }
+                    let highlightedItem = section.properties.hasHighlightedItem ? firstItem : nil
+                    let item = Item(.item(.highlight(highlight, item: highlightedItem)), in: section)
+                    return Row(section: section, items: [item])
                 }
                 .eraseToAnyPublisher()
         }

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -399,6 +399,8 @@ private extension PageViewModel {
                 return .heroStage
             case .highlight:
                 return (Highlight(from: contentSection) != nil) ? .highlight : .mediaSwimlane
+            case .showPromotion:
+                return (Highlight(from: contentSection) != nil) ? .highlight : .showSwimlane
             case .mediaElement, .showElement:
                 return .element
             case .mediaElementSwimlane:

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -324,6 +324,7 @@ private extension PageViewModel {
             return section.properties.publisher(pageSize: pageSize, paginatedBy: paginator, filter: id)
                 .map { items in
                     guard let firstItem = items.first else { return Row(section: section, items: []) }
+                    
                     let highlightedItem = section.properties.hasHighlightedItem ? firstItem : nil
                     let item = Item(.item(.highlight(highlight, item: highlightedItem)), in: section)
                     return Row(section: section, items: [item])

--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct HighlightCell: View {
     let highlight: Highlight
     let section: Content.Section
+    let sectionUniqueItem: Content.Item?
     let filter: SectionFiltering?
     
     @Environment(\.isSelected) private var isSelected
@@ -31,7 +32,12 @@ struct HighlightCell: View {
     
 #if os(tvOS)
     private func action() {
-        navigateToSection(section, filter: filter)
+        if case let .show(show) = sectionUniqueItem {
+            navigateToShow(show)
+        }
+        else {
+            navigateToSection(section, filter: filter)
+        }
     }
 #endif
     
@@ -153,10 +159,10 @@ struct HighlightCell_Previews: PreviewProvider {
     static let highlight = Mock.highlight()
     
     static var previews: some View {
-        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), filter: nil)
+        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), sectionUniqueItem: nil, filter: nil)
             .previewLayout(layoutWidth: 1000, horizontalSizeClass: .regular)
 #if os(iOS)
-        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), filter: nil)
+        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), sectionUniqueItem: nil, filter: nil)
             .previewLayout(layoutWidth: 400, horizontalSizeClass: .compact)
 #endif
     }

--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct HighlightCell: View {
     let highlight: Highlight?
     let section: Content.Section
-    let sectionUniqueItem: Content.Item?
+    let item: Content.Item?
     let filter: SectionFiltering?
     
     @Environment(\.isSelected) private var isSelected
@@ -34,7 +34,7 @@ struct HighlightCell: View {
     
 #if os(tvOS)
     private func action() {
-        if case let .show(show) = sectionUniqueItem {
+        if case let .show(show) = item {
             navigateToShow(show)
         }
         else {
@@ -166,10 +166,10 @@ struct HighlightCell_Previews: PreviewProvider {
     static let highlight = Mock.highlight()
     
     static var previews: some View {
-        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), sectionUniqueItem: nil, filter: nil)
+        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), item: nil, filter: nil)
             .previewLayout(layoutWidth: 1000, horizontalSizeClass: .regular)
 #if os(iOS)
-        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), sectionUniqueItem: nil, filter: nil)
+        HighlightCell(highlight: highlight, section: .configured(.tvAllShows), item: nil, filter: nil)
             .previewLayout(layoutWidth: 400, horizontalSizeClass: .compact)
 #endif
     }

--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -140,15 +140,12 @@ private extension HighlightCell {
 // MARK: Size
 
 enum HighlightCellSize {
-    fileprivate static let aspectRatio: CGFloat = 16 / 9
+    private static func aspectRatio(horizontalSizeClass: UIUserInterfaceSizeClass) -> CGFloat {
+        return horizontalSizeClass == .compact ? 16 / 9 : 4
+    }
     
     static func fullWidth(layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
-        if horizontalSizeClass == .compact {
-            return LayoutSwimlaneCellSize(layoutWidth, aspectRatio, 0)
-        }
-        else {
-            return LayoutFractionedCellSize(layoutWidth, aspectRatio, 0.4)
-        }
+        return LayoutSwimlaneCellSize(layoutWidth, aspectRatio(horizontalSizeClass: horizontalSizeClass), 0)
     }
 }
 

--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -9,7 +9,7 @@ import SwiftUI
 // MARK: View
 
 struct HighlightCell: View {
-    let highlight: Highlight
+    let highlight: Highlight?
     let section: Content.Section
     let sectionUniqueItem: Content.Item?
     let filter: SectionFiltering?
@@ -20,12 +20,14 @@ struct HighlightCell: View {
 #if os(tvOS)
         ExpandingCardButton(action: action) {
             MainView(highlight: highlight)
+                .redactable()
                 .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: .isButton)
         }
 #else
         MainView(highlight: highlight)
-            .selectionAppearance(when: isSelected)
+            .selectionAppearance(when: isSelected && highlight != nil)
             .cornerRadius(LayoutStandardViewCornerRadius)
+            .redactable()
             .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint)
 #endif
     }
@@ -43,7 +45,7 @@ struct HighlightCell: View {
     
     /// Behavior: h-exp, v-exp
     private struct MainView: View {
-        let highlight: Highlight
+        let highlight: Highlight?
         
         @Environment(\.uiHorizontalSizeClass) private var horizontalSizeClass
         
@@ -56,11 +58,12 @@ struct HighlightCell: View {
         }
         
         private var imageUrl: URL? {
+            guard let highlight else { return nil }
             return SRGDataProvider.current!.url(for: highlight.image, size: .large)
         }
         
         private var contentMode: ImageView.ContentMode {
-            if let focalPoint = highlight.imageFocalPoint {
+            if let focalPoint = highlight?.imageFocalPoint {
                 return .aspectFillFocused(relativeWidth: focalPoint.relativeWidth, relativeHeight: focalPoint.relativeHeight)
             }
             else {
@@ -73,23 +76,27 @@ struct HighlightCell: View {
                 if isCompact {
                     ZStack(alignment: .bottom) {
                         ImageView(source: imageUrl, contentMode: contentMode)
-                        LinearGradient(gradient: Gradient(colors: [.srgGray16.opacity(0.9), .clear]), startPoint: .bottom, endPoint: .center)
-                        Text(highlight.title)
-                            .srgFont(.H2)
-                            .lineLimit(2)
-                            .foregroundColor(.white)
-                            .padding(16)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let highlight {
+                            LinearGradient(gradient: Gradient(colors: [.srgGray16.opacity(0.9), .clear]), startPoint: .bottom, endPoint: .center)
+                            Text(highlight.title)
+                                .srgFont(.H2)
+                                .lineLimit(2)
+                                .foregroundColor(.white)
+                                .padding(16)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
                 }
                 else {
                     ZStack(alignment: .leading) {
                         ImageView(source: imageUrl, contentMode: contentMode)
-                        LinearGradient(gradient: Gradient(colors: [.srgGray16.opacity(0.9), .clear]), startPoint: .leading, endPoint: .trailing)
-                        DescriptionView(highlight: highlight)
-                            .padding(.horizontal, 60)
-                            .padding(.vertical, 40)
-                            .frame(width: geometry.size.width * 2 / 3, height: geometry.size.height)
+                        if let highlight {
+                            LinearGradient(gradient: Gradient(colors: [.srgGray16.opacity(0.9), .clear]), startPoint: .leading, endPoint: .trailing)
+                            DescriptionView(highlight: highlight)
+                                .padding(.horizontal, 60)
+                                .padding(.vertical, 40)
+                                .frame(width: geometry.size.width * 2 / 3, height: geometry.size.height)
+                        }
                     }
                 }
             }
@@ -99,7 +106,7 @@ struct HighlightCell: View {
     /// Behavior: h-exp, v-hug
     private struct DescriptionView: View {
         let highlight: Highlight
-                
+        
         var body: some View {
             VStack(alignment: .leading, spacing: 15) {
                 Text(highlight.title)
@@ -122,7 +129,7 @@ struct HighlightCell: View {
 
 private extension HighlightCell {
     var accessibilityLabel: String? {
-        return highlight.title
+        return highlight?.title
     }
     
     var accessibilityHint: String? {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19130,8 +19130,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 17.0.0;
+				branch = "feature/41-show-promotion";
+				kind = branch;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19130,8 +19130,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = "feature/41-show-promotion";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 17.0.1;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -293,8 +293,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "7b1c3e001213315ef1eed9892cb97651a3e03dfd",
-        "version" : "17.0.0"
+        "branch" : "feature/41-show-promotion",
+        "revision" : "48e9073453a114eacc9ff2b44982311c94a5c8b5"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -293,8 +293,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "branch" : "feature/41-show-promotion",
-        "revision" : "48e9073453a114eacc9ff2b44982311c94a5c8b5"
+        "revision" : "75818e9de479d6cc460840d6f924be9f144513d8",
+        "version" : "17.0.1"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

Resolves #267. 

### Description

Show promotion is a new layout.
Not yet deployed in production on Play PAC, only in IL Stage.

It also removes empty highlight (media) section, like Play web behavior.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
