### PR TITLE
iPad show page with item media list

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -83,9 +83,6 @@
 /* Search setting option */
 "All" = "Tutto";
 
-/* Beta tests toggle label to enable episodes as a list in show pages setting label */
-"Always display episodes as a list in show pages (iPad)" = "Always display episodes as a list in show pages (iPad)";
-
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Sempre visibile con VoiceOver attivo.";
 
@@ -118,10 +115,6 @@
 
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Diventare un beta tester";
-
-/* Beta tests alert title
-   Beta tests section header */
-"Beta tests" = "Beta tests";
 
 /* Show by date short button title */
 "By date" = "Per data";
@@ -453,8 +446,7 @@
 /* Now button in program guide */
 "Now" = "Ora";
 
-/* Title of an information alert button
-   Title of the button displayed at the end of an onboarding
+/* Title of the button displayed at the end of an onboarding
    Title of the button to validate date settings
    Title of the search settings button to apply settings */
 "OK" = "OK";
@@ -665,9 +657,6 @@
 /* Server setting name */
 "Test" = "Test";
 
-/* Beta tests alert explanation */
-"Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab." = "Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.";
-
 /* Add to Calendar alert explanation */
 "The application uses the calendar to add TV programs." = "L'applicazione usa il calendario per aggiungere i programmi TV";
 
@@ -736,9 +725,6 @@
 
 /* Related content media list title */
 "This might interest you" = "Potrebbero interessarti";
-
-/* Beta tests section footer */
-"This section is only available for beta testers." = "This section is only available for beta testers.";
 
 /* Advanced features section footer
    Reset section footer */
@@ -843,9 +829,6 @@
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Sei stato scollegato automaticamente. Esegui nuovamente il login per mantenere i dati sincronizzati su tutti i dispositivi.";
-
-/* Beta tests alert explanation */
-"You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Label of the button to display feedback form */
 "Your feedback" = "Esprimere un'opinione";

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -83,9 +83,6 @@
 /* Search setting option */
 "All" = "Tut";
 
-/* Beta tests toggle label to enable episodes as a list in show pages setting label */
-"Always display episodes as a list in show pages (iPad)" = "Always display episodes as a list in show pages (iPad)";
-
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Adina visibel cun VoiceOver activà.";
 
@@ -118,10 +115,6 @@
 
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Daventa in Beta-Tester";
-
-/* Beta tests alert title
-   Beta tests section header */
-"Beta tests" = "Beta tests";
 
 /* Show by date short button title */
 "By date" = "Tenor data";
@@ -453,8 +446,7 @@
 /* Now button in program guide */
 "Now" = "Ussa";
 
-/* Title of an information alert button
-   Title of the button displayed at the end of an onboarding
+/* Title of the button displayed at the end of an onboarding
    Title of the button to validate date settings
    Title of the search settings button to apply settings */
 "OK" = "OK";
@@ -665,9 +657,6 @@
 /* Server setting name */
 "Test" = "Test";
 
-/* Beta tests alert explanation */
-"Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab." = "Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.";
-
 /* Add to Calendar alert explanation */
 "The application uses the calendar to add TV programs." = "L'applicaziun utilisescha il chalender per agiuntar programs da TV.";
 
@@ -736,9 +725,6 @@
 
 /* Related content media list title */
 "This might interest you" = "Quai pudess interessar Vus";
-
-/* Beta tests section footer */
-"This section is only available for beta testers." = "This section is only available for beta testers.";
 
 /* Advanced features section footer
    Reset section footer */
@@ -843,9 +829,6 @@
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Vus essas vegni deconnectà automaticamain. Per mantegnair la sincronisaziun da las datas sur tut ils apparats far anc ina giada il login.";
-
-/* Beta tests alert explanation */
-"You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Label of the button to display feedback form */
 "Your feedback" = "Voss resun";

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -83,9 +83,6 @@
 /* Search setting option */
 "All" = "Tout";
 
-/* Beta tests toggle label to enable episodes as a list in show pages setting label */
-"Always display episodes as a list in show pages (iPad)" = "Always display episodes as a list in show pages (iPad)";
-
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Toujours visible lorsque VoiceOver est activé.";
 
@@ -118,10 +115,6 @@
 
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Devenez bêta-testeur";
-
-/* Beta tests alert title
-   Beta tests section header */
-"Beta tests" = "Beta tests";
 
 /* Show by date short button title */
 "By date" = "Par date";
@@ -453,8 +446,7 @@
 /* Now button in program guide */
 "Now" = "Maintenant";
 
-/* Title of an information alert button
-   Title of the button displayed at the end of an onboarding
+/* Title of the button displayed at the end of an onboarding
    Title of the button to validate date settings
    Title of the search settings button to apply settings */
 "OK" = "OK";
@@ -665,9 +657,6 @@
 /* Server setting name */
 "Test" = "Test";
 
-/* Beta tests alert explanation */
-"Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab." = "Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.";
-
 /* Add to Calendar alert explanation */
 "The application uses the calendar to add TV programs." = "L'application utilise le calendrier pour ajouter des programmes TV.";
 
