### PR TITLE
Add metrics on user content action in settings view

### DIFF
--- a/Application/Sources/Settings/SettingsViewModel.swift
+++ b/Application/Sources/Settings/SettingsViewModel.swift
@@ -182,14 +182,17 @@ final class SettingsViewModel: ObservableObject {
     
     func removeHistory() {
         SRGUserData.current?.history.discardHistoryEntries(withUids: nil, completionBlock: nil)
+        AnalyticsHiddenEvent.historyRemove(source: .button, urn: nil).send()
     }
     
     func removeFavorites() {
         FavoritesRemoveShows(nil)
+        AnalyticsHiddenEvent.favorite(action: .remove, source: .button, urn: nil).send()
     }
     
     func removeWatchLaterItems() {
         SRGUserData.current?.playlists.discardPlaylistEntries(withUids: nil, fromPlaylistWithUid: SRGPlaylistUid.watchLater.rawValue, completionBlock: nil)
+        AnalyticsHiddenEvent.watchLater(action: .remove, source: .button, urn: nil).send()
     }
     
     func clearWebCache() {


### PR DESCRIPTION
### Motivation and Context

Alignement with Android applications.

### Description

Discussions between native apps team members output: Get information when users use buttons in settings view:
- reset history
- reset favorites
- reset watch later media list

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
