### PR TITLE
CI: xcodebuild archive succeeded on Mac OS Ventura

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -177,7 +177,7 @@ name: srgmediaplayer-apple, nameSpecified: SRGMediaPlayer, owner: SRGSSR, versio
 
 name: srgnetwork-apple, nameSpecified: SRGNetwork, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgnetwork-apple
 
-name: srguserdata-apple, nameSpecified: SRGUserData, owner: SRGSSR, version: 3.3.0, source: https://github.com/SRGSSR/srguserdata-apple
+name: srguserdata-apple, nameSpecified: srguserdata-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srguserdata-apple
 
 name: swift-collections, nameSpecified: swift-collections, owner: apple, version: 1.0.4, source: https://github.com/apple/swift-collections
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -342,7 +342,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srguserdata-apple</string>
 			<key>Title</key>
-			<string>SRGUserData (3.3.0)</string>
+			<string>srguserdata-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19170,8 +19170,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srguserdata-apple.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.3.0;
+				branch = "feature/5-swift-package-manager-mac-os-ventura";
+				kind = branch;
 			};
 		};
 		6F2546392521C34800F9F4FE /* XCRemoteSwiftPackageReference "Aiolos" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19170,7 +19170,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srguserdata-apple.git";
 			requirement = {
-				branch = "feature/5-swift-package-manager-mac-os-ventura";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI TV.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "6F331D1324D06BB800C096AB"
+                     BuildableName = "Play RSI.app"
+                     BlueprintName = "Play RSI TV"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI TV.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "08C68DF61D38D72000BB8AAA"
+                     BuildableName = "Play RSI.app"
+                     BlueprintName = "Play RSI"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RSI.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR TV.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "6F331D2B24D06BC600C096AB"
+                     BuildableName = "Play RTR.app"
+                     BlueprintName = "Play RTR TV"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR TV.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "08C68E2D1D38D73000BB8AAA"
+                     BuildableName = "Play RTR.app"
+                     BlueprintName = "Play RTR"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTR.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS TV.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "6F331CFB24D06BA200C096AB"
+                     BuildableName = "Play RTS.app"
+                     BlueprintName = "Play RTS TV"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS TV.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "08C68DBF1D38D70D00BB8AAA"
+                     BuildableName = "Play RTS.app"
+                     BlueprintName = "Play RTS"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play RTS.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF TV.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "6F331CE324D06B8200C096AB"
+                     BuildableName = "Play SRF.app"
+                     BlueprintName = "Play SRF TV"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF TV.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SRF.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "08C68D881D38D6F400BB8AAA"
+                     BuildableName = "Play SRF.app"
+                     BlueprintName = "Play SRF"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI TV.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI TV.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI TV.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "6F331D4324D06C2600C096AB"
+                     BuildableName = "Play SWI.app"
+                     BlueprintName = "Play SWI TV"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               scriptText = "# Get SRGUserData checkout path.&#10;SRG_USER_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple&quot;&#10;&#10;# Apply SRGUserData script.&#10;sh &quot;$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh&quot; &quot;$SRG_USER_DATA&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI.xcscheme
+++ b/PlaySRG.xcodeproj/xcshareddata/xcschemes/Play SWI.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Get SRGUserData CoreData checkout path.&#10;SRG_USER_DATA_DATA=&quot;${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple/Sources/SRGUserData/Data&quot;&#10;&#10;# Apply write permission on XC mapping files, to avoid MappingModelCompile errors.&#10;find &quot;$SRG_USER_DATA_DATA&quot; -type d -name &quot;*.xcmappingmodel&quot; -exec chmod +w {}/xcmapping.xml \;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "08C68E641D38D73C00BB8AAA"
+                     BuildableName = "Play SWI.app"
+                     BlueprintName = "Play SWI"
+                     ReferencedContainer = "container:PlaySRG.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <PostActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,8 +356,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srguserdata-apple.git",
       "state" : {
-        "revision" : "9c5f317ca346af90749c295c62cadc35eade09c6",
-        "version" : "3.3.0"
+        "branch" : "feature/5-swift-package-manager-mac-os-ventura",
+        "revision" : "614dbf415ea86e14e8962d291e44dce3ce824386"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -356,8 +356,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srguserdata-apple.git",
       "state" : {
-        "branch" : "feature/5-swift-package-manager-mac-os-ventura",
-        "revision" : "3840173c5073a5f8ab355c5823dd3d538a6646cc"
+        "branch" : "develop",
+        "revision" : "b116c3c7e0317c30bb0d0aac0ae0ef24c57275d0"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -357,7 +357,7 @@
       "location" : "https://github.com/SRGSSR/srguserdata-apple.git",
       "state" : {
         "branch" : "feature/5-swift-package-manager-mac-os-ventura",
-        "revision" : "614dbf415ea86e14e8962d291e44dce3ce824386"
+        "revision" : "3840173c5073a5f8ab355c5823dd3d538a6646cc"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

Resolves #299:
- on CI running on Mac OS Ventura: archives failed. No more nightly builds.
- on Xcode for developers running on Mac OS Ventura: some CoreData error displayed.

### Description

- User the new script from `SRGUserData` to avoid CoreData errors during compilation.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

* The project uses Github merge queue feature, which rebases onto the `develop` branch before merging the PR. 
