### PR TITLE
Program guide fixes

### DIFF
--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -77,6 +77,7 @@ extension UIViewController {
         present(pageViewController, animated: animated, completion: completion)
     }
     
+#if os(tvOS)
     func navigateToProgram(_ program: SRGProgram, in channel: SRGChannel, animated: Bool = true, completion: (() -> Void)? = nil) {
         cancellable = mediaPublisher(for: program, in: channel)?
             .receive(on: DispatchQueue.main)
@@ -84,13 +85,14 @@ extension UIViewController {
                 // No error banners displayed on tvOS yet
             } receiveValue: { [weak self] media in
                 let playAnalyticsClickEvent = media.contentType == .livestream ?
-                AnalyticsClickEvent.tvGuidePlayLivestream(program: program, channel: channel) :
+                AnalyticsClickEvent.tvGuidePlayLivestream(program: program, channel: channel, source: .grid) :
                 AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: (program.startDate...program.endDate).contains(Date()), channel: channel)
                 let mediaAnalyticsClickEvent = AnalyticsClickEvent.tvGuideOpenInfoBox(program: program, programGuideLayout: .grid)
                 
                 self?.navigateToMedia(media, mediaAnalyticsClickEvent: mediaAnalyticsClickEvent, playAnalyticsClickEvent: playAnalyticsClickEvent, from: program, animated: animated, completion: completion)
             }
     }
+#endif
     
     func navigateToSection(_ section: Content.Section, filter: SectionFiltering?, animated: Bool = true, completion: (() -> Void)? = nil) {
         let sectionViewController = SectionViewController(section: section, filter: filter)

--- a/Application/Sources/Helpers/AnalyticsClickEvent.swift
+++ b/Application/Sources/Helpers/AnalyticsClickEvent.swift
@@ -36,22 +36,27 @@ struct AnalyticsClickEvent {
         )
     }
     
-    static func tvGuidePlayLivestream(program: SRGProgram, channel: SRGChannel) -> AnalyticsClickEvent {
+    enum TvGuidePlaySource: String {
+        case infoBox = "InfoBox"
+        case grid = "Grid"
+    }
+    
+    static func tvGuidePlayLivestream(program: SRGProgram, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> AnalyticsClickEvent {
         return Self(
             name: "TvGuidePlayLivestream",
             value1: PageId.tvGuide.rawValue,
             value2: channel.title,
-            value3: "InfoBox",
+            value3: source.rawValue,
             value4: program.mediaURN
         )
     }
     
-    static func tvGuidePlayMedia(media: SRGMedia, programIsLive: Bool, channel: SRGChannel) -> AnalyticsClickEvent {
+    static func tvGuidePlayMedia(media: SRGMedia, programIsLive: Bool, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> AnalyticsClickEvent {
         return Self(
             name: "TvGuidePlayMedia",
             value1: PageId.tvGuide.rawValue,
             value2: media.urn,
-            value3: "InfoBox",
+            value3: source.rawValue,
             value4: programIsLive ? channel.title : nil
         )
     }

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -220,7 +220,7 @@ final class ProgramViewModel: ObservableObject {
             label: NSLocalizedString("Watch from start", comment: "Button to watch some program from the start"),
             action: {
                 guard let tabBarController = UIApplication.shared.mainTabBarController else { return }
-                if HistoryCanResumePlaybackForMedia(media) {
+                if HistoryCanResumePlaybackForMedia(media) && HistoryPlaybackProgressForMedia(media) != 0 {
                     let alertController = UIAlertController(title: NSLocalizedString("Watch from start?", comment: "Resume playback alert title"),
                                                             message: NSLocalizedString("You already played this content.", comment: "Resume playback alert explanation"),
                                                             preferredStyle: .alert)

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -212,6 +212,9 @@ final class ProgramViewModel: ObservableObject {
     
     var watchFromStartButtonProperties: ButtonProperties? {
         guard isLive, let media, media.blockingReason(at: Date()) == .none else { return nil }
+        
+        let data = self.data
+        let analyticsClickEvent = data != nil ? AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: true, channel: data!.channel) : nil
         return ButtonProperties(
             icon: "start_over",
             label: NSLocalizedString("Watch from start", comment: "Button to watch some program from the start"),
@@ -222,15 +225,21 @@ final class ProgramViewModel: ObservableObject {
                                                             message: NSLocalizedString("You already played this content.", comment: "Resume playback alert explanation"),
                                                             preferredStyle: .alert)
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Resume", comment: "Alert choice to resume playback"), style: .default, handler: { _ in
+                        analyticsClickEvent?.send()
+                        
                         tabBarController.play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
                     }))
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Watch from start", comment: "Alert choice to watch content from start"), style: .default, handler: { _ in
+                        analyticsClickEvent?.send()
+                        
                         tabBarController.play_presentMediaPlayer(with: media, position: .default, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
                     }))
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Title of a cancel button"), style: .cancel, handler: nil))
                     tabBarController.play_top.present(alertController, animated: true, completion: nil)
                 }
                 else {
+                    analyticsClickEvent?.send()
+                    
                     tabBarController.play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
                 }
             }


### PR DESCRIPTION
### Motivation and Context

Following #263 review with Android team, some missed events found.
Also a strange "start over" alert displayed too much times.

### Description

- Add `TVGuidePlayMedia` missing events if start over from te livestream.
- Update `TVGuidePlayLivestream` source for tvOS.
- Fix the start over alert, to be displayed only if the media has a resume playback position.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
