### PR TITLE
CI: Do the git flow release finish with fastlane

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -27,9 +27,7 @@
 | Release to the store ||||||
 | [iOS] Update Github pages to display hidden releases (with fastlane\*) ||||||
 | [iOS] Check what's new information with production applications ||||||
-| Finish git-flow release ||||||
-| Bump patch / build version numbers in project ||||||
-| Push master, develop and tag ||||||
+| Finish git-flow release, tags, Bump patch / build version numbers and push (with fastlane\*) ||||||
 | Close milestone and issues on github ||||||
 | Create github release ||||||
 | Update status page on Confluence (Release date, old versions section) ||||||
@@ -53,6 +51,8 @@
 	- **Play SRG tvOS AppStore releases** (with `true` to `submit_for_review` parameter):  `fastlane ios tvOSPrepareAppStoreReleases submit_for_review:true`
 - Publish release notes on Github pages with correct released status (AppStore and TestFlight release notes)
  	- **Play SRG Publish release notes**: `fastlane ios publishReleaseNotes`
+- After AppStore validation, finish git-flow release, bump build version numbers, push master, develop and tag.
+ 	- **Play SRG After AppStore validation GitFlow**: `fastlane ios afterAppStoreValidationGitFlow`
 
 ### \*\*Manual fastlane:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -361,6 +361,31 @@ platform :ios do
     UI.success 'Play release notes pushed on Github pages. ✅'
   end
 
+  # After AppStore validation git flow (similar to 'git flow release finish')
+
+  desc 'After AppStore validation git flow: merges to master, tags released platforms, merges first tag to develop. Bumps marketing version and build number and pushes.'
+  lane :afterAppStoreValidationGitFlow do
+    branch_name = git_branch_name
+    unless branch_name.include? 'release/'
+      UI.user_error! 'After AppStore validation git flow must runs on \'release/*\' branch.'
+    end
+
+    # Tag only platfoms which not have already a tag and have a what's new for beta.
+    git_pull(only_tags: true)
+    platforms = ['iOS', 'tvOS'].reject do |platform|
+      tag = srg_tag(platform)
+      tag_version = tag_version(platform)
+      git_tag_exists(tag:) || what_s_new_for_beta(platform, tag_version).empty?
+    end
+    unless platforms.count.positive?
+      UI.user_error! 'Tags already exist or what\'s new for tags don\'t exist.'
+    end
+
+    UI.message "Start git flow release with Play #{platforms} platforms."
+    gitflow_release_platforms(platforms, branch_name)
+    UI.success "Git flow release with Play #{platforms} platforms succeeded. ✅"
+  end
+
   # Individual iOS screenshots
 
   desc 'RSI: Makes iOS screenshots and replaces current ones on App Store Connect.'
@@ -1397,6 +1422,16 @@ def xcode_marketing_version(platform)
   )
 end
 
+# Override marketing version for a platform (current project version)
+def xcode_override_marketing_version(platform, marketing_version)
+  update_xcconfig_value(
+    path: srg_xcconfig_path(platform),
+    name: 'MARKETING_VERSION',
+    value: marketing_version
+  )
+  marketing_version
+end
+
 # Returns the build number for a platform
 def xcode_build_number(platform)
   get_xcconfig_value(
@@ -1772,7 +1807,8 @@ def srg_add_tag_and_bump_build_number(platform, tag)
 end
 
 def bump_build_number_commit(platform)
-  build_number = xcode_override_build_number(platform, xcode_build_number(platform).to_i + 1)
+  build_number = bump_build_number(xcode_build_number(platform))
+  build_number = xcode_override_build_number(platform, build_number)
   commit_version_bump(
     xcodeproj: 'PlaySRG.xcodeproj',
     message: "Bump #{platform} build number to #{build_number}",
@@ -1792,6 +1828,65 @@ def beta_app_review_info
     contact_last_name: ENV.fetch('ITUNES_CONNECT_REVIEW_LAST_NAME', nil),
     contact_phone: ENV.fetch('ITUNES_CONNECT_REVIEW_PHONE', nil)
   }
+end
+
+# Gitflow release platforms: Merge to master, tag platforms, merge one tag to develop, bump
+# marketing version and build number and push to the repository, only if we are not on the
+# master branch and at least, one platform has to be released.
+def gitflow_release_platforms(platforms, branch_name)
+  return if branch_name.include? 'master'
+  return unless platforms.count.positive?
+
+  tags = platforms.map { |platform| srg_tag(platform) }
+  tag_versions = platforms.map { |platform| tag_version(platform) }
+
+  gitflow_release(tags, branch_name)
+  platforms.each_index do |index|
+    bump_marketing_version_and_build_number_commit(platforms[index], tag_versions[index])
+  end
+
+  push_to_git_remote(local_branch: 'master', remote_branch: 'master')
+  push_to_git_remote(local_branch: 'develop', remote_branch: 'develop')
+end
+
+def gitflow_release(tags, branch_name)
+  Dir.chdir('..') do
+    sh 'git checkout master'
+    sh 'git pull --rebase'
+    sh "git merge --no-ff #{branch_name}"
+  end
+  tags.each do |tag|
+    add_git_tag(tag:, sign: true)
+    UI.message "Tag \"#{tag}\" created. ✅"
+  end
+  Dir.chdir('..') do
+    sh 'git checkout develop'
+    sh 'git pull --rebase'
+    sh "git merge --no-ff #{tags[0]}"
+  end
+end
+
+def bump_marketing_version_and_build_number_commit(platform, tag_version)
+  build_number = bump_build_number(build_number_from_tag_version(tag_version))
+  build_number = xcode_override_build_number(platform, build_number)
+  marketing_version = bump_marketing_version(marketing_version_from_tag_version(tag_version))
+  marketing_version = xcode_override_marketing_version(platform, marketing_version)
+  commit_version_bump(
+    xcodeproj: 'PlaySRG.xcodeproj',
+    message: "Bump #{platform} version to #{marketing_version}-#{build_number}",
+    include: srg_xcconfig_path(platform),
+    ignore: /.+/
+  )
+end
+
+def bump_build_number(build_number)
+  build_number.to_i + 1
+end
+
+def bump_marketing_version(marketing_version)
+  major, minor, patch = marketing_version.split('.').map(&:to_i)
+  patch += 1
+  [major, minor, patch].join('.')
 end
 
 def snapshot_devices(platform)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -175,6 +175,14 @@ Get AppStore App status for iOS and tvOS
 
 Publish release notes for iOS and tvOS on Github pages
 
+### ios afterAppStoreValidationGitFlow
+
+```sh
+[bundle exec] fastlane ios afterAppStoreValidationGitFlow
+```
+
+After AppStore validation git flow: merges to master, tags released platforms, merges first tag to develop. Bumps marketing version and build number and pushes.
+
 ### ios iOSrsiScreenshots
 
 ```sh


### PR DESCRIPTION
### Motivation and Context

Beta tags are done by the CI, not AppStore release tags.
The goal is to run a fastlane on the CI to finish the git flow release started.

### Description

`afterAppStoreValidationGitFlow` lane:
- run on a `release/*` branch only.
- Find tags for iOS and/or tvOS platforms.
- Merge to `master` branch, apply tags.
- Merge first tag to `develop`branch.
- Bump marketing version and build number.
- Push `master`,  `develop` and tags to the origin.

### How to test locally

Comment the 2 `push_to_git_remote` lines, to avoid last step.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
