### PR TITLE
Pronunciation of "more" for accessibility in show page

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Accessibility.strings
@@ -30,6 +30,7 @@
 "Audio described" = "Audiodescrizione";
 
 /* Close button label
+   Close button label on handle view
    Close button label on player view */
 "Close" = "Chiudere";
 
@@ -102,7 +103,8 @@
 /* Accessibility hint associated with the account header */
 "Manages account information" = "Gestire le informazioni sull'account";
 
-/* More button label */
+/* More button label
+   More label on truncatable text view */
 "More" = "Altro";
 
 /* A more episode button label

--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -113,6 +113,10 @@
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Diventare un beta tester";
 
+/* Beta tests alert title
+   Beta tests section header */
+"Beta tests" = "Beta tests";
+
 /* Show by date short button title */
 "By date" = "Per data";
 
@@ -204,6 +208,9 @@
 /* User activity title when displaying a show page */
 "Display %@ episodes" = "Mostra le puntate di %@";
 
+/* Toggle label to enable episodes as a list in show pages setting label */
+"Display episodes as a list in show pages (iPad)" = "Display episodes as a list in show pages (iPad)";
+
 /* Done button title */
 "Done" = "Fine";
 
@@ -216,7 +223,8 @@
 /* Search setting */
 "Duration" = "Durata";
 
-/* Label for the button keeping autoplay enabled */
+/* Label for the button keeping autoplay enabled
+   title of enable button */
 "Enable" = "Attivare";
 
 /* Label of the button to toggle FLEX */
@@ -365,7 +373,7 @@
 /* Message on top screen when trying to open a media in the download list and the media is not downloaded. */
 "Media not available yet" = "Media non disponibile";
 
-/* More button label */
+/* More label on truncatable text view */
 "More" = "Altro";
 
 /* Autoplay setting section footer */
@@ -608,7 +616,8 @@
 /* Label of the button to simulate a memory warning */
 "Simulate memory warning" = "Simulare l'avviso di memoria";
 
-/* Title of the button to skip updating the application */
+/* Title of a Skip button
+   Title of the button to skip updating the application */
 "Skip" = "Salta";
 
 /* Short label identifying content which will be available soon. */
@@ -723,6 +732,9 @@
 /* Related content media list title */
 "This might interest you" = "Potrebbero interessarti";
 
+/* Beta tests section footer */
+"This section is only available for beta testers." = "This section is only available for beta testers.";
+
 /* Advanced features section footer
    Reset section footer */
 "This section is only available in nightly and beta versions, and won't appear in the production version." = "Questa sezione è solo disponibile solo nelle versioni nightly e beta, e non verrà visualizzata nella versione di produzione.";
@@ -823,6 +835,9 @@
 /* Description of the alert view to keep autoplay permanently
    Description of the alert view to opt-in for background video playback */
 "You can manage this feature in the settings at any time." = "È possibile gestire questa funzionalità nelle impostazioni in qualsiasi momento.";
+
+/* Beta tests alert explanation */
+"You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Sei stato scollegato automaticamente. Esegui nuovamente il login per mantenere i dati sincronizzati su tutti i dispositivi.";

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Accessibility.strings
@@ -30,6 +30,7 @@
 "Audio described" = "Audio descrit";
 
 /* Close button label
+   Close button label on handle view
    Close button label on player view */
 "Close" = "Serrar";
 
@@ -102,7 +103,8 @@
 /* Accessibility hint associated with the account header */
 "Manages account information" = "Organisescha las infurmaziuns da l'account";
 
-/* More button label */
+/* More button label
+   More label on truncatable text view */
 "More" = "Dapli";
 
 /* A more episode button label

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -113,6 +113,10 @@
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Daventa in Beta-Tester";
 
+/* Beta tests alert title
+   Beta tests section header */
+"Beta tests" = "Beta tests";
+
 /* Show by date short button title */
 "By date" = "Tenor data";
 
@@ -204,6 +208,9 @@
 /* User activity title when displaying a show page */
 "Display %@ episodes" = "Mussa las episodas %@";
 