@@ -736,9 +725,6 @@
 
 /* Related content media list title */
 "This might interest you" = "Cela pourrait vous intéresser";
-
-/* Beta tests section footer */
-"This section is only available for beta testers." = "This section is only available for beta testers.";
 
 /* Advanced features section footer
    Reset section footer */
@@ -843,9 +829,6 @@
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Vous avez été automatiquement déconnecté. Connectez-vous à nouveau pour conserver vos données synchronisées entre vos appareils.";
-
-/* Beta tests alert explanation */
-"You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Label of the button to display feedback form */
 "Your feedback" = "Votre avis";

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -83,9 +83,6 @@
 /* Search setting option */
 "All" = "Alle";
 
-/* Beta tests toggle label to enable episodes as a list in show pages setting label */
-"Always display episodes as a list in show pages (iPad)" = "Always display episodes as a list in show pages (iPad)";
-
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Immer sichtbar wenn VoiceOver aktiviert ist.";
 
@@ -118,10 +115,6 @@
 
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Beta-Tester werden";
-
-/* Beta tests alert title
-   Beta tests section header */
-"Beta tests" = "Beta tests";
 
 /* Show by date short button title */
 "By date" = "Nach Datum";
@@ -453,8 +446,7 @@
 /* Now button in program guide */
 "Now" = "Jetzt";
 
-/* Title of an information alert button
-   Title of the button displayed at the end of an onboarding
+/* Title of the button displayed at the end of an onboarding
    Title of the button to validate date settings
    Title of the search settings button to apply settings */
 "OK" = "OK";
@@ -665,9 +657,6 @@
 /* Server setting name */
 "Test" = "Test";
 
-/* Beta tests alert explanation */
-"Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab." = "Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.";
-
 /* Add to Calendar alert explanation */
 "The application uses the calendar to add TV programs." = "Die Applikation verwendet den Kalender, um Einträge aus dem TV-Programm hinzuzufügen.";
 
@@ -736,9 +725,6 @@
 
 /* Related content media list title */
 "This might interest you" = "Das könnte Sie auch interessieren";
-
-/* Beta tests section footer */
-"This section is only available for beta testers." = "This section is only available for beta testers.";
 
 /* Advanced features section footer
    Reset section footer */
@@ -843,9 +829,6 @@
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Sie wurden automatisch abgemeldet. Melden Sie sich erneut an, um Ihre Daten zu synchronisieren.";
-
-/* Beta tests alert explanation */
-"You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Label of the button to display feedback form */
 "Your feedback" = "Feedback geben";

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -83,9 +83,6 @@
 /* Search setting option */
 "All" = "All";
 
-/* Beta tests toggle label to enable episodes as a list in show pages setting label */
-"Always display episodes as a list in show pages (iPad)" = "Always display episodes as a list in show pages (iPad)";
-
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Always visible when VoiceOver is active.";
 
@@ -118,10 +115,6 @@
 
 /* Label of the button to become beta tester */
 "Become a beta tester" = "Become a beta tester";
-
-/* Beta tests alert title
-   Beta tests section header */
-"Beta tests" = "Beta tests";
 
 /* Show by date short button title */
 "By date" = "By date";
@@ -453,8 +446,7 @@
 /* Now button in program guide */
 "Now" = "Now";
 
-/* Title of an information alert button
-   Title of the button displayed at the end of an onboarding
+/* Title of the button displayed at the end of an onboarding
    Title of the button to validate date settings
    Title of the search settings button to apply settings */
 "OK" = "OK";
@@ -665,9 +657,6 @@
 /* Server setting name */
 "Test" = "Test";
 
-/* Beta tests alert explanation */
-"Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab." = "Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.";
-
 /* Add to Calendar alert explanation */
 "The application uses the calendar to add TV programs." = "The application uses the calendar to add TV programs.";
 
@@ -736,9 +725,6 @@
 
 /* Related content media list title */
 "This might interest you" = "This might interest you";
-
-/* Beta tests section footer */
-"This section is only available for beta testers." = "This section is only available for beta testers.";
 
 /* Advanced features section footer
    Reset section footer */
@@ -843,9 +829,6 @@
 
 /* Notification displayed when the user has been logged out unexpectedly. */
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "You have been automatically logged out. Login again to keep your data synchronized across devices.";
-
-/* Beta tests alert explanation */
-"You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab." = "You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.";
 
 /* Label of the button to display feedback form */
 "Your feedback" = "Your feedback";

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -160,6 +160,13 @@ static void *s_kvoContext = &s_kvoContext;
         completionHandler(YES);
     }, @"MigrateSelectedLiveStreamURNForChannels");
     
