### PR TITLE
Use truncatable text view on tvOS media detail view

### DIFF
--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -22,6 +22,9 @@ struct TruncatableTextView: View {
     
     let showMore: () -> Void
     
+    var foregroundColor: Color = .srgGray96
+    var secondaryColor: Color = .white
+    
     @State private var isTruncated = false
     @State private var isFocused = false
     
@@ -37,11 +40,25 @@ struct TruncatableTextView: View {
         self.showMore = showMore
     }
     
+    func foregroundColor(_ color: Color) -> Self {
+        var truncatableTextView = self
+        
+        truncatableTextView.foregroundColor = color
+        return truncatableTextView
+    }
+    
+    func secondaryColor(_ color: Color) -> Self {
+        var truncatableTextView = self
+        
+        truncatableTextView.secondaryColor = color
+        return truncatableTextView
+    }
+    
     var body: some View {
         Button {
             showMore()
         } label: {
-            MainView(content: content, lineLimit: lineLimit, isTruncated: $isTruncated) {
+            MainView(content: content, lineLimit: lineLimit, foregroundColor: foregroundColor, secondaryColor: secondaryColor, isTruncated: $isTruncated) {
                 showMore()
             }
             .onParentFocusChange { isFocused = $0 }
@@ -56,6 +73,8 @@ struct TruncatableTextView: View {
     fileprivate struct MainView: View {
         let content: String
         let lineLimit: Int?
+        let foregroundColor: Color
+        let secondaryColor: Color
         @Binding private(set) var isTruncated: Bool
         
         let showMore: () -> Void
@@ -70,7 +89,7 @@ struct TruncatableTextView: View {
             return Text(content)
                 .srgFont(fontStyle)
                 .lineLimit(lineLimit)
-                .foregroundColor(.srgGray96)
+                .foregroundColor(foregroundColor)
                 .multilineTextAlignment(.leading)
         }
         
@@ -97,7 +116,7 @@ struct TruncatableTextView: View {
                     if isTruncated {
                         Text(showMoreButtonString)
                             .srgFont(fontStyle)
-                            .foregroundColor(.white)
+                            .foregroundColor(secondaryColor)
                     }
                 }
                 .background(
@@ -155,6 +174,9 @@ struct TruncableTextView_Previews: PreviewProvider {
         Group {
             TruncatableTextView(content: "Short description.", lineLimit: 3) {}
             TruncatableTextView(content: String.loremIpsum, lineLimit: 3) {}
+            TruncatableTextView(content: String.loremIpsum, lineLimit: 3) {}
+                .foregroundColor(.white)
+                .secondaryColor(.srgGray96)
         }
         .frame(width: 375)
         .previewLayout(.sizeThatFits)

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -154,24 +154,14 @@ struct MediaDetailView: View {
     
     private struct SummaryView: View {
         @ObservedObject var model: MediaDetailViewModel
-        @State var isFocused = false
         
         var body: some View {
-            GeometryReader { geometry in
-                VStack(alignment: .leading, spacing: 0) {
-                    if let summary = model.media?.play_fullSummary {
-                        Button {
-                            navigateToText(summary)
-                        } label: {
-                            Text(summary)
-                                .foregroundColor(.white)
-                                .srgFont(.body)
-                                .frame(width: geometry.size.width, alignment: .leading)
-                                .padding(.vertical, 5)
-                                .onParentFocusChange { isFocused = $0 }
-                        }
-                        .buttonStyle(TextButtonStyle(focused: isFocused))
+            VStack(alignment: .leading, spacing: 0) {
+                if let summary = model.media?.play_fullSummary {
+                    TruncatableTextView(content: summary, lineLimit: 3) {
+                        navigateToText(summary)
                     }
+                    .foregroundColor(.white)
                 }
             }
         }


### PR DESCRIPTION
### Motivation and Context

Use same Text view component on SwiftUI view.
tvOS media detail view has a media summary view. 

### Description

- Replace the `Text` view with `TruncatableTextView`.
- Adapt with white foreground color.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