+/* Toggle label to enable episodes as a list in show pages setting label */
+"Display episodes as a list in show pages (iPad)" = "Display episodes as a list in show pages (iPad)";
+
 /* Done button title */
 "Done" = "Fatg";
 
@@ -216,7 +223,8 @@
 /* Search setting */
 "Duration" = "Durada";
 
-/* Label for the button keeping autoplay enabled */
+/* Label for the button keeping autoplay enabled
+   title of enable button */
 "Enable" = "Activar";
 
 /* Label of the button to toggle FLEX */
@@ -365,7 +373,7 @@
 /* Message on top screen when trying to open a media in the download list and the media is not downloaded. */
 "Media not available yet" = "Media betg disponibel";
 
-/* More button label */
+/* More label on truncatable text view */
 "More" = "Dapli";
 
 /* Autoplay setting section footer */
@@ -608,7 +616,8 @@
 /* Label of the button to simulate a memory warning */
 "Simulate memory warning" = "Simular in avertiment da memoria";
 
-/* Title of the button to skip updating the application */
+/* Title of a Skip button
+   Title of the button to skip updating the application */
 "Skip" = "Finir";
 
 /* Short label identifying content which will be available soon. */
@@ -723,6 +732,9 @@
 /* Related content media list title */
 "This might interest you" = "Quai pudess interessar Vus";
 
+/* Beta tests section footer */
+"This section is only available for beta testers." = "This section is only available for beta testers.";
+
 /* Advanced features section footer
    Reset section footer */
 "This section is only available in nightly and beta versions, and won't appear in the production version." = "Questa secziun è mo disponibla en la versiun nightly ni beta e na vegn betg en producziun.";
@@ -823,6 +835,9 @@
 /* Description of the alert view to keep autoplay permanently
    Description of the alert view to opt-in for background video playback */
 "You can manage this feature in the settings at any time." = "Vus paudais puspe activar questa funcziun.";
+
+/* Beta tests alert explanation */
+"You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Vus essas vegni deconnectà automaticamain. Per mantegnair la sincronisaziun da las datas sur tut ils apparats far anc ina giada il login.";

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Accessibility.strings
@@ -30,6 +30,7 @@
 "Audio described" = "Audiodécrit";
 
 /* Close button label
+   Close button label on handle view
    Close button label on player view */
 "Close" = "Fermer";
 
@@ -102,7 +103,8 @@
 /* Accessibility hint associated with the account header */
 "Manages account information" = "Gère les informations du compte";
 
-/* More button label */
+/* More button label
+   More label on truncatable text view */
 "More" = "Pluss";
 
 /* A more episode button label

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -113,6 +113,10 @@
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Devenez bêta-testeur";
 
+/* Beta tests alert title
+   Beta tests section header */
+"Beta tests" = "Beta tests";
+
 /* Show by date short button title */
 "By date" = "Par date";
 
@@ -204,6 +208,9 @@
 /* User activity title when displaying a show page */
 "Display %@ episodes" = "Afficher les épisodes pour %@";
 
+/* Toggle label to enable episodes as a list in show pages setting label */
+"Display episodes as a list in show pages (iPad)" = "Display episodes as a list in show pages (iPad)";
+
 /* Done button title */
 "Done" = "OK";
 
@@ -216,7 +223,8 @@
 /* Search setting */
 "Duration" = "Durée";
 
-/* Label for the button keeping autoplay enabled */
+/* Label for the button keeping autoplay enabled
+   title of enable button */
 "Enable" = "Activer";
 
 /* Label of the button to toggle FLEX */
@@ -365,7 +373,7 @@
 /* Message on top screen when trying to open a media in the download list and the media is not downloaded. */
 "Media not available yet" = "Contenu non disponible";
 
-/* More button label */
+/* More label on truncatable text view */
 "More" = "Plus";
 
 /* Autoplay setting section footer */
@@ -608,7 +616,8 @@
 /* Label of the button to simulate a memory warning */
 "Simulate memory warning" = "Simuler une alerte mémoire";
 
-/* Title of the button to skip updating the application */
+/* Title of a Skip button
+   Title of the button to skip updating the application */
 "Skip" = "Ignorer";
 
 /* Short label identifying content which will be available soon. */
