### PR TITLE
Code improvements on user content actions metrics in settings view

### DIFF
--- a/Application/Sources/Settings/SettingsViewModel.swift
+++ b/Application/Sources/Settings/SettingsViewModel.swift
@@ -181,8 +181,10 @@ final class SettingsViewModel: ObservableObject {
 #endif
     
     func removeHistory() {
-        SRGUserData.current?.history.discardHistoryEntries(withUids: nil, completionBlock: nil)
-        AnalyticsHiddenEvent.historyRemove(source: .button, urn: nil).send()
+        SRGUserData.current?.history.discardHistoryEntries(withUids: nil, completionBlock: { error in
+            guard error == nil else { return }
+            AnalyticsHiddenEvent.historyRemove(source: .button, urn: nil).send()
+        })
     }
     
     func removeFavorites() {
@@ -191,8 +193,10 @@ final class SettingsViewModel: ObservableObject {
     }
     
     func removeWatchLaterItems() {
-        SRGUserData.current?.playlists.discardPlaylistEntries(withUids: nil, fromPlaylistWithUid: SRGPlaylistUid.watchLater.rawValue, completionBlock: nil)
-        AnalyticsHiddenEvent.watchLater(action: .remove, source: .button, urn: nil).send()
+        SRGUserData.current?.playlists.discardPlaylistEntries(withUids: nil, fromPlaylistWithUid: SRGPlaylistUid.watchLater.rawValue, completionBlock: { error in
+            guard error == nil else { return }
+            AnalyticsHiddenEvent.watchLater(action: .remove, source: .button, urn: nil).send()
+        })
     }
     
     func clearWebCache() {


### PR DESCRIPTION
Missing completion block in #276.

### Description

Fix this code feedback. Use completion block.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
