### PR TITLE
Improve media and show summary on featured content and media cell 

### DIFF
--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -105,6 +105,14 @@ extension String {
         let size = self.size(withAttributes: fontAttributes)
         return size.width
     }
+    
+    var compactString: String {
+        return self
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "  ", with: " ")
+            .trimmingCharacters(in: .newlines)
+    }
 }
 
 extension Array {

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -106,7 +106,10 @@ extension String {
         return size.width
     }
     
-    var compactString: String {
+    /*
+     * Compact the string to not contain any empty lines.
+     */
+    var compacted: String {
         return self
             .replacingOccurrences(of: "\r", with: " ")
             .replacingOccurrences(of: "\n", with: " ")

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -84,6 +84,11 @@ extension String {
             eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.
             """
     
+    static let loremIpsumWithSpacesAndNewLine: String = """
+            \r\n   Lorem ipsum dolor sit amet.\r\n\r\n\rConsetetur sadipscing elitr, sed diam \
+            nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.\r\n
+            """
+    
     func unobfuscated() -> String {
         return components(separatedBy: .decimalDigits).joined()
     }
@@ -111,10 +116,10 @@ extension String {
      */
     var compacted: String {
         return self
-            .replacingOccurrences(of: "\r", with: " ")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "  ", with: " ")
-            .trimmingCharacters(in: .newlines)
+            .components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: " ")
     }
 }
 

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -112,14 +112,10 @@ extension String {
     }
     
     /*
-     * Compact the string to not contain any empty lines.
+     * Compact the string to not contain any empty lines or white spaces.
      */
     var compacted: String {
-        return self
-            .components(separatedBy: .newlines)
-            .filter { !$0.isEmpty }
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .joined(separator: " ")
+        return self.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression).trimmingCharacters(in: .whitespaces)
     }
 }
 

--- a/Application/Sources/Helpers/SRGMedia.swift
+++ b/Application/Sources/Helpers/SRGMedia.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SRGDataProvider
+
+extension SRGMedia {
+    var play_summary: String? {
+        return leadOrSummary
+    }
+    
+    private var leadOrSummary: String? {
+        return lead?.isEmpty ?? true ? summary : lead
+    }
+}

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -89,7 +89,7 @@ struct FeaturedShowContent: FeaturedContent {
     }
     
     var summary: String? {
-        return show?.play_summary
+        return show?.play_summary?.compacted
     }
     
     var accessibilityLabel: String? {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -89,7 +89,7 @@ enum MediaDescription {
     }
     
     static func summary(for media: SRGMedia) -> String? {
-        return media.summary
+        return media.play_summary?.compacted
     }
     
     static func duration(for media: SRGMedia) -> Double? {

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -178,8 +178,7 @@ struct MediaCell: View {
             guard horizontalSizeClass == .regular, style == .dateAndSummary else { return nil }
             
             guard let media else { return .placeholder(length: 15) }
-            // Compact the summary to not have empty lines.
-            return MediaDescription.summary(for: media)?.compactString
+            return MediaDescription.summary(for: media)
         }
         
         private var mediaDescriptionStyle: MediaDescription.Style {

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -178,7 +178,8 @@ struct MediaCell: View {
             guard horizontalSizeClass == .regular, style == .dateAndSummary else { return nil }
             
             guard let media else { return .placeholder(length: 15) }
-            return MediaDescription.summary(for: media)
+            // Compact the summary to not have empty lines.
+            return MediaDescription.summary(for: media)?.compactString
         }
         
         private var mediaDescriptionStyle: MediaDescription.Style {

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -30,7 +30,7 @@ struct TruncatableTextView: View {
     
     init(content: String, lineLimit: Int?, showMore: @escaping () -> Void) {
         // Compact the content to not have "show more" button floating alone at bottom right.
-        self.content = content.compactString
+        self.content = content.compacted
         
         self.lineLimit = lineLimit
         self.showMore = showMore

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -30,11 +30,7 @@ struct TruncatableTextView: View {
     
     init(content: String, lineLimit: Int?, showMore: @escaping () -> Void) {
         // Compact the content to not have "show more" button floating alone at bottom right.
-        self.content = content
-            .replacingOccurrences(of: "\r", with: " ")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "  ", with: " ")
-            .trimmingCharacters(in: .newlines)
+        self.content = content.compactString
         
         self.lineLimit = lineLimit
         self.showMore = showMore

--- a/Application/Sources/UI/Views/TruncatableTextView.swift
+++ b/Application/Sources/UI/Views/TruncatableTextView.swift
@@ -175,6 +175,7 @@ struct TruncableTextView_Previews: PreviewProvider {
             TruncatableTextView(content: String.loremIpsum, lineLimit: 3) {}
                 .foregroundColor(.white)
                 .secondaryColor(.srgGray96)
+            TruncatableTextView(content: String.loremIpsumWithSpacesAndNewLine, lineLimit: 3) {}
         }
         .frame(width: 375)
         .previewLayout(.sizeThatFits)

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -57,6 +57,15 @@
 		0456C4A82976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
 		0456C4A92976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
 		0456C4AA2976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
+		04C02F9429EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9529EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9629EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9729EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9829EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9929EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9A29EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9B29EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
+		04C02F9C29EECAE4008C747E /* SRGMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C02F9329EECAE3008C747E /* SRGMedia.swift */; };
 		04C2DE782937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
 		04C2DE792937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
 		04C2DE7A2937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
@@ -2749,6 +2758,7 @@
 		0451ECE228742D8000E89975 /* UIWindow+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+PlaySRG.swift"; sourceTree = "<group>"; };
 		0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsHiddenEvent.swift; sourceTree = "<group>"; };
 		0497D5FE29D4B626005BF060 /* REMOTE_CONFIGURATION.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = REMOTE_CONFIGURATION.md; path = docs/REMOTE_CONFIGURATION.md; sourceTree = "<group>"; };
+		04C02F9329EECAE3008C747E /* SRGMedia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SRGMedia.swift; sourceTree = "<group>"; };
 		04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClickEvent.swift; sourceTree = "<group>"; };
 		04D21DBB299BEB42009CEA15 /* TruncatableTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TruncatableTextView.swift; sourceTree = "<group>"; };
 		04D2A92A29ACFE5900E11B28 /* Handle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handle.swift; sourceTree = "<group>"; };
@@ -3946,6 +3956,7 @@
 				08AF947E217D27E40028B082 /* SharingItem.h */,
 				08AF947F217D27E40028B082 /* SharingItem.m */,
 				6F74293C265BE52E0000538D /* Signals.swift */,
+				04C02F9329EECAE3008C747E /* SRGMedia.swift */,
 				044E391F29B10C9100C1768A /* SRGShow.swift */,
 				6F00875B219AA888004BD6FF /* StoreReview.h */,
 				6F00875C219AA888004BD6FF /* StoreReview.m */,
@@ -8396,6 +8407,7 @@
 				08AA551D1D49EBF600C5026E /* ApplicationConfiguration.m in Sources */,
 				6FB90D18270D91010033D860 /* CarPlayList.swift in Sources */,
 				6F5FAA44268CB88C007F0CA8 /* Localization.swift in Sources */,
+				04C02F9429EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6FDF08D7218B126700B2AF2C /* Download.m in Sources */,
 				6FC2A21C265E3D2300EBC0F0 /* SectionShowHeaderView.swift in Sources */,
 				6FCA5BDC27D9DE4C00916D0B /* DiskInfoFooterViewModel.swift in Sources */,
@@ -8727,6 +8739,7 @@
 				6FE8626D2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				6FC8866C1EC58BD5000BC3FF /* SRGProgram+PlaySRG.m in Sources */,
 				0827DA1F1F0D36E200A31A42 /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9529EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6F54D35A26050FE5008B46FF /* MediaVisualView.swift in Sources */,
 				6F0EDA662448B0D800F0FED2 /* RefreshControl.m in Sources */,
 				6F80E9C321A682E70027CA2F /* TableRequestViewController.m in Sources */,
@@ -8986,6 +8999,7 @@
 				6FE8626E2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				6FC8866D1EC58BD5000BC3FF /* SRGProgram+PlaySRG.m in Sources */,
 				0827DA201F0D36E200A31A42 /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9629EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6F54D35B26050FE5008B46FF /* MediaVisualView.swift in Sources */,
 				6F0EDA672448B0D800F0FED2 /* RefreshControl.m in Sources */,
 				6F80E9C421A682E70027CA2F /* TableRequestViewController.m in Sources */,
@@ -9245,6 +9259,7 @@
 				6FE8626F2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				6FC8866E1EC58BD5000BC3FF /* SRGProgram+PlaySRG.m in Sources */,
 				0827DA211F0D36E400A31A42 /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9729EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6F54D35C26050FE6008B46FF /* MediaVisualView.swift in Sources */,
 				6F0EDA682448B0D800F0FED2 /* RefreshControl.m in Sources */,
 				6F80E9C521A682E70027CA2F /* TableRequestViewController.m in Sources */,
@@ -9391,6 +9406,7 @@
 				04D5478127BFFE79003D1BC2 /* LoadingCell.swift in Sources */,
 				0825914427285ACD00E2F8F7 /* ProgramGuideHeaderView.swift in Sources */,
 				088899492077628500242654 /* TVChannel.m in Sources */,
+				04C02F9829EECAE4008C747E /* SRGMedia.swift in Sources */,
 				E66BEC201DA7FCED00AD4450 /* MediaPlayerViewController.m in Sources */,
 				6F8BE02B27A7CA85009FE094 /* ProgramGuideChildViewController.swift in Sources */,
 				6F2DE05726440FB20059335E /* ActivityIndicator.swift in Sources */,
@@ -9737,6 +9753,7 @@
 				04FE629F29A4F2AF00628570 /* TruncatableTextView.swift in Sources */,
 				6F026EED250134FD00BAE8D1 /* UIView+PlaySRG.m in Sources */,
 				6F6C0FA8257AAF240077322C /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9929EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6FD1EF3C2861A39400BCBF19 /* PlaySection.swift in Sources */,
 				6F5FAA49268CB88C007F0CA8 /* Localization.swift in Sources */,
 				6F6B5BB825E640A600F549E7 /* WatchLater.m in Sources */,
@@ -9891,6 +9908,7 @@
 				6FA8E599261CB792003FFDCF /* DataViewController.m in Sources */,
 				6F026EEE250134FE00BAE8D1 /* UIView+PlaySRG.m in Sources */,
 				6F6C0FBD257AAF250077322C /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9A29EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6FD1EF3D2861A39400BCBF19 /* PlaySection.swift in Sources */,
 				6F5FAA4A268CB88C007F0CA8 /* Localization.swift in Sources */,
 				6F6B5BB925E640A600F549E7 /* WatchLater.m in Sources */,
@@ -10045,6 +10063,7 @@
 				6FA8E59A261CB792003FFDCF /* DataViewController.m in Sources */,
 				6F026EEF250134FE00BAE8D1 /* UIView+PlaySRG.m in Sources */,
 				6F6C0FBE257AAF250077322C /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9B29EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6FD1EF3E2861A39400BCBF19 /* PlaySection.swift in Sources */,
 				6F5FAA4B268CB88C007F0CA8 /* Localization.swift in Sources */,
 				6F6B5BCE25E640A700F549E7 /* WatchLater.m in Sources */,
@@ -10199,6 +10218,7 @@
 				6FA8E5B4261CB793003FFDCF /* DataViewController.m in Sources */,
 				6F026EF0250134FF00BAE8D1 /* UIView+PlaySRG.m in Sources */,
 				6F6C0FBF257AAF260077322C /* NSBundle+PlaySRG.m in Sources */,
+				04C02F9C29EECAE4008C747E /* SRGMedia.swift in Sources */,
 				6FD1EF3F2861A39400BCBF19 /* PlaySection.swift in Sources */,
 				6F5FAA4C268CB88C007F0CA8 /* Localization.swift in Sources */,
 				6F6B5BCF25E640A800F549E7 /* WatchLater.m in Sources */,


### PR DESCRIPTION
### Motivation and Context

Following #306, @svenduvoisin and @Loic-Dumas found RSI content issue on the new show page on iPad:
- Description with empty lines.
- Media lead and description used differently on Play web and between application items (featured content, media detail page). 

### Description

- Prefer lead for media summary, fallback to description if lead is empty.
- Compact media summary in media cell (for iPad).
- Compact media summary in featured content section.
- Compact show summary in featured content section.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