@@ -723,6 +732,9 @@
 /* Related content media list title */
 "This might interest you" = "Cela pourrait vous intéresser";
 
+/* Beta tests section footer */
+"This section is only available for beta testers." = "This section is only available for beta testers.";
+
 /* Advanced features section footer
    Reset section footer */
 "This section is only available in nightly and beta versions, and won't appear in the production version." = "Cette section n’est disponible que dans les versions nightly et beta, et n'apparaîtra pas en production.";
@@ -823,6 +835,9 @@
 /* Description of the alert view to keep autoplay permanently
    Description of the alert view to opt-in for background video playback */
 "You can manage this feature in the settings at any time." = "Vous pouvez activer ou désactiver cette fonctionnalité dans les réglages à tout moment.";
+
+/* Beta tests alert explanation */
+"You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Vous avez été automatiquement déconnecté. Connectez-vous à nouveau pour conserver vos données synchronisées entre vos appareils.";

--- a/Application/Resources/Apps/Play SRF/de.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Accessibility.strings
@@ -30,6 +30,7 @@
 "Audio described" = "Audiodeskription";
 
 /* Close button label
+   Close button label on handle view
    Close button label on player view */
 "Close" = "Schliessen";
 
@@ -102,7 +103,8 @@
 /* Accessibility hint associated with the account header */
 "Manages account information" = "Anmeldeinformationen verwalten";
 
-/* More button label */
+/* More button label
+   More label on truncatable text view */
 "More" = "Mehr";
 
 /* A more episode button label

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -113,6 +113,10 @@
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Beta-Tester werden";
 
+/* Beta tests alert title
+   Beta tests section header */
+"Beta tests" = "Beta tests";
+
 /* Show by date short button title */
 "By date" = "Nach Datum";
 
@@ -204,6 +208,9 @@
 /* User activity title when displaying a show page */
 "Display %@ episodes" = "Zeige die Folgen von %@";
 
+/* Toggle label to enable episodes as a list in show pages setting label */
+"Display episodes as a list in show pages (iPad)" = "Display episodes as a list in show pages (iPad)";
+
 /* Done button title */
 "Done" = "Fertig";
 
@@ -216,7 +223,8 @@
 /* Search setting */
 "Duration" = "Dauer";
 
-/* Label for the button keeping autoplay enabled */
+/* Label for the button keeping autoplay enabled
+   title of enable button */
 "Enable" = "Aktivieren";
 
 /* Label of the button to toggle FLEX */
@@ -365,7 +373,7 @@
 /* Message on top screen when trying to open a media in the download list and the media is not downloaded. */
 "Media not available yet" = "Inhalt noch nicht verfügbar";
 
-/* More button label */
+/* More label on truncatable text view */
 "More" = "Mehr";
 
 /* Autoplay setting section footer */
@@ -608,7 +616,8 @@
 /* Label of the button to simulate a memory warning */
 "Simulate memory warning" = "Speicherwarnung simulieren";
 
-/* Title of the button to skip updating the application */
+/* Title of a Skip button
+   Title of the button to skip updating the application */
 "Skip" = "Abbrechen";
 
 /* Short label identifying content which will be available soon. */
@@ -723,6 +732,9 @@
 /* Related content media list title */
 "This might interest you" = "Das könnte Sie auch interessieren";
 
+/* Beta tests section footer */
+"This section is only available for beta testers." = "This section is only available for beta testers.";
+
 /* Advanced features section footer
    Reset section footer */
 "This section is only available in nightly and beta versions, and won't appear in the production version." = "Die erweiterten Funktionen sind nur in Nightlies oder Betas sichtbar.";
@@ -823,6 +835,9 @@
 /* Description of the alert view to keep autoplay permanently
    Description of the alert view to opt-in for background video playback */
 "You can manage this feature in the settings at any time." = "Sie können Autoplay in den Einstellungen wieder anpassen.";
+
+/* Beta tests alert explanation */
+"You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Sie wurden automatisch abgemeldet. Melden Sie sich erneut an, um Ihre Daten zu synchronisieren.";

