### PR TITLE
Better show description content

### DIFF
--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -28,5 +28,6 @@
   "endTolerance": 10,
   "endToleranceRatio": 0.01,
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
-  "searchSettingSubtitledHidden": true
+  "searchSettingSubtitledHidden": true,
+  "prefersShowLeadInsteadOfDescription": true
 }

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -91,6 +91,8 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, readonly, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
+@property (nonatomic, readonly, getter=isShowLeadPreferred) BOOL showLeadPreferred;
+
 - (nullable RadioChannel *)radioChannelForUid:(nullable NSString *)uid;
 - (nullable RadioChannel *)radioHomepageChannelForUid:(nullable NSString *)uid;         // only returns a result if the radio channel exists and has a corresponding homepage
 - (nullable TVChannel *)tvChannelForUid:(nullable NSString *)uid;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -155,6 +155,8 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
+@property (nonatomic, getter=isShowLeadPreferred) BOOL showLeadPreferred;
+
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 @property (nonatomic) NSURL *overridePlayURL;
 #endif
@@ -406,6 +408,8 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.searchSettingsHidden = [firebaseConfiguration boolForKey:@"searchSettingsHidden"];
     self.searchSettingSubtitledHidden = [firebaseConfiguration boolForKey:@"searchSettingSubtitledHidden"];
     self.showsSearchHidden = [firebaseConfiguration boolForKey:@"showsSearchHidden"];
+    
+    self.showLeadPreferred = [firebaseConfiguration boolForKey:@"showLeadPreferred"];
     
     [NSNotificationCenter.defaultCenter postNotificationName:ApplicationConfigurationDidChangeNotification
                                                       object:self];

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -189,13 +189,13 @@ struct ShowHeaderView: View {
                 }
                 .frame(height: constant(iOS: 40, tvOS: 70))
                 .alert(isPresented: $model.isFavoriteRemovalAlertDisplayed, content: favoriteRemovalAlert)
-                if let lead = model.lead {
+                if let summary = model.show?.play_summary {
 #if os(iOS)
-                    LeadView(lead)
+                    SummaryView(summary)
                     // See above
                         .fixedSize(horizontal: false, vertical: true)
 #else
-                    LeadView(lead)
+                    SummaryView(summary)
                     // See above
                         .fixedSize(horizontal: false, vertical: true)
 #endif
@@ -234,7 +234,7 @@ struct ShowHeaderView: View {
 #endif
         
         /// Behavior: h-exp, v-hug
-        private struct LeadView: View {
+        private struct SummaryView: View {
             let content: String
             
             @FirstResponder private var firstResponder

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -190,15 +190,9 @@ struct ShowHeaderView: View {
                 .frame(height: constant(iOS: 40, tvOS: 70))
                 .alert(isPresented: $model.isFavoriteRemovalAlertDisplayed, content: favoriteRemovalAlert)
                 if let summary = model.show?.play_summary {
-#if os(iOS)
                     SummaryView(summary)
                     // See above
                         .fixedSize(horizontal: false, vertical: true)
-#else
-                    SummaryView(summary)
-                    // See above
-                        .fixedSize(horizontal: false, vertical: true)
-#endif
                 }
                 if let broadcastInformation = model.broadcastInformation {
                     Badge(text: broadcastInformation, color: Color(.srgGray96), textColor: Color(.srgGray16))

--- a/Application/Sources/Content/ShowHeaderViewModel.swift
+++ b/Application/Sources/Content/ShowHeaderViewModel.swift
@@ -52,7 +52,7 @@ final class ShowHeaderViewModel: ObservableObject {
     }
     
     var lead: String? {
-        return show?.leadOrSummary
+        return show?.play_summary
     }
     
     var broadcastInformation: String? {

--- a/Application/Sources/Content/ShowHeaderViewModel.swift
+++ b/Application/Sources/Content/ShowHeaderViewModel.swift
@@ -51,7 +51,7 @@ final class ShowHeaderViewModel: ObservableObject {
         return show?.title
     }
     
-    var lead: String? {
+    var summary: String? {
         return show?.play_summary
     }
     

--- a/Application/Sources/Helpers/SRGShow.swift
+++ b/Application/Sources/Helpers/SRGShow.swift
@@ -7,7 +7,15 @@
 import SRGDataProvider
 
 extension SRGShow {
-    var leadOrSummary: String? {
+    var play_summary: String? {
+        return ApplicationConfiguration.shared.isShowLeadPreferred ? leadOrSummary : summaryOrLead
+    }
+    
+    private var leadOrSummary: String? {
         return lead?.isEmpty ?? true ? summary : lead
+    }
+    
+    private var summaryOrLead: String? {
+        return summary?.isEmpty ?? true ? lead : summary
     }
 }

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -89,7 +89,7 @@ struct FeaturedShowContent: FeaturedContent {
     }
     
     var summary: String? {
-        return show?.leadOrSummary
+        return show?.play_summary
     }
     
     var accessibilityLabel: String? {

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -68,6 +68,7 @@ The keys common to both TV and radio channels JSON dictionaries are:
 The radio channel JSON dictionaries have one more key:
 
 * `homepageHidden` (optional, boolean): Set to `true` iff a homepage does not have to be displayed for the radio channel. If omitted, `false`.
+* `showLeadPreferred` (optional, boolean): Set to `true` iff show pages and show elements should display lead instead of description. If omitted, `false`.
 
 ## Audio homepage
 


### PR DESCRIPTION
### Motivation and Context

After #279, the show header view has now a turntable text view with a "more" action.

Play RSI has only show descriptions, Play SRF has short show leads and longer show descriptions.
Proposition is to display show description now, like Play web does.  

### Description

- A remote configuration added to prefer show leads. By default, it's prefer show descriptions.
- Applied this summary preference in show pages (displayed in the show header view).
- Applied this summary preference in the show element view.
- Renamed `LeadView` to `SummaryView` and fix unnecessary platform target.

Keep show lead only for Play RTS for now, like Play web.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
