### PR TITLE
Analytics cleanup

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -17,7 +17,6 @@
 #import "NSBundle+PlaySRG.h"
 #import "PlayApplication.h"
 #import "PlayFirebaseConfiguration.h"
-#import "Playlist.h"
 #import "PlayLogger.h"
 #import "PlaySRG-Swift.h"
 #import "PushService.h"
@@ -360,12 +359,8 @@ static void *s_kvoContext = &s_kvoContext;
 {
     SRGMedia *media = notification.userInfo[SRGLetterboxMediaKey];
     if (media) {
-        SRGLetterboxController *letterboxController = notification.object;
-        Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
-        
         [[AnalyticsHiddenEventObjC continuousPlaybackWithAction:AnalyticsContiniousPlaybackActionPlayAutomatic
-                                                       mediaUrn:media.URN
-                                              recommendationUid:playlist.recommendationUid]
+                                                       mediaUrn:media.URN]
          send];
     }
 }

--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -48,10 +48,8 @@ extension UIViewController {
                 .sink { upcomingMedia in
                     guard let upcomingMedia else { return }
                     
-                    let playlist = controller.playlistDataSource as? Playlist
                     AnalyticsHiddenEvent.continuousPlayback(action: .display,
-                                                            mediaUrn: upcomingMedia.urn,
-                                                            recommendationUid: playlist?.recommendationUid)
+                                                            mediaUrn: upcomingMedia.urn)
                     .send()
                 }
                 .store(in: &cancellables)

--- a/Application/Sources/DeepLinking/DeepLinkAction.m
+++ b/Application/Sources/DeepLinking/DeepLinkAction.m
@@ -39,12 +39,11 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
 
 #pragma mark Class methods
 