+    PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
+        NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
+        [userDefaults removeObjectForKey:PlaySRGSettingMediaListDividerEnabled];
+        [userDefaults synchronize];
+        completionHandler(YES);
+    }, @"ClearMediaListDividerPreference");
+    
     FavoritesUpdatePushService();
     
     [NSNotificationCenter.defaultCenter addObserverForName:SRGPreferencesDidChangeNotification object:SRGUserData.currentUserData.preferences queue:nil usingBlock:^(NSNotification * _Nonnull notification) {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -515,6 +515,7 @@ extension PageViewController: TabBarActionable {
 
 private extension PageViewController {
     private static let itemSpacing: CGFloat = constant(iOS: 8, tvOS: 40)
+    private static let layoutHorizontalMargin: CGFloat = constant(iOS: 16, tvOS: 0)
     private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
     
     private func layoutConfiguration() -> UICollectionViewCompositionalLayoutConfiguration {
@@ -544,77 +545,77 @@ private extension PageViewController {
                 
                 switch section.viewModelProperties.layout {
                 case .heroStage:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, _ in
                         return HeroMediaCellSize.recommended(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
                     }
                     layoutSection.orthogonalScrollingBehavior = .groupPaging
                     return layoutSection
                 case .highlight:
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, _ in
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, _ in
                         return HighlightCellSize.fullWidth(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
                     }
                 case .headline:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, _ in
                         return FeaturedContentCellSize.headline(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
                     }
                     layoutSection.orthogonalScrollingBehavior = .groupPaging
                     return layoutSection
                 case .element:
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, _ in
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, _ in
                         return FeaturedContentCellSize.element(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
                     }
                 case .elementSwimlane:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, _ in
                         return FeaturedContentCellSize.element(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .mediaSwimlane:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return MediaCellSize.swimlane()
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .liveMediaSwimlane:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return LiveMediaCellSize.swimlane()
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .showSwimlane:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return ShowCellSize.swimlane(for: section.properties.imageVariant)
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .topicSelector:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return TopicCellSize.swimlane()
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .mediaGrid:
                     if horizontalSizeClass == .compact {
-                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                             return MediaCellSize.fullWidth()
                         }
                     }
                     else {
-                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
                             return MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                         }
                     }
                 case .liveMediaGrid:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
                         return LiveMediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                     }
                 case .showGrid:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
                         return ShowCellSize.grid(for: section.properties.imageVariant, layoutWidth: layoutWidth, spacing: spacing)
                     }
 #if os(iOS)
                 case .showAccess:
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return ShowAccessCellSize.fullWidth()
                     }
 #endif

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -685,8 +685,7 @@ private extension SectionViewController {
                 switch configuration.viewModelProperties.layout {
                 case .mediaList:
 #if os(iOS)
-                    let spacing = horizontalSizeClass == .compact ? Self.itemSpacing : Self.itemSpacing * 2
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: spacing, top: top) { _, _ in
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { _, _ in
                         return MediaCellSize.fullWidth(horizontalSizeClass: horizontalSizeClass, displayDivider: configuration.viewModelProperties.displayDivider)
                     }
 #else

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -178,18 +178,15 @@ final class SectionViewController: UIViewController {
             .store(in: &cancellables)
         
 #if os(iOS)
-        Publishers.Merge(
-            ApplicationSignal.settingUpdates(at: \.PlaySRGSettingMediaListDividerEnabled),
-            ApplicationSignal.settingUpdates(at: \.PlaySRGSettingMediaListLayoutEnabled)
-        )
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] _ in
-            guard let self else { return }
-            
-            self.contentInsets = Self.contentInsets(for: self.model.state, displayDivider: self.model.configuration.viewModelProperties.displayDivider)
-            self.collectionView.reloadData()
-        }
-        .store(in: &cancellables)
+        ApplicationSignal.settingUpdates(at: \.PlaySRGSettingMediaListDividerEnabled)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                
+                self.contentInsets = Self.contentInsets(for: self.model.state, displayDivider: self.model.configuration.viewModelProperties.displayDivider)
+                self.collectionView.reloadData()
+            }
+            .store(in: &cancellables)
 #endif
     }
     

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -840,7 +840,7 @@ private extension SectionViewController {
                     Color.clear
                 }
             case let .show(show):
-                ShowHeaderView(show: show)
+                ShowHeaderView(show: show, horizontalPadding: SectionViewController.margin)
             case .none:
                 Color.clear
             }
@@ -858,7 +858,7 @@ private extension SectionViewController {
                     return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))
                 }
             case let .show(show):
-                return ShowHeaderViewSize.recommended(for: show, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
+                return ShowHeaderViewSize.recommended(for: show, horizontalPadding: SectionViewController.margin, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
             case .none:
                 return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))
             }

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -177,7 +177,7 @@ final class SectionViewController: UIViewController {
             }
             .store(in: &cancellables)
         
-#if os(iOS)
+#if os(iOS) && (DEBUG || NIGHTLY || BETA)
         ApplicationSignal.settingUpdates(at: \.PlaySRGSettingMediaListDividerEnabled)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -201,53 +201,6 @@ final class SectionViewController: UIViewController {
         userActivity = model.configuration.viewModelProperties.userActivity
     }
     
