### PR TITLE
Add local configuration for source code url

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -8,6 +8,7 @@
   "playURL": "https://www.rsi.ch/play/",
   "playServiceURL": "https://www.rsi.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
+  "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",
   "supportEmailAddress": "info@rsi.ch",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite",
   "tvLiveHomeSections": "tvLive,radioLive,radioLiveSatellite",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -7,6 +7,7 @@
   "playURL": "https://www.rtr.ch/play/",
   "playServiceURL": "https://www.rtr.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
+  "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvScheduledLivestreams",
   "tvLiveHomeSections": "tvLive,tvScheduledLivestreams,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioLatestEpisodes,radioWatchLater",

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -11,6 +11,7 @@
   "identityWebserviceURL": "https://hummingbird.rts.ch/api/profile",
   "identityWebsiteURL": "https://www.rts.ch/profile",
   "userDataServiceURL": "https://profil.rts.ch/api",
+  "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",
   "supportEmailAddress": "support.play@rts.ch",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvScheduledLivestreams",
   "tvLiveHomeSections": "tvLive,tvScheduledLivestreams,radioLive,radioLiveSatellite",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -8,6 +8,7 @@
   "playURL": "https://www.srf.ch/play/",
   "playServiceURL": "https://www.srf.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
+  "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",
   "liveHomeSections": "tvLive,radioLive,radioLiveSatellite,tvLiveCenterScheduledLivestreams,tvLiveCenterEpisodes",
   "tvLiveHomeSections": "tvLive,tvLiveCenterScheduledLivestreams,tvLiveCenterEpisodes,radioLive,radioLiveSatellite",
   "audioHomeSections": "radioLatest,radioShowsAccess,radioFavoriteShows,radioLatestEpisodesFromFavorites,radioResumePlayback,radioMostPopular,radioLatestEpisodes,radioWatchLater",

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -8,6 +8,7 @@
   "playURL": "https://play.swissinfo.ch/play/",
   "playServiceURL": "https://play.swissinfo.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
+  "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",
   "minimumSocialViewCount": 50,
   "dataProtectionURL": "https://www.swissinfo.ch/eng/data-privacy-statement/133174",
   "whatsNewURL": "https://srgssr.github.io/playsrg-apple/releases/release_notes-ios-swi.html",


### PR DESCRIPTION
### Motivation and Context

A SRF user reported  than the code source url in application settings returns 404.

Remote configuration had the old github urls: https://github.com/SRGSSR/playsrg-ios
Github stopped the redirection after a while.

Remote configuration is now updated. Local configuration could be updated as well.

### Description

- Add local configuration for source code url.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