-+ (instancetype)unsupportedActionWithOptions:(UISceneOpenURLOptions *)options source:(AnalyticsOpenUrlSource)source
++ (instancetype)unsupportedActionWithSource:(AnalyticsOpenUrlSource)source
 {
     AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionOpenPlayApp
                                                                                  source:source
-                                                                                    urn:nil
-                                                                      sourceApplication:options.sourceApplication];
+                                                                                    urn:nil];
     
     return [[self alloc] initWithType:DeepLinkTypeUnsupported
                            identifier:@""
@@ -54,28 +53,27 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
 
 + (instancetype)actionFromURLContext:(UIOpenURLContext *)URLContext
 {
-    return [self actionFromURL:URLContext.URL options:URLContext.options source:AnalyticsOpenUrlSourceCustomURL canConvertURL:YES];
+    return [self actionFromURL:URLContext.URL source:AnalyticsOpenUrlSourceCustomURL canConvertURL:YES];
 }
 
 + (instancetype)actionFromUniversalLinkURL:(NSURL *)URL
 {
-    return [self actionFromURL:URL options:nil source:AnalyticsOpenUrlSourceUniversalLink canConvertURL:YES];
+    return [self actionFromURL:URL source:AnalyticsOpenUrlSourceUniversalLink canConvertURL:YES];
 }
 
-+ (instancetype)actionFromURL:(NSURL *)URL options:(UISceneOpenURLOptions *)options source:(AnalyticsOpenUrlSource)source canConvertURL:(BOOL)canConvertURL
++ (instancetype)actionFromURL:(NSURL *)URL source:(AnalyticsOpenUrlSource)source canConvertURL:(BOOL)canConvertURL
 {
     NSURLComponents *URLComponents = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:YES];
     NSString *type = URLComponents.host.lowercaseString;
     if ([type isEqualToString:DeepLinkTypeMedia]) {
         NSString *mediaURN = URLComponents.path.lastPathComponent;
         if (! mediaURN) {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
         
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionPlayMedia
                                                                                      source:source
-                                                                                        urn:mediaURN
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:mediaURN];
         
         return [[self alloc] initWithType:type
                                identifier:mediaURN
@@ -85,13 +83,12 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if ([type isEqualToString:DeepLinkTypeShow]) {
         NSString *showURN = URLComponents.path.lastPathComponent;
         if (! showURN) {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
         
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionDisplayShow
                                                                                      source:source
-                                                                                        urn:showURN
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:showURN];
         
         return [[self alloc] initWithType:type
                                identifier:showURN
@@ -101,13 +98,12 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if ([type isEqualToString:DeepLinkTypeTopic]) {
         NSString *topicURN = URLComponents.path.lastPathComponent;
         if (! topicURN) {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
         
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionDisplayPage
                                                                                      source:source
-                                                                                        urn:topicURN
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:topicURN];
         
         return [[self alloc] initWithType:type
                                identifier:topicURN
@@ -117,8 +113,7 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if ([@[ DeepLinkTypeHome, DeepLinkTypeAZ, DeepLinkTypeByDate, DeepLinkTypeSearch, DeepLinkTypeLivestreams ] containsObject:type]) {
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionDisplayPage
                                                                                      source:source
-                                                                                        urn:type
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:type];
         
         return [[self alloc] initWithType:type
                                identifier:type
@@ -128,13 +123,12 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if ([type isEqualToString:DeepLinkTypeSection]) {
         NSString *sectionUid = URLComponents.path.lastPathComponent;
         if (! sectionUid) {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
         
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionDisplayPage
                                                                                      source:source
-                                                                                        urn:sectionUid
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:sectionUid];
         
         return [[self alloc] initWithType:type
                                identifier:sectionUid
@@ -144,13 +138,12 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if ([type isEqualToString:DeepLinkTypeLink]) {
         NSString *URLString = [self valueForParameterWithName:@"url" inQueryItems:URLComponents.queryItems];
         if (! URLString) {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
         
         AnalyticsHiddenEventObjC *hiddenEvent = [AnalyticsHiddenEventObjC openUrlWithAction:AnalyticsOpenUrlActionDisplayUrl
                                                                                      source:source
-                                                                                        urn:URLString
-                                                                          sourceApplication:options.sourceApplication];
+                                                                                        urn:URLString];
         
         return [[self alloc] initWithType:type
                                identifier:URLString
@@ -161,15 +154,15 @@ DeepLinkType const DeepLinkTypeUnsupported = @"unsupported";
     else if (canConvertURL) {
         NSURL *convertedURL = [DeepLinkService.currentService customURLFromWebURL:URL];
         if (convertedURL) {
-            return [self actionFromURL:convertedURL options:options source:source canConvertURL:NO];
+            return [self actionFromURL:convertedURL source:source canConvertURL:NO];
         }
         else {
-            return [self unsupportedActionWithOptions:options source:source];
+            return [self unsupportedActionWithSource:source];
         }
     }
 #endif
     else {
-        return [self unsupportedActionWithOptions:options source:source];
+        return [self unsupportedActionWithSource:source];
     }
 }
 

--- a/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
+++ b/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
@@ -31,13 +31,12 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String, recommendationUid: String?) -> AnalyticsHiddenEvent {
+    static func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String) -> AnalyticsHiddenEvent {
         return Self(
             name: "continuous_playback",
             source: action.source,
             type: action.type,
-            value: mediaUrn,
-            value1: recommendationUid
+            value: mediaUrn
         )
     }
     
@@ -182,8 +181,8 @@ struct AnalyticsHiddenEvent {
         self.event.send()
     }
     
-    @objc class func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String, recommendationUid: String?) -> AnalyticsHiddenEventObjC {
-        return Self(event: AnalyticsHiddenEvent.continuousPlayback(action: action, mediaUrn: mediaUrn, recommendationUid: recommendationUid))
+    @objc class func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String) -> AnalyticsHiddenEventObjC {
+        return Self(event: AnalyticsHiddenEvent.continuousPlayback(action: action, mediaUrn: mediaUrn))
     }
     
     @objc class func download(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEventObjC {

--- a/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
+++ b/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
@@ -87,13 +87,12 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?, sourceApplication: String?) -> AnalyticsHiddenEvent {
+    static func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?) -> AnalyticsHiddenEvent {
         return Self(
             name: "open_url",
             source: source.value,
             type: action.type,
-            value: urn,
-            value1: sourceApplication
+            value: urn
         )
     }
     
@@ -205,8 +204,8 @@ struct AnalyticsHiddenEvent {
         return Self(event: AnalyticsHiddenEvent.notification(action: action, from: from, uid: uid, overrideSource: overrideSource, overrideType: overrideType))
     }
     
-    @objc class func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?, sourceApplication: String?) -> AnalyticsHiddenEventObjC {
-        return Self(event: AnalyticsHiddenEvent.openUrl(action: action, source: source, urn: urn, sourceApplication: sourceApplication))
+    @objc class func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?) -> AnalyticsHiddenEventObjC {
+        return Self(event: AnalyticsHiddenEvent.openUrl(action: action, source: source, urn: urn))
     }
     
     @objc class func pictureInPicture(urn: String?) -> AnalyticsHiddenEventObjC {

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -321,11 +321,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         [self updateSharingStatus];
         
         if (letterboxController.continuousPlaybackUpcomingMedia) {
-            Playlist *playlist = [letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)letterboxController.playlistDataSource : nil;
-            
             [[AnalyticsHiddenEventObjC continuousPlaybackWithAction:AnalyticsContiniousPlaybackActionDisplay
-                                                           mediaUrn:letterboxController.continuousPlaybackUpcomingMedia.URN
-                                                  recommendationUid:playlist.recommendationUid]
+                                                           mediaUrn:letterboxController.continuousPlaybackUpcomingMedia.URN]
              send];
         }
     }];
@@ -557,11 +554,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     [super viewDidDisappear:animated];
     
     if (self.letterboxController.continuousPlaybackUpcomingMedia) {
-        Playlist *playlist = [self.letterboxController.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)self.letterboxController.playlistDataSource : nil;
-        
         [[AnalyticsHiddenEventObjC continuousPlaybackWithAction:AnalyticsContiniousPlaybackActionCancel
-                                                       mediaUrn:self.letterboxController.continuousPlaybackUpcomingMedia.URN
-                                              recommendationUid:playlist.recommendationUid]
+                                                       mediaUrn:self.letterboxController.continuousPlaybackUpcomingMedia.URN]
          send];
     }
     
@@ -1664,12 +1658,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
 
 - (void)letterboxView:(SRGLetterboxView *)letterboxView didEngageInContinuousPlaybackWithUpcomingMedia:(SRGMedia *)upcomingMedia
 {
-    SRGLetterboxController *controller = letterboxView.controller;
-    Playlist *playlist = [controller.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)controller.playlistDataSource : nil;
-    
     [[AnalyticsHiddenEventObjC continuousPlaybackWithAction:AnalyticsContiniousPlaybackActionPlay
-                                                   mediaUrn:upcomingMedia.URN
-                                          recommendationUid:playlist.recommendationUid]
+                                                   mediaUrn:upcomingMedia.URN]
      send];
 }
 
@@ -1691,12 +1681,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         [self presentViewController:alertController animated:YES completion:nil];
     }, @"DisableAutoplayAsked");
     
-    SRGLetterboxController *controller = letterboxView.controller;
-    Playlist *playlist = [controller.playlistDataSource isKindOfClass:Playlist.class] ? (Playlist *)controller.playlistDataSource : nil;
-    
     [[AnalyticsHiddenEventObjC continuousPlaybackWithAction:AnalyticsContiniousPlaybackActionCancel
-                                                   mediaUrn:upcomingMedia.URN
-                                          recommendationUid:playlist.recommendationUid]
+                                                   mediaUrn:upcomingMedia.URN]
      send];
 }
 

--- a/TV Application/Sources/LetterboxDelegate.swift
+++ b/TV Application/Sources/LetterboxDelegate.swift
@@ -17,11 +17,8 @@ class LetterboxDelegate: NSObject {
             .sink { notification in
                 guard let media = notification.userInfo?[SRGLetterboxMediaKey] as? SRGMedia else { return }
                 
-                let controller = notification.object as? SRGLetterboxController,
-                    playlist = controller?.playlistDataSource as? Playlist
                 AnalyticsHiddenEvent.continuousPlayback(action: .playAutomatic,
-                                                        mediaUrn: media.urn,
-                                                        recommendationUid: playlist?.recommendationUid)
+                                                        mediaUrn: media.urn)
                 .send()
             }
             .store(in: &cancellables)
@@ -30,18 +27,14 @@ class LetterboxDelegate: NSObject {
 
 extension LetterboxDelegate: SRGLetterboxViewControllerDelegate {
     func letterboxViewController(_ letterboxViewController: SRGLetterboxViewController, didEngageInContinuousPlaybackWithUpcomingMedia upcomingMedia: SRGMedia) {
-        let playlist = letterboxViewController.controller.playlistDataSource as? Playlist
         AnalyticsHiddenEvent.continuousPlayback(action: .play,
-                                                mediaUrn: upcomingMedia.urn,
-                                                recommendationUid: playlist?.recommendationUid)
+                                                mediaUrn: upcomingMedia.urn)
         .send()
     }
     
     func letterboxViewController(_ letterboxViewController: SRGLetterboxViewController, didCancelContinuousPlaybackWithUpcomingMedia upcomingMedia: SRGMedia) {
-        let playlist = letterboxViewController.controller.playlistDataSource as? Playlist
         AnalyticsHiddenEvent.continuousPlayback(action: .cancel,
-                                                mediaUrn: upcomingMedia.urn,
-                                                recommendationUid: playlist?.recommendationUid)
+                                                mediaUrn: upcomingMedia.urn)
         .send()
     }
     


### PR DESCRIPTION
### Motivation and Context

SRGSSR would like to reduce unique values for hidden event `value1` property.

### Description

- Remove value1 for continuousPlayback analytics event.
- Remove value1 for openUrl analytics event.
- Clean code.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style:
	-  [x] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [x] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

* The project uses Github merge queue feature, which rebases onto the `develop` branch before merging the PR. 
