### PR TITLE
Update SwiftLint to 0.52.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,7 @@ opt_in_rules:
   - contains_over_first_not_nil
   - contains_over_range_nil_comparison
   - convenience_type
+  - direct_return
   - discarded_notification_center_observer
   - discouraged_assert
   - discouraged_object_literal
@@ -71,6 +72,7 @@ opt_in_rules:
   - prohibited_super_call
   - raw_value_for_camel_cased_codable_enum
   - redundant_nil_coalescing
+  - redundant_self_in_closure
   - redundant_type_annotation
   - required_enum_case
   - return_value_from_void_function
@@ -79,6 +81,7 @@ opt_in_rules:
   - switch_case_on_newline
   - test_case_accessibility
   - toggle_bool
+  - unhandled_throwing_task
   - unneeded_parentheses_in_closure_argument
   - unowned_variable_capture
   - untyped_error_in_catch

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -43,7 +43,7 @@ enum Content {
 #endif
         
         case highlightPlaceholder(index: Int)
-        case highlight(_ highlight: Highlight, item: Item?)
+        case highlight(_ highlight: Highlight, item: Self?)
         
         case transparent
         
@@ -68,12 +68,12 @@ enum Content {
             }
         }
         
-        static func groupAlphabetically(_ items: [Item]) -> [(key: Character, value: [Item])] {
+        static func groupAlphabetically(_ items: [Self]) -> [(key: Character, value: [Self])] {
             return items.groupedAlphabetically { $0.title }
         }
     }
     
