### PR TITLE
Update unplayable downloaded videos

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -132,7 +132,7 @@ static void *s_kvoContext = &s_kvoContext;
     PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
         [Download updateUnplayableDownloads];
         completionHandler(YES);
-    }, @"updateUnplayableDownloads");
+    }, @"updateUnplayableDownloads2");
     
     [self checkForForcedUpdates];
     

--- a/Application/Sources/Model/Download.m
+++ b/Application/Sources/Model/Download.m
@@ -539,7 +539,7 @@ static NSArray<Download *> *s_sortedDownloads;
     NSString *extension = types.lastObject ?: @"mov";
     
     // Try to fix the default arbitrary binary data response with the url file extension
-    if ([type.lowercaseString isEqualToString:@"application"] && [extension.lowercaseString isEqualToString:@"octet-stream"]) {
+    if ([extension.lowercaseString isEqualToString:@"octet-stream"]) {
         if (self.downloadMediaURL.pathExtension != nil) {
             extension = self.downloadMediaURL.pathExtension;
         }


### PR DESCRIPTION
### Motivation and Context

Resolves #291.

### Description

- For files already downloaded, the migration code run once, try to rename the file with the download url extension, if any. Otherwise, it removes the file and the download item.
- For future downloads, it applies the downloaded url extension if any `octet-stream` content type extension returns by servers.

Similar as #230.

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
