### PR TITLE
Truncatable text view fixes with various font sizes

### DIFF
--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -6,6 +6,7 @@
 
 import Combine
 import Foundation
+import SRGAppearanceSwift
 import SRGDataProviderCombine
 import SwiftUI
 
@@ -91,13 +92,15 @@ extension String {
         return prefix(1).capitalized + dropFirst()
     }
     
-    func heightOfString(usingFont font: UIFont) -> CGFloat {
+    func heightOfString(usingFontStyle fontStyle: SRGFont.Style) -> CGFloat {
+        let font = SRGFont.font(fontStyle) as UIFont
         let fontAttributes = [NSAttributedString.Key.font: font]
         let size = self.size(withAttributes: fontAttributes)
         return size.height
     }
     
-    func widthOfString(usingFont font: UIFont) -> CGFloat {
+    func widthOfString(usingFontStyle fontStyle: SRGFont.Style) -> CGFloat {
+        let font = SRGFont.font(fontStyle) as UIFont
         let fontAttributes = [NSAttributedString.Key.font: font]
         let size = self.size(withAttributes: fontAttributes)
         return size.width

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -79,8 +79,10 @@ struct TruncatableTextView: View {
                 ZStack(alignment: .bottomTrailing) {
                     text(lineLimit: lineLimit)
                         .readSize { size in
-                            truncatedSize = size
-                            isTruncated = truncatedSize != intrinsicSize
+                            if size != .zero {
+                                truncatedSize = size
+                                isTruncated = truncatedSize != intrinsicSize
+                            }
                         }
                         .mask(
                             VStack(spacing: 0) {
@@ -103,8 +105,10 @@ struct TruncatableTextView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .hidden()
                         .readSize { size in
-                            intrinsicSize = size
-                            isTruncated = truncatedSize != intrinsicSize
+                            if size != .zero {
+                                intrinsicSize = size
+                                isTruncated = truncatedSize != intrinsicSize
+                            }
                         }
                 )
                 Spacer(minLength: 0)

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -120,6 +120,9 @@ struct TruncatableTextView: View {
             let fontStyle: SRGFont.Style
             let showMoreButtonString: String
             
+            // Content size changes are tracked to update mask.
+            @Environment(\.sizeCategory) private var sizeCategory
+            
             var body: some View {
                 HStack(alignment: .bottom, spacing: 0) {
                     Rectangle()
@@ -133,44 +136,13 @@ struct TruncatableTextView: View {
                         startPoint: .leading,
                         endPoint: .trailing
                     )
-                    .frame(width: 32, height: showMoreButtonString.heightOfString(usingFont: fontToUIFont(font: SRGFont.font(fontStyle))))
+                    .frame(width: 32, height: showMoreButtonString.heightOfString(usingFontStyle: fontStyle))
                     
                     Rectangle()
                         .foregroundColor(.clear)
-                        .frame(width: showMoreButtonString.widthOfString(usingFont: fontToUIFont(font: SRGFont.font(fontStyle))), alignment: .center)
+                        .frame(width: showMoreButtonString.widthOfString(usingFontStyle: fontStyle), alignment: .center)
                 }
-                .frame(height: showMoreButtonString.heightOfString(usingFont: fontToUIFont(font: SRGFont.font(fontStyle))))
-            }
-            
-            private func fontToUIFont(font: Font) -> UIFont {
-                switch font {
-#if os(iOS)
-                case .largeTitle:
-                    return UIFont.preferredFont(forTextStyle: .largeTitle)
-#endif
-                case .title:
-                    return UIFont.preferredFont(forTextStyle: .title1)
-                case .title2:
-                    return UIFont.preferredFont(forTextStyle: .title2)
-                case .title3:
-                    return UIFont.preferredFont(forTextStyle: .title3)
-                case .headline:
-                    return UIFont.preferredFont(forTextStyle: .headline)
-                case .subheadline:
-                    return UIFont.preferredFont(forTextStyle: .subheadline)
-                case .callout:
-                    return UIFont.preferredFont(forTextStyle: .callout)
-                case .caption:
-                    return UIFont.preferredFont(forTextStyle: .caption1)
-                case .caption2:
-                    return UIFont.preferredFont(forTextStyle: .caption2)
-                case .footnote:
-                    return UIFont.preferredFont(forTextStyle: .footnote)
-                case .body:
-                    return UIFont.preferredFont(forTextStyle: .body)
-                default:
-                    return UIFont.preferredFont(forTextStyle: .body)
-                }
+                .frame(height: showMoreButtonString.heightOfString(usingFontStyle: fontStyle))
             }
         }
     }

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -136,7 +136,7 @@ struct TruncatableTextView: View {
                         startPoint: .leading,
                         endPoint: .trailing
                     )
-                    .frame(width: 32, height: showMoreButtonString.heightOfString(usingFontStyle: fontStyle))
+                    .frame(width: constant(iOS: 32, tvOS: 60), height: showMoreButtonString.heightOfString(usingFontStyle: fontStyle))
                     
                     Rectangle()
                         .foregroundColor(.clear)


### PR DESCRIPTION
### Motivation and Context

#279 introduced a new truncatable text view.
The beta tests found an issue when increasing or decreasing the font size from the accessibility setting:
- No more "more" white label with bigger fonts (up to 135%)
- Opening with 135% the show page, then reducing the font, the dark mask stays with the same height. 

### Description

This PR fixes:
- the dynamics font size resizing, dark mask and "more" button is displayed, no matter the font size.
- the gradient width on tvOS: body font size is 30pts on tvOS, 16pts on iOS. So the gradient width is higher on tvOS.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [ ] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [ ] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.
