### PR TITLE
Don't start Firebase if not configured

### DIFF
--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -105,7 +105,9 @@ NSArray<NSNumber *> *FirebaseConfigurationHomeSections(NSString *string)
 - (instancetype)initWithDefaultsDictionary:(NSDictionary *)defaultsDictionary updateBlock:(void (^)(PlayFirebaseConfiguration * _Nonnull))updateBlock
 {
     if (self = [super init]) {
-        self.remoteConfig = [FIRRemoteConfig remoteConfig];
+        if ([FIRApp defaultApp] != nil) {
+            self.remoteConfig = [FIRRemoteConfig remoteConfig];
+        }
         if (self.remoteConfig) {
 #if defined(DEBUG)
             // Make it possible to retrieve the configuration more frequently during development


### PR DESCRIPTION
### Motivation and Context

Check out the project. Just run cocoa pods and no access to the private configuration repository, I can build the project for a personal investigation, as it's a public project. 

### Description

- Don't start Firebase if not configured at launch.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
