### PR TITLE
Update Letterbox dependency to 9.0.0

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -155,7 +155,7 @@ name: PLCrashReporter, nameSpecified: PLCrashReporter, owner: microsoft, version
 
 name: promises, nameSpecified: Promises, owner: google, version: 2.2.0, source: https://github.com/google/promises
 
-name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 7.10.0, source: https://github.com/SRGSSR/srganalytics-apple
+name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 8.0.0, source: https://github.com/SRGSSR/srganalytics-apple
 
 name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version: 5.2.1, source: https://github.com/SRGSSR/srgappearance-apple
 
@@ -167,7 +167,7 @@ name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, versio
 
 name: srgidentity-apple, nameSpecified: SRGIdentity, owner: SRGSSR, version: 3.3.0, source: https://github.com/SRGSSR/srgidentity-apple
 
-name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 8.4.0, source: https://github.com/SRGSSR/srgletterbox-apple
+name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9.0.0, source: https://github.com/SRGSSR/srgletterbox-apple
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -254,7 +254,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srganalytics-apple</string>
 			<key>Title</key>
-			<string>SRGAnalytics (7.10.0)</string>
+			<string>SRGAnalytics (8.0.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>
@@ -302,7 +302,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgletterbox-apple</string>
 			<key>Title</key>
-			<string>SRGLetterbox (8.4.0)</string>
+			<string>SRGLetterbox (9.0.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -202,6 +202,11 @@
 		04C2DE7F2937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
 		04C2DE802937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
 		04C2DE812937C67000E85A03 /* AnalyticsClickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2DE772937C67000E85A03 /* AnalyticsClickEvent.swift */; };
+		04D174E729AA8D6B00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
+		04D174E829AA8D6C00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
+		04D174E929AA8D6C00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
+		04D174EA29AA8D6D00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
+		04D174EB29AA8D6D00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
 		04D21DBC299BEB42009CEA15 /* TruncatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D21DBB299BEB42009CEA15 /* TruncatableTextView.swift */; };
 		04D21DBD299BEB42009CEA15 /* TruncatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D21DBB299BEB42009CEA15 /* TruncatableTextView.swift */; };
 		04D21DBE299BEB42009CEA15 /* TruncatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D21DBB299BEB42009CEA15 /* TruncatableTextView.swift */; };
@@ -212,11 +217,6 @@
 		04D2A92D29ACFE5900E11B28 /* Handle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D2A92A29ACFE5900E11B28 /* Handle.swift */; };
 		04D2A92E29ACFE5900E11B28 /* Handle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D2A92A29ACFE5900E11B28 /* Handle.swift */; };
 		04D2A92F29ACFE5900E11B28 /* Handle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D2A92A29ACFE5900E11B28 /* Handle.swift */; };
-		04D174E729AA8D6B00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
-		04D174E829AA8D6C00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
-		04D174E929AA8D6C00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
-		04D174EA29AA8D6D00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
-		04D174EB29AA8D6D00CF2F09 /* ApplicationSectionInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 087584CF23A0008500FA7207 /* ApplicationSectionInfo.m */; };
 		04D5477D27BFFE79003D1BC2 /* LoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D5477C27BFFE79003D1BC2 /* LoadingCell.swift */; };
 		04D5477E27BFFE79003D1BC2 /* LoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D5477C27BFFE79003D1BC2 /* LoadingCell.swift */; };
 		04D5477F27BFFE79003D1BC2 /* LoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D5477C27BFFE79003D1BC2 /* LoadingCell.swift */; };
@@ -19150,7 +19150,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srganalytics-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.9.0;
+				minimumVersion = 8.0.0;
 			};
 		};
 		6F3AED322614C5B6007D591F /* XCRemoteSwiftPackageReference "srgappearance-apple" */ = {
@@ -19190,7 +19190,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srgletterbox-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.4.0;
+				minimumVersion = 9.0.0;
 			};
 		};
 		6F6DD3A924E449D7003F9437 /* XCRemoteSwiftPackageReference "srgdataprovider-apple" */ = {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srganalytics-apple.git",
       "state" : {
-        "revision" : "45a2a1b1a879ad60b9857c1bc3fa5b4e314f6565",
-        "version" : "7.10.0"
+        "revision" : "363171981dc1cf97d4b8db4ae2a1e052d2478124",
+        "version" : "8.0.0"
       }
     },
     {
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgletterbox-apple.git",
       "state" : {
-        "revision" : "601ba160f29ef4fe8bf024d65c64963b5faf5c9f",
-        "version" : "8.4.0"
+        "revision" : "1bc43e1ec53a984a5329053a26435b4f0530a194",
+        "version" : "9.0.0"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

The new SRF VoD/AoD streaming packaging solution is deployed and SRF VoD with segments can't be played anymore.

https://github.com/SRGSSR/srgletterbox-apple/releases/tag/9.0.0 did an update to fix it client side.

> New SRF VoD/AoD streaming packaging solution uses server side Akamai token.
> The token is in a query parameter `hdnts` is delivered by server, Integration Layer.
> Letterbox url added an additional parameter `__b__` for start bitrate in the previous streaming packaging solution.
> Letterbox encoded the query parameter, but the streaming package solution does not accept it: 403 on HLS manifest.

### Description

- Update to Letterbox 9.0.0, which removed the encoded query parameters step.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
