### PR TITLE
Nullable program image in program guide

### DIFF
--- a/Application/Sources/Helpers/Extensions/SRGProgram+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/SRGProgram+PlaySRG.swift
@@ -22,4 +22,17 @@ extension SRGProgram {
         }
         return label + ", " + self.title
     }
+    
+    func play_programGuideImageUrl(channel: SRGChannel?, size: SRGImageSize = .medium) -> URL? {
+        if let image {
+            return PlaySRG.url(for: image, size: size)
+        }
+        // Couldn't use channel image in Play SRG image service. Use raw image.
+        else if let channelRawImage = channel?.rawImage {
+            return PlaySRG.url(for: channelRawImage, size: size)
+        }
+        else {
+            return nil
+        }
+    }
 }

--- a/Application/Sources/Helpers/Extensions/SRGProgram+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/SRGProgram+PlaySRG.swift
@@ -22,17 +22,4 @@ extension SRGProgram {
         }
         return label + ", " + self.title
     }
-    
-    func play_programGuideImageUrl(channel: SRGChannel?, size: SRGImageSize = .medium) -> URL? {
-        if let image {
-            return PlaySRG.url(for: image, size: size)
-        }
-        // Couldn't use channel image in Play SRG image service. Use raw image.
-        else if let channelRawImage = channel?.rawImage {
-            return PlaySRG.url(for: channelRawImage, size: size)
-        }
-        else {
-            return nil
-        }
-    }
 }

--- a/Application/Sources/Helpers/ProgramAndChannel.swift
+++ b/Application/Sources/Helpers/ProgramAndChannel.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import SRGDataProviderModel
+
+struct ProgramAndChannel: Hashable {
+    let program: SRGProgram
+    let channel: SRGChannel
+    
+    func programGuideImageUrl(size: SRGImageSize) -> URL? {
+        if let image = program.image {
+            return PlaySRG.url(for: image, size: size)
+        }
+        // Couldn't use channel image in Play SRG image service. Use raw image.
+        else if let channelRawImage = channel.rawImage {
+            return PlaySRG.url(for: channelRawImage, size: size)
+        }
+        else {
+            return nil
+        }
+    }
+}

