### PR TITLE
CI: display what's new for latest version (appStoreAppStatus lane)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -297,11 +297,13 @@ platform :ios do
 
         latest_version = spaceship_app_latest_known_version(platform, app)
         if !latest_version || latest_version.version_string == live_version.version_string
-          UI.message "Play #{business_unit} #{platform} version #{live_version.version_string} (#{live_version.build.version}) is the latest one."
+          UI.success "Play #{business_unit} #{platform} version #{live_version.version_string} (#{live_version.build.version}) is the latest one."
         else
           build_version = latest_version.build ? latest_version.build.version : 'NaN'
           UI.important "Play #{business_unit} #{platform} latest version #{latest_version.version_string} (#{build_version}) is #{latest_version.app_store_state}."
         end
+        version_localization = spaceship_app_version_localization(latest_version)
+        UI.message "What's new (#{version_localization.locale}):\n#{version_localization.whats_new}"
         UI.message '-----'
       end
     end
@@ -1893,6 +1895,10 @@ end
 def spaceship_app_latest_known_version(platform, app)
   includes = Spaceship::ConnectAPI::AppStoreVersion::ESSENTIAL_INCLUDES
   app.get_latest_app_store_version(platform: spaceship_platform(platform), includes:)
+end
+
+def spaceship_app_version_localization(version)
+  Spaceship::ConnectAPI::AppStoreVersionLocalization.all(app_store_version_id: version.id).first
 end
 
 def publish_on_github_pages(output_directory, releases_directory)


### PR DESCRIPTION
### Motivation and Context

During the AppStore process release, check the translated What's new.
According to existing Fastlane lanes running in CI: https://github.com/SRGSSR/playsrg-apple/blob/develop/docs/RELEASE_CHECKLIST.md#fastlane-on-playcity-ci
- `iOSPrepareAppStoreReleases` and `tvOSPrepareAppStoreReleases` lanes adds what's new from Crowdin to AppStore Connect.
- What's new are displayed on the logs, but logs are on the CI.

Idea is to get in a manual lane, like `appStoreAppStatus`.

### Description

Fastlane `appStoreAppStatus` lane displays the upcoming "What's new" after the AppStore Connect state of latest version.

### How to Test
`fastlane iOS appStoreAppStatus`

### Checklist

- [ ] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
