### PR TITLE
CI: delete local gh-pages branch before checkout it

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1853,6 +1853,7 @@ def publish_on_github_pages(output_directory, releases_directory)
   branch_name = git_branch_name
 
   Dir.chdir('..') do
+    sh 'git branch -Dq gh-pages &>/dev/null || true'
     sh 'git checkout --orphan gh-pages'
     sh 'git reset --hard'
     sh "mv \"#{output_directory}/index.html\" ./"


### PR DESCRIPTION
### Motivation and Context

On our CI (TeamCity + Mac mini devices), the `gh-pages` remote branch is sometime also on the local repository.
Then `git checkout --orphan gh-pages` failed.

### Description

The release note publication on GitHub page failed on the CI.
Local git repository is not in the expected state.

To fix it, remove the local `gh-pages` branch if exits.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [ ] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [ ] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.
