### PR TITLE
Fix show header metrics

### DIFF
--- a/Application/Sources/Content/ShowHeaderViewModel.swift
+++ b/Application/Sources/Content/ShowHeaderViewModel.swift
@@ -112,7 +112,7 @@ final class ShowHeaderViewModel: ObservableObject {
         guard let show else { return }
         FavoritesToggleShow(show)
         
-        let action = isFavorite ? .add : .remove as AnalyticsListAction
+        let action = isFavorite ? .remove : .add as AnalyticsListAction
         AnalyticsHiddenEvent.favorite(action: action, source: .button, urn: show.urn).send()
         
 #if os(iOS)
@@ -125,7 +125,7 @@ final class ShowHeaderViewModel: ObservableObject {
         guard let show, FavoritesToggleSubscriptionForShow(show) else { return }
         
         let isSubscribed = (subscriptionStatus == .subscribed)
-        let action = isSubscribed ? .add : .remove as AnalyticsListAction
+        let action = isSubscribed ? .remove : .add as AnalyticsListAction
         AnalyticsHiddenEvent.subscription(action: action, source: .button, urn: show.urn).send()
         
         Banner.showSubscription(!isSubscribed, forItemWithName: show.title)


### PR DESCRIPTION
### Motivation and Context

Sadly, the analytics hidden events refactor #269 reintroduced a metric state issue.

### Description

Favorite add/remove and subscription add/remove are inverted.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
