### PR TITLE
Fix build number used as div id on github pages

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1184,7 +1184,7 @@ end
 
 def build_number_for_version(platform, version)
   json = what_s_new_for_beta_json(platform)
-  tag_version = json.keys.select { |key| key.start_with?(version) }.last
+  tag_version = json.keys.select { |key| marketing_version_from_tag_version(key) == version }.last
   tag_version ? build_number_from_tag_version(tag_version) : '999999'
 end
 


### PR DESCRIPTION
### Motivation and Context

After the Play iOS release https://github.com/SRGSSR/playsrg-apple/releases/tag/ios%2F3.6.10-406,
The Profile / Settings / What's new web view didn't select the "3.6.10" version as "installed version, but an old "3.6.1" version.

### Description

This issue appeared because of "3.6.10" version number. The Play iOS app is loading the web page with query parameters:
 * the build number (build=406)
 * the marketing version (version=3.6.10)
 * the iOS version (iOS=16.2)
 
The What's new web page should select the correct version.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
