### PR TITLE
Improve push notification documentation

### DIFF
--- a/docs/PUSH_NOTIFICATIONS.md
+++ b/docs/PUSH_NOTIFICATIONS.md
@@ -10,8 +10,10 @@ Push notifications are sent via [Airship](https://www.airship.com), whose SDK is
 1. Pick the project corresponding to the Play SRG application you are using.
 1. Click the + button and choose _Message_. Then proceed through the required steps to create a realistic push notification:
     1. _Audience_: Either restrict to iOS or enable both platforms and select a user base (simply _All Users_ if you don't mind bothering all users).
-    1. _Content_: Select _Push notification_ and click the _Add content_ button. Set a text (notification body) and check the optional _Title_ feature to provide a title.
-    1. _Delivery_: Select _Send Now_ and enable _Mutable Content_ as well as _Badge_ (increment by +1). Also add the following _Custom Keys_ that describe the content associated with the push notification:
+    1. _Content_: Select _Push notification_, click the _Add content_ button and then:
+    	- Set a `text` (notification body / description).
+    	- Enable _Title_ optional feature to provide a `title` (notification title).
+    1. _Delivery_: Select _Send Now_ and add the following _Custom Keys_ that describe the content associated with the push notification:
         - `media`: The URN of the media you picked.
         - `show`: The URN of the show you picked and subscribed to.
         - `type`: Set to `newod` (new on-demand).
@@ -22,11 +24,16 @@ Push notifications are sent via [Airship](https://www.airship.com), whose SDK is
         - `channelId`: The id of the radio channel which the show belongs to (if none simply omit this field).
         - `startTime`: The time at which to start playback, in seconds. Omit this field to start at the default position.
 
+        Then in _iOS Options_ section:
+        
+        - Enable _Mutable Content_ to allow notification extension service to download image and store notifications locally.
+        - Enable _Badge_ with `increment by +1` option. 
+
     1. _Review & Send_: Click on _Send Message_ and observe your test device. Using debug builds you can also set breakpoints and inspect the app or extension code as needed.
 
 #### Remark
 
-To check that your setup is working you can initially create very a basic push notification containing a simple body, omitting all other fields. This notification will be processed by the app but will not provide any action or image.
+To check that your setup is working you can initially create very a basic push notification containing a simple body, omitting all other fields. This notification will be processed by the app but will not provide any action or image, and won't be stored locally to be display then in the application (if not opened from the notification itself).
 
 ## Observe push status messages
 


### PR DESCRIPTION
### Motivation and Context

Tiny improvement in the Push notification documentation.

### Description

- Split AirShip  _Content_ step in more detail sections and bullet points.
- Update basic push notification behavior.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
