### PR TITLE
Fix show header view layout updates with beta feature

### DIFF
--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -59,6 +59,7 @@ struct ShowHeaderView: View {
         private let compactDescriptionOffet: CGFloat = -12
       
 #if os(iOS)
+        // App storage property changes are tracked to update layout. Only application setting function is used to take care of the app build distribution.
         @AppStorage(PlaySRGSettingMediaListLayoutEnabled) var isMediaListLayoutEnabled = false
 #endif
         
@@ -69,7 +70,7 @@ struct ShowHeaderView: View {
         
         private var descriptionHorizontalPadding: CGFloat {
 #if os(iOS)
-            if isMediaListLayoutEnabled && horizontalSizeClass == .regular {
+            if ApplicationSettingMediaListLayoutEnabled() && horizontalSizeClass == .regular {
                 return 32
             }
             else {


### PR DESCRIPTION
### Motivation and Context

#279 introduces a beta feature.
If user tries with TestFlight distribution, but then go back to AppStore distribution, the layout must go back to production one.
Show header leading description padding keeps the user default settings, even if AppStore distribution is reinstalled.

### Description

- Fix the AppStore distribution with keeping the original leading description padding: use the Application setting function instead of user default (AppStorage) value.

### Checklist

- [x] The branch has been rebased onto the `develop` branch.
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.
