### PR TITLE
CI: Don't failed because of App Center upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1561,11 +1561,17 @@ end
 
 def upload_appcenter_dsyms(appcenter_appname)
   dsym = lane_context[SharedValues::DSYM_OUTPUT_PATH]
-  appcenter_lane(
-    appname: appcenter_appname,
-    notes: 'DSYMs from local build (via fastlane).',
-    upload_dsym: dsym
-  )
+  begin
+    appcenter_lane(
+      appname: appcenter_appname,
+      notes: 'DSYMs from local build (via fastlane).',
+      upload_dsym: dsym
+    )
+  rescue StandardError => e
+    UI.important "Error uploading dSYM to App Center: #{e.message}"
+    Dir.chdir('..') { FileUtils.cp(dsym, 'build') }
+    UI.message "#{dsym.split('/').last} file copied to ./build folder."
+  end
   lane_context.delete(SharedValues::DSYM_OUTPUT_PATH)
 end
 


### PR DESCRIPTION
### Motivation and Context

Since days, the dSYM upload failed with a 503 error and an exception is raised.
See https://github.com/microsoft/fastlane-plugin-appcenter/issues/322.

It stops the CI script.
Proposition is to be resilient to App Center sever issue.

### Description

- Catch App Center upload error.
- Copy locally the dSYM zip file if error occurred.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