--- a/Application/Resources/Apps/Play SWI/en.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Accessibility.strings
@@ -30,6 +30,7 @@
 "Audio described" = "Audio described";
 
 /* Close button label
+   Close button label on handle view
    Close button label on player view */
 "Close" = "Close";
 
@@ -102,7 +103,8 @@
 /* Accessibility hint associated with the account header */
 "Manages account information" = "Manages account information";
 
-/* More button label */
+/* More button label
+   More label on truncatable text view */
 "More" = "More";
 
 /* A more episode button label

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -113,6 +113,10 @@
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Become a beta tester";
 
+/* Beta tests alert title
+   Beta tests section header */
+"Beta tests" = "Beta tests";
+
 /* Show by date short button title */
 "By date" = "By date";
 
@@ -204,6 +208,9 @@
 /* User activity title when displaying a show page */
 "Display %@ episodes" = "Display %@ videos";
 
+/* Toggle label to enable episodes as a list in show pages setting label */
+"Display episodes as a list in show pages (iPad)" = "Display episodes as a list in show pages (iPad)";
+
 /* Done button title */
 "Done" = "Done";
 
@@ -216,7 +223,8 @@
 /* Search setting */
 "Duration" = "Duration";
 
-/* Label for the button keeping autoplay enabled */
+/* Label for the button keeping autoplay enabled
+   title of enable button */
 "Enable" = "Enable";
 
 /* Label of the button to toggle FLEX */
@@ -365,7 +373,7 @@
 /* Message on top screen when trying to open a media in the download list and the media is not downloaded. */
 "Media not available yet" = "Media not available yet";
 
-/* More button label */
+/* More label on truncatable text view */
 "More" = "More";
 
 /* Autoplay setting section footer */
@@ -608,7 +616,8 @@
 /* Label of the button to simulate a memory warning */
 "Simulate memory warning" = "Simulate memory warning";
 
-/* Title of the button to skip updating the application */
+/* Title of a Skip button
+   Title of the button to skip updating the application */
 "Skip" = "Skip";
 
 /* Short label identifying content which will be available soon. */
@@ -723,6 +732,9 @@
 /* Related content media list title */
 "This might interest you" = "This might interest you";
 
+/* Beta tests section footer */
+"This section is only available for beta testers." = "This section is only available for beta testers.";
+
 /* Advanced features section footer
    Reset section footer */
 "This section is only available in nightly and beta versions, and won't appear in the production version." = "This section is only available in nightly and beta versions, and won't appear in the production version.";
@@ -823,6 +835,9 @@
 /* Description of the alert view to keep autoplay permanently
    Description of the alert view to opt-in for background video playback */
 "You can manage this feature in the settings at any time." = "You can manage this feature in the settings at any time.";
+
+/* Beta tests alert explanation */
+"You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You can preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "You have been automatically logged out. Login again to keep your data synchronized across devices.";

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -83,7 +83,8 @@ struct TruncatableTextView: View {
         @State private var truncatedSize: CGSize = .zero
         
         private let fontStyle: SRGFont.Style = .body
-        private let showMoreButtonString = NSLocalizedString("More", comment: "More button label")
+        private let showMoreButtonString = NSLocalizedString("More", comment: "More label on truncatable text view")
+        private let showMoreButtonStringAccessibilityLabel = PlaySRGAccessibilityLocalizedString("More", comment: "More label on truncatable text view")
         
         private func text(lineLimit: Int?) -> some View {
             return Text(content)
@@ -117,6 +118,7 @@ struct TruncatableTextView: View {
                         Text(showMoreButtonString)
                             .srgFont(fontStyle)
                             .foregroundColor(secondaryColor)
+                            .accessibilityLabel(showMoreButtonStringAccessibilityLabel)
                     }
                 }
                 .background(


### PR DESCRIPTION
### Motivation and Context

The new #279 Show page header has a "show more" feature" with this label.
With Voice Over, the "more" in French should be pronounced "plus" with the "s".

Found by @svenduvoisin .

### Description

- Fix the prononciation for "more" for French VoiceOver.
- Update translation files (and keep beta test translations in English).

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

* The project uses Github merge queue feature, which rebases onto the `develop` branch before merging the PR. 
