### PR TITLE
Update swiftlint to version 0.51.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,7 +17,6 @@ disabled_rules:
   - type_body_length
 
 opt_in_rules:
-  - capture_variable
   - closure_end_indentation
   - closure_spacing
   - collection_alignment
@@ -77,17 +76,20 @@ opt_in_rules:
   - switch_case_on_newline
   - test_case_accessibility
   - toggle_bool
-  - typesafe_array_init
   - unneeded_parentheses_in_closure_argument
   - unowned_variable_capture
   - untyped_error_in_catch
-  - unused_declaration
-  - unused_import
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
   - weak_delegate
   - xct_specific_matcher
+  
+analyzer_rules:
+  - capture_variable
+  - typesafe_array_init
+  - unused_declaration
+  - unused_import
 
 line_length: 300
 file_length: 1000

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,6 +30,7 @@ opt_in_rules:
   - discouraged_assert
   - discouraged_object_literal
   - discouraged_optional_boolean
+  - duplicate_conditions
   - empty_collection_literal
   - empty_count
   - empty_string
@@ -58,6 +59,7 @@ opt_in_rules:
   - overridden_super_call
   - override_in_extension
   - pattern_matching_keywords
+  - period_spacing
   - prefer_self_in_static_references
   - prefer_self_type_over_type_of_self
   - prefer_zero_over_explicit_init


### PR DESCRIPTION
### Motivation and Context

New SwiftLint version released 2 weeks ago: https://github.com/realm/SwiftLint/releases/tag/0.51.0

### Description

- Remove warnings.
- Add `period_spacing` and `duplicate_conditions` rules.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

* The project uses Github merge queue feature, which rebases onto the `develop` branch before merging the PR. 
