### PR TITLE
Prepare betas

### DIFF
--- a/WhatsNew-iOS-beta.json
+++ b/WhatsNew-iOS-beta.json
@@ -188,5 +188,6 @@
   "3.6.11-409": "- Update unplayable downloaded videos.",
     "3.6.12-410": "- iPhone and iPad: An opt-out option for beta testers to disable a preview of a new layout on show page.\n- A better pronunciation of \"more\" with VoiceOver in show page.",
     "3.6.12-411": "- Improved readability on show pages with a vertical list on iPad.\n- Get a better summary text on media and show elements on homepage and topic pages.\n- Metrics cleanup.",
-    "3.6.13-412": "- AppStore release with internal dependency updates."
+    "3.6.13-412": "- AppStore release with internal dependency updates.",
+    "3.7.0-413": "- Add help and contact in Profile tab."
 }

--- a/WhatsNew-tvOS-beta.json
+++ b/WhatsNew-tvOS-beta.json
@@ -58,5 +58,6 @@
   "1.6.8-57": "- Fix program guide metrics.\n- Page metrics update.",
   "1.6.9-58": "- Updated show page header layout, including an update of the show more click to read the whole description.",
   "1.6.9-59": "- Better show description content. [RSI, RTR, SRF]\n- Use same truncatable text view in show and media pages.\n- Fix tvOS badge vertical text alignment.",
-    "1.6.10-60": "- Get a better summary text on media and show elements on homepage and topic pages.\n- Metrics cleanup."
+    "1.6.10-60": "- Get a better summary text on media and show elements on homepage and topic pages.\n- Metrics cleanup.",
+    "1.7.0-413": "- Personalized features (favorites, history and watch later) are available from the Profile tab.\n- Add help and contact in Profile tab."
 }

--- a/Xcode/Shared/Targets/iOS/Common.xcconfig
+++ b/Xcode/Shared/Targets/iOS/Common.xcconfig
@@ -1,7 +1,7 @@
 #include "Xcode/Shared/Common.xcconfig"
 
 // Version information
-MARKETING_VERSION = 3.6.14
+MARKETING_VERSION = 3.7.0
 
 SDKROOT = iphoneos
 TARGETED_DEVICE_FAMILY=1,2

--- a/Xcode/Shared/Targets/tvOS/Common.xcconfig
+++ b/Xcode/Shared/Targets/tvOS/Common.xcconfig
@@ -1,7 +1,7 @@
 #include "Xcode/Shared/Common.xcconfig"
 
 // Version information
-MARKETING_VERSION = 1.6.11
+MARKETING_VERSION = 1.7.0
 
 SDKROOT = appletvos
 TARGETED_DEVICE_FAMILY=3


### PR DESCRIPTION
### Motivation and Context

To test new Help and Contact features #324 . Prepare the iOS and tvOS betas.

### Description

- Bump iOS version to 3.7.0
- Bump tvOS version to 1.7.0
- Update what's news

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