-    static func medias(from items: [Content.Item]) -> [SRGMedia] {
+    static func medias(from items: [Self.Item]) -> [SRGMedia] {
         return items.compactMap { item in
             if case let .media(media) = item {
                 return media
@@ -85,7 +85,7 @@ enum Content {
     }
     
 #if os(iOS)
-    static func downloads(from items: [Content.Item]) -> [Download] {
+    static func downloads(from items: [Self.Item]) -> [Download] {
         return items.compactMap { item in
             if case let .download(download) = item {
                 return download
@@ -96,7 +96,7 @@ enum Content {
         }
     }
     
-    static func notifications(from items: [Content.Item]) -> [UserNotification] {
+    static func notifications(from items: [Self.Item]) -> [UserNotification] {
         return items.compactMap { item in
             if case let .notification(notification) = item {
                 return notification
@@ -108,7 +108,7 @@ enum Content {
     }
 #endif
     
-    static func shows(from items: [Content.Item]) -> [SRGShow] {
+    static func shows(from items: [Self.Item]) -> [SRGShow] {
         return items.compactMap { item in
             if case let .show(show) = item {
                 return show

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -144,14 +144,14 @@ final class PageViewController: UIViewController {
         
         let globalHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<TitleView>>(elementKind: Header.global.rawValue) { [weak self] view, _, _ in
             guard let self else { return }
-            view.content = TitleView(text: self.globalHeaderTitle)
+            view.content = TitleView(text: globalHeaderTitle)
         }
         
         let sectionHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<SectionHeaderView>>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] view, _, indexPath in
             guard let self else { return }
-            let snapshot = self.dataSource.snapshot()
+            let snapshot = dataSource.snapshot()
             let section = snapshot.sectionIdentifiers[indexPath.section]
-            view.content = SectionHeaderView(section: section, pageId: self.model.id)
+            view.content = SectionHeaderView(section: section, pageId: model.id)
         }
         
         dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
@@ -180,8 +180,8 @@ final class PageViewController: UIViewController {
         
         NotificationCenter.default.weakPublisher(for: UIAccessibility.voiceOverStatusDidChangeNotification)
             .sink { [weak self] _ in
-                guard let self, self.play_isViewCurrent else { return }
-                self.updateNavigationBar(animated: true)
+                guard let self, play_isViewCurrent else { return }
+                updateNavigationBar(animated: true)
             }
             .store(in: &cancellables)
 #endif

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -126,13 +126,13 @@ final class PageViewModel: Identifiable, ObservableObject {
             ApplicationSignal.wokenUp()
                 .filter { [weak self] in
                     guard let self else { return false }
-                    return self.state.sections.isEmpty
+                    return state.sections.isEmpty
                 },
             ApplicationSignal.foregroundAfterTimeInBackground(),
             ApplicationSignal.applicationConfigurationUpdate()
                 .filter { [weak self] in
                     guard let self else { return false }
-                    return self.id.isConfigured
+                    return id.isConfigured
                 }
         )
         .throttle(for: 0.5, scheduler: DispatchQueue.main, latest: false)

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -119,11 +119,11 @@ final class SectionViewController: UIViewController {
         
         let cellRegistration = UICollectionView.CellRegistration<HostCollectionViewCell<ItemCell>, SectionViewModel.Item> { [weak self] cell, indexPath, item in
             guard let self else { return }
-            let section = self.dataSource.snapshot().sectionIdentifiers[indexPath.section]
-            let isLastItem = indexPath.row + 1 == self.dataSource.snapshot().numberOfItems(inSection: section)
-            cell.content = ItemCell(item: item, configuration: self.model.configuration, isLastItem: isLastItem)
+            let section = dataSource.snapshot().sectionIdentifiers[indexPath.section]
+            let isLastItem = indexPath.row + 1 == dataSource.snapshot().numberOfItems(inSection: section)
+            cell.content = ItemCell(item: item, configuration: model.configuration, isLastItem: isLastItem)
             if let hostController = cell.hostController {
-                self.addChild(hostController)
+                addChild(hostController)
             }
         }
         
@@ -133,29 +133,29 @@ final class SectionViewController: UIViewController {
         
         let globalHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<TitleView>>(elementKind: Header.global.rawValue) { [weak self] view, _, _ in
             guard let self else { return }
-            view.content = TitleView(text: self.globalHeaderTitle)
+            view.content = TitleView(text: globalHeaderTitle)
             if let hostController = view.hostController {
-                self.addChild(hostController)
+                addChild(hostController)
             }
         }
         
         let sectionHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<SectionHeaderView>>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] view, _, indexPath in
             guard let self else { return }
-            let snapshot = self.dataSource.snapshot()
+            let snapshot = dataSource.snapshot()
             let section = snapshot.sectionIdentifiers[indexPath.section]
-            view.content = SectionHeaderView(section: section, configuration: self.model.configuration)
+            view.content = SectionHeaderView(section: section, configuration: model.configuration)
             if let hostController = view.hostController {
-                self.addChild(hostController)
+                addChild(hostController)
             }
         }
         
         let sectionFooterViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<SectionFooterView>>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] view, _, indexPath in
             guard let self else { return }
-            let snapshot = self.dataSource.snapshot()
+            let snapshot = dataSource.snapshot()
             let section = snapshot.sectionIdentifiers[indexPath.section]
             view.content = SectionFooterView(section: section)
             if let hostController = view.hostController {
-                self.addChild(hostController)
+                addChild(hostController)
             }
         }
         
@@ -184,8 +184,8 @@ final class SectionViewController: UIViewController {
             .sink { [weak self] _ in
                 guard let self else { return }
                 
-                self.contentInsets = Self.contentInsets(for: self.model.state, displayDivider: self.model.configuration.viewModelProperties.displayDivider)
-                self.collectionView.reloadData()
+                contentInsets = Self.contentInsets(for: model.state, displayDivider: model.configuration.viewModelProperties.displayDivider)
+                collectionView.reloadData()
             }
             .store(in: &cancellables)
 #endif

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -103,7 +103,7 @@ final class SectionViewModel: ObservableObject {
             ApplicationSignal.wokenUp()
                 .filter { [weak self] in
                     guard let self else { return false }
-                    return !self.state.hasContent
+                    return !state.hasContent
                 },
             ApplicationSignal.foregroundAfterTimeInBackground()
         )

--- a/Application/Sources/Helpers/AnalyticsClickEvent.swift
+++ b/Application/Sources/Helpers/AnalyticsClickEvent.swift
@@ -26,7 +26,7 @@ struct AnalyticsClickEvent {
         SRGAnalyticsTracker.shared.trackHiddenEvent(withName: name, labels: labels)
     }
     
-    static func tvGuideOpenInfoBox(program: SRGProgram, programGuideLayout: ProgramGuideLayout) -> AnalyticsClickEvent {
+    static func tvGuideOpenInfoBox(program: SRGProgram, programGuideLayout: ProgramGuideLayout) -> Self {
         return Self(
             name: "TvGuideOpenInfoBox",
             value1: PageId.tvGuide.rawValue,
@@ -41,7 +41,7 @@ struct AnalyticsClickEvent {
         case grid = "Grid"
     }
     
-    static func tvGuidePlayLivestream(program: SRGProgram, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> AnalyticsClickEvent {
+    static func tvGuidePlayLivestream(program: SRGProgram, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> Self {
         return Self(
             name: "TvGuidePlayLivestream",
             value1: PageId.tvGuide.rawValue,
@@ -51,7 +51,7 @@ struct AnalyticsClickEvent {
         )
     }
     
-    static func tvGuidePlayMedia(media: SRGMedia, programIsLive: Bool, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> AnalyticsClickEvent {
+    static func tvGuidePlayMedia(media: SRGMedia, programIsLive: Bool, channel: SRGChannel, source: TvGuidePlaySource = .infoBox) -> Self {
         return Self(
             name: "TvGuidePlayMedia",
             value1: PageId.tvGuide.rawValue,
@@ -61,35 +61,35 @@ struct AnalyticsClickEvent {
         )
     }
     
-    static func tvGuideNow() -> AnalyticsClickEvent {
+    static func tvGuideNow() -> Self {
         return Self(
             name: "DateSelectionNowClick",
             value1: PageId.tvGuide.rawValue
         )
     }
     
-    static func tvGuideTonight() -> AnalyticsClickEvent {
+    static func tvGuideTonight() -> Self {
         return Self(
             name: "DateSelectionTonightClick",
             value1: PageId.tvGuide.rawValue
         )
     }
     
-    static func tvGuidePreviousDay() -> AnalyticsClickEvent {
+    static func tvGuidePreviousDay() -> Self {
         return Self(
             name: "DateSelectionPreviousDayClick",
             value1: PageId.tvGuide.rawValue
         )
     }
     
-    static func tvGuideNextDay() -> AnalyticsClickEvent {
+    static func tvGuideNextDay() -> Self {
         return Self(
             name: "DateSelectionNextDayClick",
             value1: PageId.tvGuide.rawValue
         )
     }
     
-    static func tvGuideCalendar(to selectedDate: Date) -> AnalyticsClickEvent {
+    static func tvGuideCalendar(to selectedDate: Date) -> Self {
         return Self(
             name: "DateSelectionCalendarClick",
             value1: DateFormatter.play_iso8601Calendar().string(from: selectedDate),
@@ -97,7 +97,7 @@ struct AnalyticsClickEvent {
         )
     }
     
-    static func tvGuideChangeLayout(to programGuideLayout: ProgramGuideLayout) -> AnalyticsClickEvent {
+    static func tvGuideChangeLayout(to programGuideLayout: ProgramGuideLayout) -> Self {
         return Self(
             name: "TvGuideSwitchLayout",
             value1: PageId.tvGuide.rawValue,

--- a/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
+++ b/Application/Sources/Helpers/AnalyticsHiddenEvent.swift
@@ -22,7 +22,7 @@ struct AnalyticsHiddenEvent {
         SRGAnalyticsTracker.shared.trackHiddenEvent(withName: name, labels: labels)
     }
     
-    static func calendarEventAdd(channel: SRGChannel) -> AnalyticsHiddenEvent {
+    static func calendarEventAdd(channel: SRGChannel) -> Self {
         return Self(
             name: "calendar_add",
             source: "button",
@@ -31,7 +31,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String) -> AnalyticsHiddenEvent {
+    static func continuousPlayback(action: AnalyticsContiniousPlaybackAction, mediaUrn: String) -> Self {
         return Self(
             name: "continuous_playback",
             source: action.source,
@@ -40,7 +40,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func download(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func download(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> Self {
         return Self(
             name: action.downloadName,
             source: source.value,
@@ -48,7 +48,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func favorite(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func favorite(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> Self {
         return Self(
             name: action.favoriteName,
             source: source.value,
@@ -56,14 +56,14 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func googleGast(urn: String) -> AnalyticsHiddenEvent {
+    static func googleGast(urn: String) -> Self {
         return Self(
             name: "google_cast",
             value: urn
         )
     }
     
-    static func historyRemove(source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func historyRemove(source: AnalyticsListSource, urn: String?) -> Self {
         return Self(
             name: "history_remove",
             source: source.value,
@@ -71,14 +71,14 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func identity(action: AnalyticsIdentityAction) -> AnalyticsHiddenEvent {
+    static func identity(action: AnalyticsIdentityAction) -> Self {
         return Self(
             name: "identity",
             labels: action.labels
         )
     }
     
-    static func notification(action: AnalyticsNotificationAction, from: AnalyticsNotificationFrom, uid: String, overrideSource: String? = nil, overrideType: String? = nil) -> AnalyticsHiddenEvent {
+    static func notification(action: AnalyticsNotificationAction, from: AnalyticsNotificationFrom, uid: String, overrideSource: String? = nil, overrideType: String? = nil) -> Self {
         return Self(
             name: from.name,
             source: overrideSource ?? from.source,
@@ -87,7 +87,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func openUrl(action: AnalyticsOpenUrlAction, source: AnalyticsOpenUrlSource, urn: String?) -> Self {
         return Self(
             name: "open_url",
             source: source.value,
@@ -96,14 +96,14 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func pictureInPicture(urn: String?) -> AnalyticsHiddenEvent {
+    static func pictureInPicture(urn: String?) -> Self {
         return Self(
             name: "picture_in_picture",
             value: urn
         )
     }
     
-    static func sharing(action: AnalyticsSharingAction, uid: String, mediaContentType: AnalyticsSharingMediaContentType, source: AnalyticsSharingSource, type: String?) -> AnalyticsHiddenEvent {
+    static func sharing(action: AnalyticsSharingAction, uid: String, mediaContentType: AnalyticsSharingMediaContentType, source: AnalyticsSharingSource, type: String?) -> Self {
         return Self(
             name: action.name,
             source: source.value,
@@ -113,14 +113,14 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func shortcutItem(action: AnalyticsShortcutItemAction) -> AnalyticsHiddenEvent {
+    static func shortcutItem(action: AnalyticsShortcutItemAction) -> Self {
         return Self(
             name: "quick_actions",
             type: action.type
         )
     }
     
-    static func subscription(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func subscription(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> Self {
         return Self(
             name: action.subscriptionName,
             source: source.value,
@@ -128,7 +128,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func userActivity(action: AnalyticsUserActivityAction, urn: String) -> AnalyticsHiddenEvent {
+    static func userActivity(action: AnalyticsUserActivityAction, urn: String) -> Self {
         return Self(
             name: "user_activity_ios",
             source: "handoff",
@@ -137,7 +137,7 @@ struct AnalyticsHiddenEvent {
         )
     }
     
-    static func watchLater(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> AnalyticsHiddenEvent {
+    static func watchLater(action: AnalyticsListAction, source: AnalyticsListSource, urn: String?) -> Self {
         return Self(
             name: action.watchLaterName,
             source: source.value,

--- a/Application/Sources/Model/ServiceMessage.swift
+++ b/Application/Sources/Model/ServiceMessage.swift
@@ -17,7 +17,7 @@ struct ServiceMessage: Codable, Identifiable, Equatable {
         return data.text
     }
     
-    static func == (lhs: ServiceMessage, rhs: ServiceMessage) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.id == rhs.id
     }
     

--- a/Application/Sources/Onboarding/OnboardingViewController.swift
+++ b/Application/Sources/Onboarding/OnboardingViewController.swift
@@ -24,7 +24,7 @@ final class OnboardingViewController: BaseViewController {
     
     static func viewController(for onboarding: Onboarding!) -> OnboardingViewController {
         let storyboard = UIStoryboard(name: "OnboardingViewController", bundle: nil)
-        let viewController = storyboard.instantiateInitialViewController() as! OnboardingViewController
+        let viewController = storyboard.instantiateInitialViewController() as! Self
         viewController.onboarding = onboarding
         viewController.title = onboarding.title
         return viewController

--- a/Application/Sources/ProgramGuide/ProgramCell.swift
+++ b/Application/Sources/ProgramGuide/ProgramCell.swift
@@ -112,7 +112,7 @@ struct ProgramCell: View {
             }
             .cornerRadius(4)
             .readSize { size in
-                self.availableSize = size
+                availableSize = size
             }
         }
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
@@ -106,9 +106,9 @@ final class ProgramGuideDailyViewController: UIViewController {
                 guard let self else { return }
                 switch change {
                 case let .time(time):
-                    self.scrollToTime(time, animated: true)
+                    scrollToTime(time, animated: true)
                 case .channel:
-                    self.scrollToTime(self.programGuideModel.time, animated: false)
+                    scrollToTime(programGuideModel.time, animated: false)
                 default:
                     break
                 }

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -160,7 +160,7 @@ extension ProgramGuideDailyViewModel {
         case content(firstPartyBouquet: Bouquet, thirdPartyBouquet: Bouquet, day: SRGDay)
         case failed(error: Error)
         
-        fileprivate static func loading(firstPartyChannels: [SRGChannel], thirdPartyChannels: [SRGChannel], day: SRGDay) -> State {
+        fileprivate static func loading(firstPartyChannels: [SRGChannel], thirdPartyChannels: [SRGChannel], day: SRGDay) -> Self {
             return .content(firstPartyBouquet: .loading(channels: firstPartyChannels), thirdPartyBouquet: .loading(channels: thirdPartyChannels), day: day)
         }
         

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -100,7 +100,7 @@ final class ProgramGuideGridViewController: UIViewController {
         
         let headerViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<ChannelHeaderView>>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] view, _, indexPath in
             guard let self else { return }
-            let snapshot = self.dataSource.snapshot()
+            let snapshot = dataSource.snapshot()
             let channel = snapshot.sectionIdentifiers[indexPath.section]
             view.content = ChannelHeaderView(channel: channel)
         }
@@ -124,12 +124,12 @@ final class ProgramGuideGridViewController: UIViewController {
                 guard let self else { return }
                 switch change {
                 case let .day(day):
-                    self.dailyModel.day = day
+                    dailyModel.day = day
                 case let .time(time):
-                    self.scrollToTarget(ScrollTarget(time: time), animated: true)
+                    scrollToTarget(ScrollTarget(time: time), animated: true)
                 case let .dayAndTime(day: day, time: time):
-                    self.dailyModel.day = day
-                    self.scrollToTarget(ScrollTarget(time: time), animated: true)
+                    dailyModel.day = day
+                    scrollToTarget(ScrollTarget(time: time), animated: true)
                 default:
                     break
                 }

--- a/Application/Sources/Search/SearchViewController.swift
+++ b/Application/Sources/Search/SearchViewController.swift
@@ -105,9 +105,9 @@ final class SearchViewController: UIViewController {
         
         let sectionHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<SectionHeaderView>>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] view, _, indexPath in
             guard let self else { return }
-            let snapshot = self.dataSource.snapshot()
+            let snapshot = dataSource.snapshot()
             let section = snapshot.sectionIdentifiers[indexPath.section]
-            view.content = SectionHeaderView(section: section, settings: self.model.settings)
+            view.content = SectionHeaderView(section: section, settings: model.settings)
         }
         
         dataSource.supplementaryViewProvider = { collectionView, _, indexPath in
@@ -117,9 +117,9 @@ final class SearchViewController: UIViewController {
         model.$state
             .sink { [weak self] state in
                 guard let self else { return }
-                self.reloadData(for: state)
+                reloadData(for: state)
 #if os(tvOS)
-                guard let searchController = self.searchController else { return }
+                guard let searchController = searchController else { return }
                 if case let .loaded(rows: _, suggestions: suggestions) = state {
                     if let suggestions {
                         searchController.searchSuggestions = suggestions.map { UISearchSuggestionItem(localizedSuggestion: $0.text) }

--- a/Application/Sources/Search/SearchViewModel.swift
+++ b/Application/Sources/Search/SearchViewModel.swift
@@ -63,7 +63,7 @@ final class SearchViewModel: ObservableObject {
             ApplicationSignal.wokenUp()
                 .filter { [weak self] in
                     guard let self else { return false }
-                    return !self.state.hasContent
+                    return !state.hasContent
                 },
             ApplicationSignal.foregroundAfterTimeInBackground()
         )

--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -64,7 +64,7 @@ struct Service: Identifiable, Equatable {
     
     static var services: [Service] = [production, stage, test, mmf, samProduction, samStage, samTest]
     
-    static func service(forId id: String?) -> Service {
+    static func service(forId id: String?) -> Self {
 #if DEBUG || NIGHTLY || BETA
         guard let id, let server = services.first(where: { $0.id == id }) else {
             return .production

--- a/Application/Sources/UI/Views/ImageView.swift
+++ b/Application/Sources/UI/Views/ImageView.swift
@@ -55,7 +55,7 @@ struct ImageView: View {
     let source: ImageRequestConvertible?
     let contentMode: ContentMode
     
-    private static func alignment(for contentMode: ImageView.ContentMode) -> Alignment {
+    private static func alignment(for contentMode: Self.ContentMode) -> Alignment {
         switch contentMode {
         case .aspectFit, .aspectFill, .center, .fill, .aspectFillFocused:
             return .center

--- a/Application/Sources/UI/Views/LiveMediaCellViewModel.swift
+++ b/Application/Sources/UI/Views/LiveMediaCellViewModel.swift
@@ -34,7 +34,7 @@ final class LiveMediaCellViewModel: ObservableObject {
         if let media, let channel = media.channel, media.contentType == .livestream {
             channelObserver = ChannelService.shared.addObserverForUpdates(with: channel, livestreamUid: media.uid) { [weak self] composition in
                 guard let self else { return }
-                self.programComposition = composition
+                programComposition = composition
             }
         }
     }

--- a/TV Application/Sources/ExpandingCardButton.swift
+++ b/TV Application/Sources/ExpandingCardButton.swift
@@ -31,7 +31,7 @@ struct ExpandingCardButton<Content: View>: View {
                 content()
                     .frame(width: geometry.size.width, height: geometry.size.height)
                     .onParentFocusChange { focused in
-                        if let onFocusAction = self.onFocusChangeAction {
+                        if let onFocusAction = onFocusChangeAction {
                             onFocusAction(focused)
                         }
                         isFocused = focused

--- a/TV Application/Sources/LabeledCardButton.swift
+++ b/TV Application/Sources/LabeledCardButton.swift
@@ -40,7 +40,7 @@ struct LabeledCardButton<Content: View, Label: View>: View {
             .onFocusChange { focused in
                 isFocused = focused
                 
-                if let onFocusAction = self.onFocusChangeAction {
+                if let onFocusAction = onFocusChangeAction {
                     onFocusAction(focused)
                 }
             }


### PR DESCRIPTION
### Motivation and Context

Following https://github.com/SRGSSR/pillarbox-apple/pull/365

The CI now uses SwiftLint 0.52.1 version.

### Description

- Update Swift code, according to the syntax improvements introduced in Swift 5.8 like implicit self in closures.
- Add new opt-in rules and update Swift code.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