--- a/Application/Sources/ProgramGuide/ProgramCell.swift
+++ b/Application/Sources/ProgramGuide/ProgramCell.swift
@@ -10,14 +10,14 @@ import SwiftUI
 // MARK: Cell
 
 struct ProgramCell: View {
-    @Binding var data: ProgramCellViewModel.Data
+    @Binding var data: ProgramAndChannel
     let direction: StackDirection
     
     @StateObject private var model = ProgramCellViewModel()
     
     @Environment(\.isSelected) private var isSelected
     
-    init(program: SRGProgram, channel: SRGChannel?, direction: StackDirection) {
+    init(program: SRGProgram, channel: SRGChannel, direction: StackDirection) {
         _data = .constant(.init(program: program, channel: channel))
         self.direction = direction
     }

--- a/Application/Sources/ProgramGuide/ProgramCellViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramCellViewModel.swift
@@ -10,7 +10,7 @@ import SRGDataProviderModel
 // MARK: View model
 
 final class ProgramCellViewModel: ObservableObject {
-    @Published var data: Data?
+    @Published var data: ProgramAndChannel?
     @Published private(set) var date = Date()
     
     init() {
@@ -47,15 +47,5 @@ final class ProgramCellViewModel: ObservableObject {
         guard let program = data?.program else { return nil }
         let progress = date.timeIntervalSince(program.startDate) / program.endDate.timeIntervalSince(program.startDate)
         return (0...1).contains(progress) ? progress : nil
-    }
-}
-
-// MARK: Types
-
-extension ProgramCellViewModel {
-    /// Input data for the model
-    struct Data: Hashable {
-        let program: SRGProgram
-        let channel: SRGChannel?
     }
 }

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -161,7 +161,7 @@ final class ProgramGuideGridViewController: UIViewController {
 #if os(tvOS)
             if let channel = model.selectedChannel ?? model.channels.first, let section = state.sections.first(where: { $0 == channel }) ?? state.sections.first,
                let currentProgram = state.items(for: section).compactMap(\.program).first(where: { $0.play_containsDate(model.date(for: model.time)) }) {
-                model.focusedProgram = currentProgram
+                model.focusedProgram = ProgramGuideViewModel.FocusedProgram(program: currentProgram, channel: channel)
             }
             else {
                 model.focusedProgram = nil
@@ -309,7 +309,13 @@ extension ProgramGuideGridViewController: UICollectionViewDelegate {
             let snapshot = dataSource.snapshot()
             let channel = snapshot.sectionIdentifiers[nextFocusedIndexPath.section]
             model.selectedChannel = channel
-            model.focusedProgram = snapshot.itemIdentifiers(inSection: channel)[nextFocusedIndexPath.row].program
+            let program = snapshot.itemIdentifiers(inSection: channel)[nextFocusedIndexPath.row].program
+            if let program {
+                model.focusedProgram = ProgramGuideViewModel.FocusedProgram(program: program, channel: channel)
+            }
+            else {
+                model.focusedProgram = nil
+            }
         }
     }
 #endif

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -161,10 +161,10 @@ final class ProgramGuideGridViewController: UIViewController {
 #if os(tvOS)
             if let channel = model.selectedChannel ?? model.channels.first, let section = state.sections.first(where: { $0 == channel }) ?? state.sections.first,
                let currentProgram = state.items(for: section).compactMap(\.program).first(where: { $0.play_containsDate(model.date(for: model.time)) }) {
-                model.focusedProgram = ProgramGuideViewModel.FocusedProgram(program: currentProgram, channel: channel)
+                model.focusedProgramAndChannel = ProgramAndChannel(program: currentProgram, channel: channel)
             }
             else {
-                model.focusedProgram = nil
+                model.focusedProgramAndChannel = nil
             }
 #endif
         }
@@ -311,10 +311,10 @@ extension ProgramGuideGridViewController: UICollectionViewDelegate {
             model.selectedChannel = channel
             let program = snapshot.itemIdentifiers(inSection: channel)[nextFocusedIndexPath.row].program
             if let program {
-                model.focusedProgram = ProgramGuideViewModel.FocusedProgram(program: program, channel: channel)
+                model.focusedProgramAndChannel = ProgramAndChannel(program: program, channel: channel)
             }
             else {
-                model.focusedProgram = nil
+                model.focusedProgramAndChannel = nil
             }
         }
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
@@ -25,7 +25,7 @@ struct ProgramGuideHeaderView: View {
     var body: some View {
 #if os(tvOS)
         ZStack {
-            ProgramPreview(focusedProgram: model.focusedProgram)
+            ProgramPreview(data: model.focusedProgramAndChannel)
                 .accessibilityHidden(true)
             NavigationBar(model: model)
                 .focusable()

--- a/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
@@ -25,7 +25,7 @@ struct ProgramGuideHeaderView: View {
     var body: some View {
 #if os(tvOS)
         ZStack {
-            ProgramPreview(program: model.focusedProgram)
+            ProgramPreview(focusedProgram: model.focusedProgram)
                 .accessibilityHidden(true)
             NavigationBar(model: model)
                 .focusable()

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -11,6 +11,14 @@ import Foundation
 // MARK: View model
 
 final class ProgramGuideViewModel: ObservableObject {
+#if os(tvOS)
+    /// Input data for the model
+    struct FocusedProgram: Hashable {
+        let program: SRGProgram
+        let channel: SRGChannel
+    }
+#endif
+    
     @Published private(set) var data: Data = .empty
     
     /// Only significant changes are published. Noisy changes (e.g. because of scrolling) are not published.
@@ -19,7 +27,7 @@ final class ProgramGuideViewModel: ObservableObject {
 #if os(iOS)
     @Published var isHeaderUserInteractionEnabled = true
 #else
-    @Published var focusedProgram: SRGProgram?
+    @Published var focusedProgram: FocusedProgram?
 #endif
     
     private(set) var day: SRGDay

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -11,14 +11,6 @@ import Foundation
 // MARK: View model
 
 final class ProgramGuideViewModel: ObservableObject {
-#if os(tvOS)
-    /// Input data for the model
-    struct FocusedProgram: Hashable {
-        let program: SRGProgram
-        let channel: SRGChannel
-    }
-#endif
-    
     @Published private(set) var data: Data = .empty
     
     /// Only significant changes are published. Noisy changes (e.g. because of scrolling) are not published.
@@ -27,7 +19,7 @@ final class ProgramGuideViewModel: ObservableObject {
 #if os(iOS)
     @Published var isHeaderUserInteractionEnabled = true
 #else
-    @Published var focusedProgram: FocusedProgram?
+    @Published var focusedProgramAndChannel: ProgramAndChannel?
 #endif
     
     private(set) var day: SRGDay

--- a/Application/Sources/ProgramGuide/ProgramPreview.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreview.swift
@@ -13,12 +13,12 @@ import SwiftUI
 
 /// Behavior: h-exp, v-exp
 struct ProgramPreview: View {
-    @Binding var program: SRGProgram?
+    @Binding var focusedProgram: ProgramGuideViewModel.FocusedProgram?
     
     @StateObject private var model = ProgramPreviewModel()
     
-    init(program: SRGProgram?) {
-        _program = .constant(program)
+    init(focusedProgram: ProgramGuideViewModel.FocusedProgram?) {
+        _focusedProgram = .constant(focusedProgram)
     }
     
     var body: some View {
@@ -36,12 +36,12 @@ struct ProgramPreview: View {
                 Color.clear
             }
         }
-        .redactedIfNil(program)
+        .redactedIfNil(focusedProgram)
         .onAppear {
-            model.program = program
+            model.focusProgram = focusedProgram
         }
-        .onChange(of: program) { newValue in
-            model.program = newValue
+        .onChange(of: focusedProgram) { newValue in
+            model.focusProgram = newValue
         }
     }
     
@@ -88,9 +88,9 @@ struct ProgramPreview: View {
 struct ProgramPreview_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            ProgramPreview(program: Mock.program())
-            ProgramPreview(program: Mock.program(.overflow))
-            ProgramPreview(program: nil)
+            ProgramPreview(focusedProgram: ProgramGuideViewModel.FocusedProgram(program: Mock.program(), channel: Mock.channel()))
+            ProgramPreview(focusedProgram: ProgramGuideViewModel.FocusedProgram(program: Mock.program(.overflow), channel: Mock.channel()))
+            ProgramPreview(focusedProgram: nil)
         }
         .previewLayout(.fixed(width: 1920, height: 700))
     }

--- a/Application/Sources/ProgramGuide/ProgramPreview.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreview.swift
@@ -13,12 +13,12 @@ import SwiftUI
 
 /// Behavior: h-exp, v-exp
 struct ProgramPreview: View {
-    @Binding var focusedProgram: ProgramGuideViewModel.FocusedProgram?
+    @Binding var data: ProgramAndChannel?
     
     @StateObject private var model = ProgramPreviewModel()
     
-    init(focusedProgram: ProgramGuideViewModel.FocusedProgram?) {
-        _focusedProgram = .constant(focusedProgram)
+    init(data: ProgramAndChannel?) {
+        _data = .constant(data)
     }
     
     var body: some View {
@@ -36,12 +36,12 @@ struct ProgramPreview: View {
                 Color.clear
             }
         }
-        .redactedIfNil(focusedProgram)
+        .redactedIfNil(data)
         .onAppear {
-            model.focusProgram = focusedProgram
+            model.data = data
         }
-        .onChange(of: focusedProgram) { newValue in
-            model.focusProgram = newValue
+        .onChange(of: data) { newValue in
+            model.data = newValue
         }
     }
     
@@ -88,9 +88,9 @@ struct ProgramPreview: View {
 struct ProgramPreview_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            ProgramPreview(focusedProgram: ProgramGuideViewModel.FocusedProgram(program: Mock.program(), channel: Mock.channel()))
-            ProgramPreview(focusedProgram: ProgramGuideViewModel.FocusedProgram(program: Mock.program(.overflow), channel: Mock.channel()))
-            ProgramPreview(focusedProgram: nil)
+            ProgramPreview(data: ProgramAndChannel(program: Mock.program(), channel: Mock.channel()))
+            ProgramPreview(data: ProgramAndChannel(program: Mock.program(.overflow), channel: Mock.channel()))
+            ProgramPreview(data: nil)
         }
         .previewLayout(.fixed(width: 1920, height: 700))
     }

--- a/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
@@ -10,8 +10,16 @@ import SRGDataProviderModel
 // MARK: View model
 
 final class ProgramPreviewModel: ObservableObject {
-    @Published var program: SRGProgram?
+    @Published var focusProgram: ProgramGuideViewModel.FocusedProgram?
     @Published private(set) var date = Date()
+    
+    private var program: SRGProgram? {
+        return focusProgram?.program
+    }
+    
+    private var channel: SRGChannel? {
+        return focusProgram?.channel
+    }
     
     private var isLive: Bool {
         guard let program else { return false }
@@ -65,7 +73,7 @@ final class ProgramPreviewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        return url(for: program?.image, size: .medium)
+        return program?.play_programGuideImageUrl(channel: channel)
     }
     
     init() {

--- a/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
@@ -10,15 +10,11 @@ import SRGDataProviderModel
 // MARK: View model
 
 final class ProgramPreviewModel: ObservableObject {
-    @Published var focusProgram: ProgramGuideViewModel.FocusedProgram?
+    @Published var data: ProgramAndChannel?
     @Published private(set) var date = Date()
     
     private var program: SRGProgram? {
-        return focusProgram?.program
-    }
-    
-    private var channel: SRGChannel? {
-        return focusProgram?.channel
+        return data?.program
     }
     
     private var isLive: Bool {
@@ -73,7 +69,7 @@ final class ProgramPreviewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        return program?.play_programGuideImageUrl(channel: channel)
+        return data?.programGuideImageUrl(size: .medium)
     }
     
     init() {

--- a/Application/Sources/ProgramGuide/ProgramView.swift
+++ b/Application/Sources/ProgramGuide/ProgramView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 // Behavior: h-exp, v-hug
 struct ProgramView: View {
-    @Binding var data: ProgramViewModel.Data
+    @Binding var data: ProgramAndChannel
     @StateObject private var model = ProgramViewModel()
     
     static func viewController(for program: SRGProgram, channel: SRGChannel) -> UIViewController {

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -14,7 +14,7 @@ import SRGDataProviderModel
 // MARK: View model
 
 final class ProgramViewModel: ObservableObject {
-    @Published var data: Data? {
+    @Published var data: ProgramAndChannel? {
         didSet {
             Self.mediaDataPublisher(for: data?.program)
                 .receive(on: DispatchQueue.main)
@@ -116,7 +116,7 @@ final class ProgramViewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        return program?.play_programGuideImageUrl(channel: channel)
+        return data?.programGuideImageUrl(size: .medium)
     }
     
     private var duration: Double? {
@@ -439,12 +439,6 @@ extension ProgramViewModel {
 // MARK: Types
 
 extension ProgramViewModel {
-    /// Input data for the model
-    struct Data: Hashable {
-        let program: SRGProgram
-        let channel: SRGChannel
-    }
-    
     /// Data related to the program crew members
     struct CrewMembersData: Identifiable {
         let role: String?

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -116,16 +116,15 @@ final class ProgramViewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        let imageUrl = url(for: program?.image, size: .medium)
-        
-        // Ths is a workaround, to have a non blur image if channel svg logo are used. See https://github.com/SRGSSR/playsrg-apple/issues/344
-        if let imageUrl, let query = imageUrl.query,
-           let range = query.range(of: ".svg/format/png"), !range.isEmpty,
-           let channelRawImage = self.data?.channel.rawImage {
+        if let image = program?.image {
+            return url(for: image, size: .medium)
+        }
+        // Couldn't use channel image in Play SRG image service. Use raw image.
+        else if let channelRawImage = self.data?.channel.rawImage {
             return url(for: channelRawImage, size: .medium)
         }
         else {
-            return imageUrl
+            return nil
         }
     }
     

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -116,16 +116,7 @@ final class ProgramViewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        if let image = program?.image {
-            return url(for: image, size: .medium)
-        }
-        // Couldn't use channel image in Play SRG image service. Use raw image.
-        else if let channelRawImage = self.data?.channel.rawImage {
-            return url(for: channelRawImage, size: .medium)
-        }
-        else {
-            return nil
-        }
+        return program?.play_programGuideImageUrl(channel: channel)
     }
     
     private var duration: Double? {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -132,6 +132,16 @@
 		0456C4A82976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
 		0456C4A92976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
 		0456C4AA2976EE460088508A /* AnalyticsHiddenEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */; };
+		0463DA102A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA112A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA122A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA132A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA142A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA152A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA162A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA172A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA182A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
+		0463DA192A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */; };
 		0481D59929F41D5B00D174B3 /* SRGMedia+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481D59829F41D5B00D174B3 /* SRGMedia+PlaySRG.swift */; };
 		0481D59A29F41D5B00D174B3 /* SRGMedia+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481D59829F41D5B00D174B3 /* SRGMedia+PlaySRG.swift */; };
 		0481D59B29F41D5B00D174B3 /* SRGMedia+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0481D59829F41D5B00D174B3 /* SRGMedia+PlaySRG.swift */; };
@@ -2748,6 +2758,7 @@
 		044E391F29B10C9100C1768A /* SRGShow+PlaySRG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SRGShow+PlaySRG.swift"; sourceTree = "<group>"; };
 		0451ECE228742D8000E89975 /* UIWindow+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+PlaySRG.swift"; sourceTree = "<group>"; };
 		0456C4A02976EE460088508A /* AnalyticsHiddenEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsHiddenEvent.swift; sourceTree = "<group>"; };
+		0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramAndChannel.swift; sourceTree = "<group>"; };
 		0481D59829F41D5B00D174B3 /* SRGMedia+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRGMedia+PlaySRG.swift"; sourceTree = "<group>"; };
 		0481D5A329F44D4D00D174B3 /* SRGProgram+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRGProgram+PlaySRG.swift"; sourceTree = "<group>"; };
 		0481D5AE29F460C500D174B3 /* SRGProgramComposition+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRGProgramComposition+PlaySRG.swift"; sourceTree = "<group>"; };
@@ -3924,6 +3935,7 @@
 				6F9D2742203AD99C00FDE899 /* Playlist.m */,
 				6F7CE6EF1DD6021700FA4A6D /* PlayLogger.h */,
 				6FDEC19126DE307E0020A03F /* PresenterMode.swift */,
+				0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */,
 				08C33ED323CB5C6500D422C1 /* Protocols */,
 				08209306208F522A00711DE4 /* PushService.h */,
 				08209307208F522A00711DE4 /* PushService.m */,
@@ -8459,6 +8471,7 @@
 				6FDF08F0218B126700B2AF2C /* UpdateInfo.m in Sources */,
 				6FAE561C26C19D6F00EBFCD6 /* UICollectionView+Index.swift in Sources */,
 				6F30AB9C2604B66600457331 /* TopicCell.swift in Sources */,
+				0463DA102A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6F16C7A326025698006F685A /* PageViewController.swift in Sources */,
 				04D5F91F286C4542000A5A4E /* Recommendation.swift in Sources */,
 				6FA5D15D1F2077B10059E4E2 /* NSString+PlaySRG.m in Sources */,
@@ -8762,6 +8775,7 @@
 				6FCB65F126F4994C00A95C07 /* GoogleCastFloatingButton.swift in Sources */,
 				6FF0C84826B44F6A006B3C6A /* ShowCellViewModel.swift in Sources */,
 				6F010E12286607450024A745 /* SearchSettingsBucketCell.swift in Sources */,
+				0463DA112A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6F0850F526256A7700B4E410 /* Reachability.m in Sources */,
 				6F9D2744203AD99C00FDE899 /* Playlist.m in Sources */,
 				042F6F3529E08785003F46AA /* NSSet+PlaySRG.swift in Sources */,
@@ -9025,6 +9039,7 @@
 				6FCB65F226F4994C00A95C07 /* GoogleCastFloatingButton.swift in Sources */,
 				6FF0C84926B44F6A006B3C6A /* ShowCellViewModel.swift in Sources */,
 				6F010E13286607450024A745 /* SearchSettingsBucketCell.swift in Sources */,
+				0463DA122A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6F0850F626256A7700B4E410 /* Reachability.m in Sources */,
 				6F9D2745203AD99C00FDE899 /* Playlist.m in Sources */,
 				042F6F3629E08785003F46AA /* NSSet+PlaySRG.swift in Sources */,
@@ -9288,6 +9303,7 @@
 				6FCB65F326F4994C00A95C07 /* GoogleCastFloatingButton.swift in Sources */,
 				6FF0C84A26B44F6A006B3C6A /* ShowCellViewModel.swift in Sources */,
 				6F010E14286607450024A745 /* SearchSettingsBucketCell.swift in Sources */,
+				0463DA132A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6F0850F726256A7700B4E410 /* Reachability.m in Sources */,
 				6F9D2746203AD99C00FDE899 /* Playlist.m in Sources */,
 				042F6F3729E08785003F46AA /* NSSet+PlaySRG.swift in Sources */,
@@ -9410,6 +9426,7 @@
 				6F008761219AA888004BD6FF /* StoreReview.m in Sources */,
 				6F54D32626050FBD008B46FF /* MediaCell.swift in Sources */,
 				6F4760991EB37DF2003021EA /* UIViewController+PlaySRG.m in Sources */,
+				0463DA142A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6F54D40626051037008B46FF /* MediaDescription.swift in Sources */,
 				E6971AF11D4B300C008CA703 /* PlayApplicationError.m in Sources */,
 				6F978B552849C3CA003061E8 /* ScrollableContent.m in Sources */,
@@ -9786,6 +9803,7 @@
 				08E6135225843C7E00C5FE4B /* PlayApplication.m in Sources */,
 				0481D5BF29F55EAE00D174B3 /* AccessibilityIdentifier.swift in Sources */,
 				6F8A545F2655100400AE78FD /* SectionViewController.swift in Sources */,
+				0463DA152A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6FC44B4A25DE552300DE6E6F /* Recommendation.m in Sources */,
 				6FF129DD256C0D370042F446 /* PlayDurationFormatter.m in Sources */,
 				6F7625CB2721786B00C134AA /* DeepLinkAction.m in Sources */,
@@ -9938,6 +9956,7 @@
 				08E6136725843C8100C5FE4B /* PlayApplication.m in Sources */,
 				0481D5C029F55EAE00D174B3 /* AccessibilityIdentifier.swift in Sources */,
 				6F8A54602655100400AE78FD /* SectionViewController.swift in Sources */,
+				0463DA162A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6FC44B4B25DE552400DE6E6F /* Recommendation.m in Sources */,
 				6FF129F2256C0D370042F446 /* PlayDurationFormatter.m in Sources */,
 				6F7625CC2721786D00C134AA /* DeepLinkAction.m in Sources */,
@@ -10090,6 +10109,7 @@
 				08E6136825843C8200C5FE4B /* PlayApplication.m in Sources */,
 				0481D5C129F55EAE00D174B3 /* AccessibilityIdentifier.swift in Sources */,
 				6F8A54612655100500AE78FD /* SectionViewController.swift in Sources */,
+				0463DA172A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6FC44B4C25DE552400DE6E6F /* Recommendation.m in Sources */,
 				6FF129F3256C0D380042F446 /* PlayDurationFormatter.m in Sources */,
 				6F7625CD2721786D00C134AA /* DeepLinkAction.m in Sources */,
@@ -10242,6 +10262,7 @@
 				08E6136925843C8200C5FE4B /* PlayApplication.m in Sources */,
 				0481D5C229F55EAE00D174B3 /* AccessibilityIdentifier.swift in Sources */,
 				6F8A54622655100500AE78FD /* SectionViewController.swift in Sources */,
+				0463DA182A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6FC44B4D25DE552400DE6E6F /* Recommendation.m in Sources */,
 				6FF12A08256C0D390042F446 /* PlayDurationFormatter.m in Sources */,
 				6F7625CE2721786E00C134AA /* DeepLinkAction.m in Sources */,
@@ -10314,6 +10335,7 @@
 				087B5F4C257C502C002F58AF /* Favorites.m in Sources */,
 				6FC413F224EEEDCB00FDF806 /* RadioChannel.m in Sources */,
 				6FD9595D26989FD900739FAE /* MediaVisualViewModel.swift in Sources */,
+				0463DA192A73D8B000CD6556 /* ProgramAndChannel.swift in Sources */,
 				6FCE753E26D3786F00667298 /* HeroMediaCell.swift in Sources */,
 				6FCA5BF127DA00AC00916D0B /* SectionViewModel.swift in Sources */,
 				6F2F557427B40967003DC9C0 /* NowArrowView.swift in Sources */,


### PR DESCRIPTION
### Motivation and Context

Following #345 and SRG Data Provider update to fix nullable program image url, https://github.com/SRGSSR/srgdataprovider-apple/pull/49, the program guide views have empty thumbnails now.
To keep a correct UI, fallback to the channel logo.

### Description

- Remove workaround on iOS program view.
- Add fallback support on tvOS program header view.
- Refactor similar structure for program and channel.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
