### PR TITLE
Add spm-outdated make command to check SPM dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ git-hook-uninstall:
 	@git config --unset core.hooksPath
 	@echo "... done.\n"
 
+.PHONY: spm-outdated
+spm-outdated:
+	@echo "Checking outdated Swift package dependencies..."
+	@Scripts/spm-outdated.sh
+	@echo "... done.\n"
+
 .PHONY: help
 help:
 	@echo "The following targets are available:"
@@ -68,5 +74,7 @@ help:
 	@echo ""
 	@echo "   git-hook-install    Use hooks located in ./hooks"
 	@echo "   git-hook-uninstall  Use default hooks located in .git/hooks"
+	@echo ""
+	@echo "   spm-outdated        Run outdated Swift package dependencies check"
 	@echo ""
 	@echo "   help                Display this message"

--- a/Scripts/spm-outdated.sh
+++ b/Scripts/spm-outdated.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if which swift-outdated >/dev/null; then
+  swift outdated
+else
+  echo "warning: swift-outdated not installed, download from https://github.com/kiliankoe/swift-outdated"
+fi


### PR DESCRIPTION
### Motivation and Context

Updating SPM dependencies with Xcode only take care with the version rules defined (next major, next minor, branch, commit hash).

https://github.com/kiliankoe/swift-outdated can help developer to be notify of all new updates.
Thanks @defagos to shared this tool.

### Description

- Add `spm-outdated` make command.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
