### PR TITLE
Rename content section property

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -143,8 +143,7 @@ protocol SectionProperties {
     
 #if os(iOS)
     var sharingItem: SharingItem? { get }
-    
-    var displayingEpisodesOfShow: SRGShow? { get }
+    var displayedShow: SRGShow? { get }
 #endif
     
     /// Analytics information
@@ -286,7 +285,7 @@ private extension Content {
             return SharingItem(for: contentSection)
         }
         
-        var displayingEpisodesOfShow: SRGShow? {
+        var displayedShow: SRGShow? {
             return nil
         }
 #endif
@@ -645,7 +644,7 @@ private extension Content {
             }
         }
         
-        var displayingEpisodesOfShow: SRGShow? {
+        var displayedShow: SRGShow? {
             switch configuredSection {
             case let .show(show):
                 return show

--- a/Application/Sources/UI/Helpers/ContextMenu.swift
+++ b/Application/Sources/UI/Helpers/ContextMenu.swift
@@ -218,8 +218,8 @@ extension ContextMenu {
               let show = media.show,
               let navigationController = viewController.navigationController else { return nil }
         if let sectionViewController = viewController as? SectionViewController,
-           let sectionShow = sectionViewController.model.configuration.properties.displayingEpisodesOfShow {
-            guard !show.isEqual(sectionShow) else { return nil }
+           let displayedShow = sectionViewController.model.configuration.properties.displayedShow {
+            guard !show.isEqual(displayedShow) else { return nil }
         }
         return UIAction(title: NSLocalizedString("More episodes", comment: "Context menu action to open more episodes associated with a media"),
                         image: UIImage(named: "episodes")) { _ in


### PR DESCRIPTION
### Motivation and Context

Code review from `master`and `develop` branches, a property name was no longer understandable.

### Description

- Renaming.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