-#if os(iOS)
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        if !Bundle.main.play_isAppStoreRelease {
-            if case let .configured(section) = model.configuration.wrappedValue, case .show = section {
-                PlayApplicationRunOnce({ completionHandler in
-                    if UIDevice.current.userInterfaceIdiom == .pad {
-                        if UserDefaults.standard.bool(forKey: PlaySRGSettingMediaListLayoutEnabled) {
-                            let alertController = UIAlertController(title: NSLocalizedString("Beta tests", comment: "Beta tests alert title"),
-                                                                    message: NSLocalizedString("Thank you to test the new layout. An update version is now available.\nThis preview can be disable at anytime in the application settings, in profile tab.", comment: "Beta tests alert explanation"),
-                                                                    preferredStyle: .alert)
-                            alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Title of an information alert button"), style: .cancel, handler: { _ in
-                                UserDefaults.standard.setValue(true, forKey: PlaySRGSettingMediaListDividerEnabled)
-                                UserDefaults.standard.synchronize()
-                            }))
-                            present(alertController, animated: true, completion: nil)
-                        }
-                        else {
-                            let alertController = UIAlertController(title: NSLocalizedString("Beta tests", comment: "Beta tests alert title"),
-                                                                    message: NSLocalizedString("You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.", comment: "Beta tests alert explanation"),
-                                                                    preferredStyle: .alert)
-                            alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Title of an information alert button"), style: .cancel, handler: { _ in
-                                UserDefaults.standard.setValue(true, forKey: PlaySRGSettingMediaListLayoutEnabled)
-                                UserDefaults.standard.setValue(true, forKey: PlaySRGSettingMediaListDividerEnabled)
-                                UserDefaults.standard.synchronize()
-                            }))
-                            present(alertController, animated: true, completion: nil)
-                        }
-                    }
-                    else if UIDevice.current.userInterfaceIdiom == .phone {
-                        let alertController = UIAlertController(title: NSLocalizedString("Beta tests", comment: "Beta tests alert title"),
-                                                                message: NSLocalizedString("You'll preview a new layout to display episodes.\nThis preview can be disable at anytime in the application settings, in profile tab.", comment: "Beta tests alert explanation"),
-                                                                preferredStyle: .alert)
-                        alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Title of an information alert button"), style: .cancel, handler: { _ in
-                            UserDefaults.standard.setValue(true, forKey: PlaySRGSettingMediaListDividerEnabled)
-                            UserDefaults.standard.synchronize()
-                        }))
-                        present(alertController, animated: true, completion: nil)
-                    }
-                    completionHandler(true)
-                }, "ShowPageBetaTestsAlert2")
-            }
-        }
-    }
-#endif
-    
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         userActivity = nil

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -18,7 +18,8 @@ final class SectionViewController: UIViewController {
     let fromPushNotification: Bool
     
     private static let itemSpacing: CGFloat = constant(iOS: 8, tvOS: 40)
-    private static let margin = constant(iOS: 2 * itemSpacing, tvOS: 0)
+    private static let layoutHorizontalMargin: CGFloat = constant(iOS: 16, tvOS: 0)
+    private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -647,8 +648,6 @@ extension SectionViewController: TabBarActionable {
 // MARK: Layout
 
 private extension SectionViewController {
-    private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
-    
     private func layoutConfiguration() -> UICollectionViewCompositionalLayoutConfiguration {
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
         configuration.contentInsetsReference = constant(iOS: .automatic, tvOS: .layoutMargins)
@@ -685,35 +684,36 @@ private extension SectionViewController {
                 switch configuration.viewModelProperties.layout {
                 case .mediaList:
 #if os(iOS)
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { _, _ in
+                    let horizontalMargin = horizontalSizeClass == .compact ? Self.layoutHorizontalMargin : Self.layoutHorizontalMargin * 2
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: horizontalMargin, spacing: Self.itemSpacing, top: top) { _, _ in
                         return MediaCellSize.fullWidth(horizontalSizeClass: horizontalSizeClass, displayDivider: configuration.viewModelProperties.displayDivider)
                     }
 #else
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                         return MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                     }
 #endif
                 case .mediaGrid:
                     if horizontalSizeClass == .compact {
-                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { _, _ in
+                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { _, _ in
                             return MediaCellSize.fullWidth(displayDivider: configuration.viewModelProperties.displayDivider)
                         }
                     }
                     else {
-                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                             return MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                         }
                     }
                 case .liveMediaGrid:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                         return LiveMediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                     }
                 case .showGrid:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                         return ShowCellSize.grid(for: configuration.properties.imageVariant, layoutWidth: layoutWidth, spacing: spacing)
                     }
                 case .topicGrid:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                         return TopicCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                     }
 #if os(iOS)
@@ -724,12 +724,12 @@ private extension SectionViewController {
                         }
                     }
                     else {
-                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
+                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
                             return DownloadCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                         }
                     }
                 case .notificationList:
