### PR TITLE
CI: update version notification to CI with nighty build number

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,9 @@ platform :ios do
     tag_version = tag_version(platform)
     branch_name = git_branch_name
 
+    # Build number overrided
+    notify_version_to_ci(platform, tag_version, build_name(branch_name))
+
     ios_application_schemes.each_index do |index|
       build_lane(
         configuration: 'Nightly_AppCenter',
@@ -743,6 +746,9 @@ platform :ios do
 
     tag_version = tag_version(platform)
     branch_name = git_branch_name
+
+    # Build number overrided
+    notify_version_to_ci(platform, tag_version, build_name(branch_name))
 
     schemes = application_schemes(platform)
     schemes.each_index do |index|


### PR DESCRIPTION
### Motivation and Context

Fastlane code update for branch beta #339 creates a regression for nighties information on CI:
The build number from the nighties is not displayed anymore.
Fix it.  

### Description

- When build number is override for nighties, notify the CI.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
