### PR TITLE
Stop player quicker when closing mini player

### DIFF
--- a/Application/Sources/MiniPlayer/PlayMiniPlayerView.m
+++ b/Application/Sources/MiniPlayer/PlayMiniPlayerView.m
@@ -404,6 +404,7 @@
 
 - (IBAction)close:(id)sender
 {
+    [self.controller stop];
     [SRGLetterboxService.sharedService disableForController:self.controller];
     [self.controller reset];
     


### PR DESCRIPTION
### Motivation and Context

On old devices, some user feedbacks shared that the sound continue to be played after a while, after closing the mini player.

### Description

- Call stop on the player when closing the mini player.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
