### PR TITLE
Update screenshot script to avoid user consent banner

### DIFF
--- a/Application/Sources/Application/UserConsentHelper.swift
+++ b/Application/Sources/Application/UserConsentHelper.swift
@@ -103,6 +103,9 @@ enum UCService: Hashable, CaseIterable {
     // MARK: Setup
     
     @objc static func setup() {
+        // Skip user consent banner if making screenshots
+        guard !ProcessInfo.processInfo.arguments.contains("FL_SCREENSHOTS") else { return }
+        
         guard !hasRunSetup else { return }
         
         configureAndApplyConsents()

--- a/UITests/Screenshots/Resources/Apps/Play RTS/Configuration.plist
+++ b/UITests/Screenshots/Resources/Apps/Play RTS/Configuration.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SearchText</key>
-	<string>Street</string>
+	<string>52 minutes</string>
 	<key>RadioCellIndex</key>
 	<integer>4</integer>
 </dict>

--- a/UITests/Screenshots/Sources/Helpers/SnapshotHelper.swift
+++ b/UITests/Screenshots/Sources/Helpers/SnapshotHelper.swift
@@ -180,7 +180,7 @@ open class Snapshot: NSObject {
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
                 #if swift(<5.0)
-                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
@@ -305,4 +305,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.28]
+// SnapshotHelperVersion [1.29]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1983,7 +1983,7 @@ def snapshot_ios_devices
   [
     'iPhone 14 Plus', # 6.5 inch, required
     'iPhone 8 Plus', # 5.5 inch, required
-    'iPad Pro (12.9-inch) (5th generation)', # 12.9 inch, required
+    'iPad Pro (12.9-inch) (6th generation)', # 12.9 inch, required
     'iPad Pro (12.9-inch) (2nd generation)' # 12.9 inch, required
   ]
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1655,6 +1655,7 @@ def upload_screenshots(platform)
     skip_binary_upload: true,
     skip_metadata: true,
     overwrite_screenshots: true,
+    ignore_language_directory_validation: true,
     precheck_include_in_app_purchases: false,
     force: true # Don't stop to wait manual preview
   )

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -6,5 +6,6 @@ xcargs('ONLY_ACTIVE_ARCH=YES')
 localize_simulator(true)
 override_status_bar(true)
 reinstall_app(true)
+launch_arguments(['FL_SCREENSHOTS'])
 
 clear_previous_screenshots(true)


### PR DESCRIPTION
### Motivation and Context

The last Play RTS screenshot for AppStore is the search view. The term needs an update.
RTS TV channel logos are updated on 21.08.2023, screenshots should be updated.

### Description

- Update Play RTS target configuration file with new search term. 
- Update Fastlane Screenshot helper, outdated.
- Update `deliver` parameters to ignore language when uploading screenshots: only on language is enabled, `fr-FR`, but device screenshots are `fr-CH`.

TBD:
- Check why `override` can't delete screenshots anymore.
- Fix it if possible.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
