### PR TITLE
Move availability badge for horizontal cell layout

### DIFF
--- a/Application/Sources/Model/Mock.swift
+++ b/Application/Sources/Model/Mock.swift
@@ -124,6 +124,11 @@ enum Mock {
         return mockObject(kind.rawValue, type: SRGMedia.self)
     }
     
+    static func download(_ kind: Media = .standard) -> Download? {
+        let media = mockObject(kind.rawValue, type: SRGMedia.self)
+        return Download.add(for: media)
+    }
+    
 #if os(iOS)
     enum Notification: String {
         case standard

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -72,7 +72,7 @@ struct DownloadCell: View {
             .redactable()
             .layoutPriority(1)
             
-            DescriptionView(model: model)
+            DescriptionView(model: model, embeddedDirection: direction)
                 .selectionAppearance(.transluscent, when: hasSelectionAppearance, while: isEditing)
                 .padding(.horizontal, horizontalPadding)
                 .padding(.top, verticalPadding)
@@ -90,12 +90,17 @@ struct DownloadCell: View {
     private struct DescriptionView: View {
         @ObservedObject var model: DownloadCellViewModel
         
+        let embeddedDirection: StackDirection
+        
         private var title: String {
             return model.title ?? .placeholder(length: 10)
         }
         
         var body: some View {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 1) {
+                if embeddedDirection == .horizontal, let properties = model.availabilityBadgeProperties {
+                    Badge(text: properties.text, color: Color(properties.color))
+                }
                 Text(title)
                     .srgFont(.H4)
                     .lineLimit(2)

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -103,7 +103,7 @@ struct DownloadCell: View {
                 }
                 Text(title)
                     .srgFont(.H4)
-                    .lineLimit(2)
+                    .lineLimit(embeddedDirection == .horizontal ? 3 : 2)
                 HStack {
                     Icon(model: model)
                     if let subtitle = model.subtitle {

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -59,7 +59,7 @@ struct DownloadCell: View {
         Stack(direction: direction, spacing: 0) {
             Group {
                 if let media = download?.media {
-                    MediaVisualView(media: media, size: .small)
+                    MediaVisualView(media: media, size: .small, embeddedDirection: direction)
                 }
                 else {
                     ImageView(source: imageUrl)

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -97,9 +97,10 @@ struct DownloadCell: View {
         }
         
         var body: some View {
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 0) {
                 if embeddedDirection == .horizontal, let properties = model.availabilityBadgeProperties {
                     Badge(text: properties.text, color: Color(properties.color))
+                        .padding(.bottom, 4)
                 }
                 Text(title)
                     .srgFont(.H4)

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -195,3 +195,30 @@ enum DownloadCellSize {
         return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(84))
     }
 }
+
+// MARK: Preview
+
+struct DownloadCell_Previews: PreviewProvider {
+    private static let verticalLayoutSize = DownloadCellSize.grid(layoutWidth: 1024, spacing: 16).previewSize
+    private static let horizontalLayoutSize = DownloadCellSize.fullWidth().previewSize
+    
+    static var previews: some View {
+        Group {
+            DownloadCell(download: Mock.download(), layout: .vertical)
+            DownloadCell(download: Mock.download(.noShow), layout: .vertical)
+            DownloadCell(download: Mock.download(.rich), layout: .vertical)
+            DownloadCell(download: Mock.download(.overflow), layout: .vertical)
+            DownloadCell(download: Mock.download(.nineSixteen), layout: .vertical)
+        }
+        .previewLayout(.fixed(width: verticalLayoutSize.width, height: verticalLayoutSize.height))
+        
+        Group {
+            DownloadCell(download: Mock.download(), layout: .horizontal)
+            DownloadCell(download: Mock.download(.noShow), layout: .horizontal)
+            DownloadCell(download: Mock.download(.rich), layout: .horizontal)
+            DownloadCell(download: Mock.download(.overflow), layout: .horizontal)
+            DownloadCell(download: Mock.download(.nineSixteen), layout: .horizontal)
+        }
+        .previewLayout(.fixed(width: horizontalLayoutSize.width, height: horizontalLayoutSize.height))
+    }
+}

--- a/Application/Sources/UI/Views/DownloadCellViewModel.swift
+++ b/Application/Sources/UI/Views/DownloadCellViewModel.swift
@@ -12,6 +12,11 @@ final class DownloadCellViewModel: ObservableObject {
     @Published var download: Download?
     @Published private(set) var state: State = .unknown
     
+    var availabilityBadgeProperties: MediaDescription.BadgeProperties? {
+        guard let media = download?.media else { return nil }
+        return MediaDescription.availabilityBadgeProperties(for: media)
+    }
+    
     var title: String? {
         return download?.title
     }

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -71,13 +71,13 @@ struct MediaCell: View {
             }
 #else
             Stack(direction: direction, spacing: 0) {
-                MediaVisualView(media: media, size: .small)
+                MediaVisualView(media: media, size: .small, embeddedDirection: direction)
                     .aspectRatio(MediaCellSize.aspectRatio, contentMode: .fit)
                     .selectionAppearance(when: hasSelectionAppearance, while: isEditing)
                     .cornerRadius(LayoutStandardViewCornerRadius)
                     .redactable()
                     .layoutPriority(1)
-                DescriptionView(media: media, style: style)
+                DescriptionView(media: media, style: style, embeddedDirection: direction)
                     .selectionAppearance(.transluscent, when: hasSelectionAppearance, while: isEditing)
                     .padding(.horizontal, horizontalPadding)
                     .padding(.top, verticalPadding)
@@ -108,6 +108,22 @@ struct MediaCell: View {
     private struct DescriptionView: View {
         let media: SRGMedia?
         let style: MediaDescription.Style
+        let embeddedDirection: StackDirection
+        
+        init(
+            media: SRGMedia?,
+            style: MediaDescription.Style,
+            embeddedDirection: StackDirection = .vertical
+        ) {
+            self.media = media
+            self.style = style
+            self.embeddedDirection = embeddedDirection
+        }
+        
+        private var availabilityBadgeProperties: MediaDescription.BadgeProperties? {
+            guard let media else { return nil }
+            return MediaDescription.availabilityBadgeProperties(for: media)
+        }
         
         private var subtitle: String? {
             guard let media else { return .placeholder(length: 15) }
@@ -120,7 +136,10 @@ struct MediaCell: View {
         }
         
         var body: some View {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 1) {
+                if embeddedDirection == .horizontal, let properties = availabilityBadgeProperties {
+                    Badge(text: properties.text, color: Color(properties.color))
+                }
                 if let subtitle {
                     Text(subtitle)
                         .srgFont(.subtitle1)

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -148,7 +148,7 @@ struct MediaCell: View {
                 }
                 Text(title)
                     .srgFont(.H4)
-                    .lineLimit(2)
+                    .lineLimit(embeddedDirection == .horizontal ? 3 : 2)
                     .foregroundColor(.srgGrayC7)
                     .layoutPriority(1)
             }

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -136,9 +136,10 @@ struct MediaCell: View {
         }
         
         var body: some View {
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 0) {
                 if embeddedDirection == .horizontal, let properties = availabilityBadgeProperties {
                     Badge(text: properties.text, color: Color(properties.color))
+                        .padding(.bottom, 4)
                 }
                 if let subtitle {
                     Text(subtitle)

--- a/Application/Sources/UI/Views/MediaVisualView.swift
+++ b/Application/Sources/UI/Views/MediaVisualView.swift
@@ -18,6 +18,7 @@ struct MediaVisualView<Content: View>: View {
     
     let size: SRGImageSize
     let contentMode: ImageView.ContentMode
+    let embeddedDirection: StackDirection
     
     @Binding private var content: (SRGMedia?) -> Content
     
@@ -27,11 +28,13 @@ struct MediaVisualView<Content: View>: View {
         media: SRGMedia?,
         size: SRGImageSize,
         contentMode: ImageView.ContentMode = .aspectFit,
+        embeddedDirection: StackDirection = .vertical,
         @ViewBuilder content: @escaping (SRGMedia?) -> Content
     ) {
         _media = .constant(media)
         self.size = size
         self.contentMode = contentMode
+        self.embeddedDirection = embeddedDirection
         _content = .constant(content)
     }
     
@@ -41,7 +44,7 @@ struct MediaVisualView<Content: View>: View {
             content(media)
             BlockingOverlay(media: media)
             
-            if let properties = model.availabilityBadgeProperties {
+            if embeddedDirection == .vertical, let properties = model.availabilityBadgeProperties {
                 Badge(text: properties.text, color: Color(properties.color))
                     .padding([.top, .leading], padding)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -114,8 +117,8 @@ struct MediaVisualView<Content: View>: View {
 // MARK: Extensions
 
 extension MediaVisualView where Content == EmptyView {
-    init(media: SRGMedia?, size: SRGImageSize, contentMode: ImageView.ContentMode = .aspectFit) {
-        self.init(media: media, size: size, contentMode: contentMode) { _ in
+    init(media: SRGMedia?, size: SRGImageSize, contentMode: ImageView.ContentMode = .aspectFit, embeddedDirection: StackDirection = .vertical) {
+        self.init(media: media, size: size, contentMode: contentMode, embeddedDirection: embeddedDirection) { _ in
             EmptyView()
         }
     }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_blocked.dataset/media-blocked.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_blocked.dataset/media-blocked.json
@@ -53,5 +53,6 @@
       } ]
    },
    "presentation" : "DEFAULT",
-   "aspectRatio" : "16:9"
+   "aspectRatio" : "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_fourFive.dataset/SRGMedia_fourFive.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_fourFive.dataset/SRGMedia_fourFive.json
@@ -38,5 +38,6 @@
       "language" : "Français",
       "source" : "HLS"
    } ],
-   "aspectRatio" : "4:5"
+   "aspectRatio" : "4:5",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_fourThree.dataset/SRGMedia_fourThree.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_fourThree.dataset/SRGMedia_fourThree.json
@@ -56,5 +56,6 @@
       "language" : "Français",
       "source" : "HLS"
    } ],
-   "aspectRatio" : "4:3"
+   "aspectRatio" : "4:3",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_minimal.dataset/SRGMedia_standard.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_minimal.dataset/SRGMedia_standard.json
@@ -39,5 +39,6 @@
     "transmission": "TV"
   },
   "presentation": "DEFAULT",
-  "aspectRatio": "16:9"
+  "aspectRatio": "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_nineSixteen.dataset/SRGMedia_nineSixteen.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_nineSixteen.dataset/SRGMedia_nineSixteen.json
@@ -39,5 +39,6 @@
       "language" : "Français",
       "source" : "HLS"
    } ],
-   "aspectRatio" : "9:16"
+   "aspectRatio" : "9:16",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_noShow.dataset/SRGMedia_noShow.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_noShow.dataset/SRGMedia_noShow.json
@@ -22,5 +22,6 @@
     "transmission": "TV"
   },
   "presentation": "DEFAULT",
-  "aspectRatio": "16:9"
+  "aspectRatio": "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_overflow.dataset/media-rts-tv.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_overflow.dataset/media-rts-tv.json
@@ -39,5 +39,6 @@
     "transmission": "TV"
   },
   "presentation": "DEFAULT",
-  "aspectRatio": "16:9"
+  "aspectRatio": "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_rich.dataset/SRGMedia_rich.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_rich.dataset/SRGMedia_rich.json
@@ -61,5 +61,6 @@
       "source" : "HLS",
       "type" : "AUDIO_DESCRIPTION"
    } ],
-   "aspectRatio" : "16:9"
+   "aspectRatio" : "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_square.dataset/SRGMedia_square.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_square.dataset/SRGMedia_square.json
@@ -38,5 +38,6 @@
       "language" : "Français",
       "source" : "HLS"
    } ],
-   "aspectRatio" : "1:1"
+   "aspectRatio" : "1:1",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }

--- a/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_standard.dataset/SRGMedia_standard.json
+++ b/Preview Content/Preview Assets.xcassets/Medias/SRGMedia_standard.dataset/SRGMedia_standard.json
@@ -47,5 +47,6 @@
       "source": "HLS"
     }
   ],
-  "aspectRatio" : "16:9"
+  "aspectRatio" : "16:9",
+  "podcastSdUrl": "https://www.srgssr.ch/typo3conf/ext/is_design/Resources/Public/imgs/logo.svg"
 }


### PR DESCRIPTION
### Motivation and Context

When media list is displayed verticality, the cell layout is horizontal, with a small image height than in grid or swimlane.
UX tests reported some readying difficulty with availability badge is display above the image in this case.

Availability badge should me on right side, with description texts.

### Description

- Move Availability badge (and livestream badge) for horizontal cell layout from image to right description texts.
- As VisualMediaView is used also for download cell, update both.
- Allow to display 3 lines for titles with horizontal cell layout.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