-                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing, top: top) { _, _ in
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { _, _ in
                         return NotificationCellSize.fullWidth()
                     }
 #endif
@@ -830,7 +830,7 @@ private extension SectionViewController {
         var body: some View {
             switch section.header {
             case let .title(title):
-                TransluscentHeaderView(title: title, horizontalPadding: SectionViewController.margin)
+                TransluscentHeaderView(title: title, horizontalPadding: SectionViewController.layoutHorizontalMargin)
             case let .item(item):
                 switch item {
                 case let .show(show):
@@ -839,7 +839,7 @@ private extension SectionViewController {
                     Color.clear
                 }
             case let .show(show):
-                ShowHeaderView(show: show, horizontalPadding: SectionViewController.margin)
+                ShowHeaderView(show: show, horizontalPadding: SectionViewController.layoutHorizontalMargin)
             case .none:
                 Color.clear
             }
@@ -848,7 +848,7 @@ private extension SectionViewController {
         static func size(section: SectionViewModel.Section, configuration: SectionViewModel.Configuration, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
             switch section.header {
             case let .title(title):
-                return TransluscentHeaderViewSize.recommended(title: title, horizontalPadding: SectionViewController.margin, layoutWidth: layoutWidth)
+                return TransluscentHeaderViewSize.recommended(title: title, horizontalPadding: SectionViewController.layoutHorizontalMargin, layoutWidth: layoutWidth)
             case let .item(item):
                 switch item {
                 case let .show(show):
@@ -857,7 +857,7 @@ private extension SectionViewController {
                     return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))
                 }
             case let .show(show):
-                return ShowHeaderViewSize.recommended(for: show, horizontalPadding: SectionViewController.margin, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
+                return ShowHeaderViewSize.recommended(for: show, horizontalPadding: SectionViewController.layoutHorizontalMargin, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
             case .none:
                 return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))
             }

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -398,7 +398,7 @@ private extension SectionViewModel {
 #endif
             case .show:
 #if os(iOS)
-                return ApplicationSettingMediaListLayoutEnabled() ? .mediaList : .mediaGrid
+                return .mediaList
 #else
                 return .mediaGrid
 #endif

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -408,7 +408,7 @@ private extension SectionViewModel {
         }
         
         var displayDivider: Bool {
-#if os(iOS)
+#if os(iOS) && (DEBUG || NIGHTLY || BETA)
             switch configuredSection {
             case .show:
                 return ApplicationSettingMediaListDividerEnabled()

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -31,16 +31,19 @@ class ShowMoreEvent: UIEvent {
 /// Behavior: h-hug, v-hug
 struct ShowHeaderView: View {
     @Binding private(set) var show: SRGShow
+    let horizontalPadding: CGFloat
+    
     @StateObject private var model = ShowHeaderViewModel()
     
     fileprivate static let verticalSpacing: CGFloat = 24
     
-    init(show: SRGShow) {
+    init(show: SRGShow, horizontalPadding: CGFloat) {
         _show = .constant(show)
+        self.horizontalPadding = horizontalPadding
     }
     
     var body: some View {
-        MainView(model: model)
+        MainView(model: model, horizontalPadding: horizontalPadding)
             .onAppear {
                 model.show = show
             }
@@ -52,23 +55,21 @@ struct ShowHeaderView: View {
     /// Behavior: h-hug, v-hug.
     fileprivate struct MainView: View {
         @ObservedObject var model: ShowHeaderViewModel
+        let horizontalPadding: CGFloat
         @Environment(\.uiHorizontalSizeClass) private var horizontalSizeClass
         
         @State private var isLandscape: Bool
         
         private let compactDescriptionOffet: CGFloat = -12
         
-        init(model: ShowHeaderViewModel) {
+        init(model: ShowHeaderViewModel, horizontalPadding: CGFloat) {
             self.model = model
+            self.horizontalPadding = horizontalPadding
             self.isLandscape = (UIApplication.shared.mainWindow?.isLandscape ?? false)
         }
         
         private var descriptionHorizontalPadding: CGFloat {
-#if os(iOS)
-            return horizontalSizeClass == .regular ? 32 : 16
-#else
-            return 0
-#endif
+            return horizontalSizeClass == .compact ? horizontalPadding : horizontalPadding * 2
         }
         
         var body: some View {
@@ -241,11 +242,11 @@ struct ShowHeaderView: View {
 // MARK: Size
 
 enum ShowHeaderViewSize {
-    static func recommended(for show: SRGShow, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
+    static func recommended(for show: SRGShow, horizontalPadding: CGFloat, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
         let fittingSize = CGSize(width: layoutWidth, height: UIView.layoutFittingExpandedSize.height)
         let model = ShowHeaderViewModel()
         model.show = show
-        let size = ShowHeaderView.MainView(model: model).adaptiveSizeThatFits(in: fittingSize, for: horizontalSizeClass)
+        let size = ShowHeaderView.MainView(model: model, horizontalPadding: horizontalPadding).adaptiveSizeThatFits(in: fittingSize, for: horizontalSizeClass)
         return NSCollectionLayoutSize(widthDimension: .absolute(layoutWidth), heightDimension: .absolute(size.height))
     }
 }
@@ -266,22 +267,22 @@ struct ShowHeaderView_Previews: PreviewProvider {
     static var previews: some View {
 #if os(tvOS)
         Group {
-            ShowHeaderView.MainView(model: model1)
-            ShowHeaderView.MainView(model: model2)
+            ShowHeaderView.MainView(model: model1, horizontalPadding: 0)
+            ShowHeaderView.MainView(model: model2, horizontalPadding: 0)
         }
         .previewLayout(.sizeThatFits)
 #else
         Group {
-            ShowHeaderView.MainView(model: model1)
-            ShowHeaderView.MainView(model: model2)
+            ShowHeaderView.MainView(model: model1, horizontalPadding: 16)
+            ShowHeaderView.MainView(model: model2, horizontalPadding: 16)
         }
         .previewLayout(.sizeThatFits)
         .frame(width: 1000)
         .environment(\.horizontalSizeClass, .regular)
         
         Group {
-            ShowHeaderView.MainView(model: model1)
-            ShowHeaderView.MainView(model: model2)
+            ShowHeaderView.MainView(model: model1, horizontalPadding: 16)
+            ShowHeaderView.MainView(model: model2, horizontalPadding: 16)
         }
         .frame(width: 375)
         .previewLayout(.sizeThatFits)

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -57,11 +57,6 @@ struct ShowHeaderView: View {
         @State private var isLandscape: Bool
         
         private let compactDescriptionOffet: CGFloat = -12
-      
-#if os(iOS)
-        // App storage property changes are tracked to update layout. Only application setting function is used to take care of the app build distribution.
-        @AppStorage(PlaySRGSettingMediaListLayoutEnabled) var isMediaListLayoutEnabled = false
-#endif
         
         init(model: ShowHeaderViewModel) {
             self.model = model
@@ -70,12 +65,7 @@ struct ShowHeaderView: View {
         
         private var descriptionHorizontalPadding: CGFloat {
 #if os(iOS)
-            if ApplicationSettingMediaListLayoutEnabled() && horizontalSizeClass == .regular {
-                return 32
-            }
-            else {
-                return 16
-            }
+            return horizontalSizeClass == .regular ? 32 : 16
 #else
             return 0
 #endif

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -348,9 +348,7 @@ extension UIHostingController {
 extension NSCollectionLayoutSection {
     typealias CellSizer = (_ layoutWidth: CGFloat, _ spacing: CGFloat) -> NSCollectionLayoutSize
     
-    static func horizontal(layoutWidth: CGFloat, spacing: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0, cellSizer: CellSizer) -> NSCollectionLayoutSection {
-        let horizontalMargin = constant(iOS: 2 * spacing, tvOS: 0)
-        
+    static func horizontal(layoutWidth: CGFloat, horizontalMargin: CGFloat = 0, spacing: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0, cellSizer: CellSizer) -> NSCollectionLayoutSection {
         let effectiveLayoutWidth = layoutWidth - 2 * horizontalMargin
         let cellSize = cellSizer(effectiveLayoutWidth, spacing)
         
@@ -366,9 +364,7 @@ extension NSCollectionLayoutSection {
         return section
     }
     
-    static func grid(layoutWidth: CGFloat, spacing: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0, cellSizer: CellSizer) -> NSCollectionLayoutSection {
-        let horizontalMargin = constant(iOS: 2 * spacing, tvOS: 0)
-        
+    static func grid(layoutWidth: CGFloat, horizontalMargin: CGFloat = 0, spacing: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0, cellSizer: CellSizer) -> NSCollectionLayoutSection {
         let effectiveLayoutWidth = layoutWidth - 2 * horizontalMargin
         let cellSize = cellSizer(effectiveLayoutWidth, spacing)
         

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
@@ -21,7 +21,7 @@ final class ProgramGuideDailyViewController: UIViewController {
     private weak var collectionView: UICollectionView!
     private weak var emptyContentView: HostView<EmptyContentView>!
     
-    private static let margin: CGFloat = 10
+    private static let layoutHorizontalMargin: CGFloat = 10
     private static let verticalSpacing: CGFloat = 3
     
     var day: SRGDay {
@@ -67,8 +67,8 @@ final class ProgramGuideDailyViewController: UIViewController {
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.topAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Self.margin),
-            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Self.margin)
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Self.layoutHorizontalMargin),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Self.layoutHorizontalMargin)
         ])
         
         let emptyContentView = HostView<EmptyContentView>(frame: .zero)

--- a/Application/Sources/Search/SearchViewController.swift
+++ b/Application/Sources/Search/SearchViewController.swift
@@ -34,6 +34,8 @@ final class SearchViewController: UIViewController {
     private weak var searchController: UISearchController?
     
     private static let itemSpacing: CGFloat = constant(iOS: 8, tvOS: 40)
+    private static let layoutHorizontalMargin: CGFloat = constant(iOS: 16, tvOS: 0)
+    private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
     
     private static func snapshot(from state: SearchViewModel.State) -> NSDiffableDataSourceSnapshot<SearchViewModel.Section, SearchViewModel.Item> {
         var snapshot = NSDiffableDataSourceSnapshot<SearchViewModel.Section, SearchViewModel.Item>()
@@ -572,7 +574,6 @@ extension SearchViewController: UIScrollViewDelegate {
 
 private extension SearchViewController {
     private static let emptyViewInsets = EdgeInsets(top: constant(iOS: 0, tvOS: 350), leading: 0, bottom: 0, trailing: 0)
-    private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
     
     private func layoutConfiguration() -> UICollectionViewCompositionalLayoutConfiguration {
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
@@ -598,23 +599,23 @@ private extension SearchViewController {
                 switch section {
                 case .medias:
                     if horizontalSizeClass == .compact {
-                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                        return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                             return MediaCellSize.fullWidth()
                         }
                     }
                     else {
-                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                        return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
                             return MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                         }
                     }
                 case .mostSearchedShows, .shows:
-                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { _, _ in
+                    let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         return ShowCellSize.swimlane(for: .default)
                     }
                     layoutSection.orthogonalScrollingBehavior = .continuousGroupLeadingBoundary
                     return layoutSection
                 case .topics:
-                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
                         return TopicCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                     }
                 case .loading:

--- a/Application/Sources/Settings/ApplicationSettings.h
+++ b/Application/Sources/Settings/ApplicationSettings.h
@@ -50,6 +50,5 @@ OBJC_EXPORT void ApplicationSettingSetLastOpenedRadioChannel(RadioChannel *radio
 OBJC_EXPORT BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void);
 
 OBJC_EXPORT BOOL ApplicationSettingMediaListDividerEnabled(void);
-OBJC_EXPORT BOOL ApplicationSettingMediaListLayoutEnabled(void);
 
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettings.m
+++ b/Application/Sources/Settings/ApplicationSettings.m
@@ -177,13 +177,3 @@ BOOL ApplicationSettingMediaListDividerEnabled(void)
         return NO;
     }
 }
-
-BOOL ApplicationSettingMediaListLayoutEnabled(void)
-{
-    if (! NSBundle.mainBundle.play_isAppStoreRelease) {
-        return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingMediaListLayoutEnabled];
-    }
-    else {
-        return NO;
-    }
-}

--- a/Application/Sources/Settings/ApplicationSettings.m
+++ b/Application/Sources/Settings/ApplicationSettings.m
@@ -170,10 +170,5 @@ BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void)
 
 BOOL ApplicationSettingMediaListDividerEnabled(void)
 {
-    if (! NSBundle.mainBundle.play_isAppStoreRelease) {
-        return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingMediaListDividerEnabled];
-    }
-    else {
-        return NO;
-    }
+    return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingMediaListDividerEnabled];
 }

--- a/Application/Sources/Settings/ApplicationSettingsConstants.h
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.h
@@ -22,6 +22,5 @@ OBJC_EXPORT NSString * const PlaySRGSettingSelectedLivestreamURNForChannels;
 OBJC_EXPORT NSString * const PlaySRGSettingServiceIdentifier;
 OBJC_EXPORT NSString * const PlaySRGSettingUserLocation;
 OBJC_EXPORT NSString * const PlaySRGSettingMediaListDividerEnabled;
-OBJC_EXPORT NSString * const PlaySRGSettingMediaListLayoutEnabled;
 
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettingsConstants.m
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.m
@@ -20,7 +20,6 @@ NSString * const PlaySRGSettingSelectedLivestreamURNForChannels = @"PlaySRGSetti
 NSString * const PlaySRGSettingServiceIdentifier = @"PlaySRGSettingServiceIdentifier";
 NSString * const PlaySRGSettingUserLocation = @"PlaySRGSettingUserLocation";
 NSString * const PlaySRGSettingMediaListDividerEnabled = @"PlaySRGSettingMediaListDividerEnabled";
-NSString * const PlaySRGSettingMediaListLayoutEnabled = @"PlaySRGSettingMediaListLayoutEnabled";
 
 __attribute__((constructor)) static void ApplicationSettingsConstantsInit(void)
 {

--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -29,9 +29,6 @@ struct SettingsView: View {
             }
 #endif
 #if os(iOS)
-            if !Bundle.main.play_isAppStoreRelease {
-                BetaTestsSection()
-            }
             QualitySection()
 #endif
             PlaybackSection()
@@ -133,20 +130,6 @@ struct SettingsView: View {
                 Text(NSLocalizedString("Quality", comment: "Quality settings section header"))
             } footer: {
                 Text(NSLocalizedString("To avoid possible extra costs this option can be disabled to have the highest quality played only on Wi-Fi networks.", comment: "Quality settings section footer"))
-            }
-        }
-    }
-    
-    private struct BetaTestsSection: View {
-        @AppStorage(PlaySRGSettingMediaListDividerEnabled) var isMediaListDividerEnabled = false
-        
-        var body: some View {
-            PlaySection {
-                Toggle(NSLocalizedString("Add line dividers in episodes list in show pages", comment: "Beta tests toggle label to add line dividers in episodes list in show pages setting label"), isOn: $isMediaListDividerEnabled)
-            } header: {
-                Text(NSLocalizedString("Beta tests", comment: "Beta tests section header"))
-            } footer: {
-                Text(NSLocalizedString("This section is only available for beta testers.", comment: "Beta tests section footer"))
             }
         }
     }
@@ -504,6 +487,9 @@ struct SettingsView: View {
         @AppStorage(PlaySRGSettingPresenterModeEnabled) var isPresenterModeEnabled = false
         @AppStorage(PlaySRGSettingStandaloneEnabled) var isStandaloneEnabled = false
         @AppStorage(PlaySRGSettingSectionWideSupportEnabled) var isSectionWideSupportEnabled = false
+#if os(iOS)
+        @AppStorage(PlaySRGSettingMediaListDividerEnabled) var isMediaListDividerEnabled = false
+#endif
         
         var body: some View {
             PlaySection {
@@ -526,6 +512,9 @@ struct SettingsView: View {
                 Toggle(NSLocalizedString("Presenter mode", comment: "Presenter mode setting label"), isOn: $isPresenterModeEnabled)
                 Toggle(NSLocalizedString("Standalone playback", comment: "Standalone playback setting label"), isOn: $isStandaloneEnabled)
                 Toggle(NSLocalizedString("Section wide support", comment: "Section wide support setting label"), isOn: $isSectionWideSupportEnabled)
+#if os(iOS)
+                Toggle(NSLocalizedString("Add line dividers in episodes list in show pages", comment: "Beta tests toggle label to add line dividers in episodes list in show pages setting label"), isOn: $isMediaListDividerEnabled)
+#endif
                 NextLink {
                     PosterImagesSelectionView()
 #if os(iOS)

--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -138,14 +138,10 @@ struct SettingsView: View {
     }
     
     private struct BetaTestsSection: View {
-        @AppStorage(PlaySRGSettingMediaListLayoutEnabled) var isMediaListLayoutEnabled = false
         @AppStorage(PlaySRGSettingMediaListDividerEnabled) var isMediaListDividerEnabled = false
         
         var body: some View {
             PlaySection {
-                if UIDevice.current.userInterfaceIdiom == .pad {
-                    Toggle(NSLocalizedString("Always display episodes as a list in show pages (iPad)", comment: "Beta tests toggle label to enable episodes as a list in show pages setting label"), isOn: $isMediaListLayoutEnabled)
-                }
                 Toggle(NSLocalizedString("Add line dividers in episodes list in show pages", comment: "Beta tests toggle label to add line dividers in episodes list in show pages setting label"), isOn: $isMediaListDividerEnabled)
             } header: {
                 Text(NSLocalizedString("Beta tests", comment: "Beta tests section header"))

--- a/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
+++ b/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
@@ -25,7 +25,9 @@ extension UserDefaults {
         return string(forKey: PlaySRG.PlaySRGSettingUserLocation)
     }
     
+#if os(iOS) && (DEBUG || NIGHTLY || BETA)
     @objc dynamic var PlaySRGSettingMediaListDividerEnabled: Bool {
         return bool(forKey: PlaySRG.PlaySRGSettingMediaListDividerEnabled)
     }
+#endif
 }

--- a/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
+++ b/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
@@ -28,8 +28,4 @@ extension UserDefaults {
     @objc dynamic var PlaySRGSettingMediaListDividerEnabled: Bool {
         return bool(forKey: PlaySRG.PlaySRGSettingMediaListDividerEnabled)
     }
-    
-    @objc dynamic var PlaySRGSettingMediaListLayoutEnabled: Bool {
-        return bool(forKey: PlaySRG.PlaySRGSettingMediaListLayoutEnabled)
-    }
 }

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -69,7 +69,7 @@ struct MediaCell: View {
     }
     
     private var dividerSpacing: CGFloat {
-        return horizontalSizeClass == .compact ? 8 : 16
+        return constant(iOS: 8, tvOS: 40)
     }
     
     init(media: SRGMedia?, style: Style, layout: Layout = .adaptive, dividerStyle: DividerStyle = .none, action: (() -> Void)? = nil) {


### PR DESCRIPTION
### Motivation and Context

After few betas and beta preview option, decision is to move with media vertical list on iPad show pages.   

### Description

- Only vertical list layout on tablet for the show page.
- No more line divider on show page.
- No more beta test options for the layout for public users.
- Internal beta keeps an opt-in option for line divider for a while.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style:
	-  [ ] `swiftlint` has run to ensure the *Swift* code style is valid.
	-  [ ] `rubocop -a` has run to ensure the *Ruby* code style is valid.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

* The project uses Github merge queue feature, which rebases onto the `develop` branch before merging the PR. 
