### PR TITLE
Remove divider beta setting option

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -64,9 +64,6 @@
 /* Show A-Z short button title */
 "A to Z" = "Dalla A alla Z";
 
-/* Beta tests toggle label to add line dividers in episodes list in show pages setting label */
-"Add line dividers in episodes list in show pages" = "Aggiungere delle linee divisorie tra gli episodi all'interno di una scheda di programma";
-
 /* Button to add an event to Calendar application */
 "Add to Calendar" = "Aggiungere al calendario";
 

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -64,9 +64,6 @@
 /* Show A-Z short button title */
 "A to Z" = "Dad A fin Z";
 
-/* Beta tests toggle label to add line dividers in episodes list in show pages setting label */
-"Add line dividers in episodes list in show pages" = "Agiunger segns per sparter lingias en episodas";
-
 /* Button to add an event to Calendar application */
 "Add to Calendar" = "Agiuntar al chalender";
 

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -64,9 +64,6 @@
 /* Show A-Z short button title */
 "A to Z" = "De A à Z";
 
-/* Beta tests toggle label to add line dividers in episodes list in show pages setting label */
-"Add line dividers in episodes list in show pages" = "Ajouter des séparateurs entre épisodes dans les pages d'Émissions";
-
 /* Button to add an event to Calendar application */
 "Add to Calendar" = "Ajouter au calendrier";
 

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -64,9 +64,6 @@
 /* Show A-Z short button title */
 "A to Z" = "A bis Z";
 
-/* Beta tests toggle label to add line dividers in episodes list in show pages setting label */
-"Add line dividers in episodes list in show pages" = "Trennlinien in Episodenlisten bei Sendungen hinzufügen";
-
 /* Button to add an event to Calendar application */
 "Add to Calendar" = "Zum Kalender hinzufügen";
 

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -64,9 +64,6 @@
 /* Show A-Z short button title */
 "A to Z" = "A to Z";
 
-/* Beta tests toggle label to add line dividers in episodes list in show pages setting label */
-"Add line dividers in episodes list in show pages" = "Add line dividers in episodes list in show pages";
-
 /* Button to add an event to Calendar application */
 "Add to Calendar" = "Add to Calendar";
 

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -169,13 +169,6 @@ static void *s_kvoContext = &s_kvoContext;
         completionHandler(YES);
     }, @"MigrateSelectedLiveStreamURNForChannels");
     
-    PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
-        NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
-        [userDefaults removeObjectForKey:PlaySRGSettingMediaListDividerEnabled];
-        [userDefaults synchronize];
-        completionHandler(YES);
-    }, @"ClearMediaListDividerPreference");
-    
     FavoritesUpdatePushService();
     
     [NSNotificationCenter.defaultCenter addObserverForName:SRGPreferencesDidChangeNotification object:SRGUserData.currentUserData.preferences queue:nil usingBlock:^(NSNotification * _Nonnull notification) {

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -65,7 +65,7 @@ final class SectionViewController: UIViewController {
         model = SectionViewModel(section: section, filter: filter)
         self.initialSectionId = initialSectionId
         self.fromPushNotification = fromPushNotification
-        contentInsets = Self.contentInsets(for: model.state, displayDivider: model.configuration.viewModelProperties.displayDivider)
+        contentInsets = Self.contentInsets(for: model.state)
         super.init(nibName: nil, bundle: nil)
         title = model.displaysTitle ? model.title : nil
     }
@@ -177,18 +177,6 @@ final class SectionViewController: UIViewController {
                 self?.reloadData(for: state)
             }
             .store(in: &cancellables)
-        
-#if os(iOS) && (DEBUG || NIGHTLY || BETA)
-        ApplicationSignal.settingUpdates(at: \.PlaySRGSettingMediaListDividerEnabled)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                guard let self else { return }
-                
-                contentInsets = Self.contentInsets(for: model.state, displayDivider: model.configuration.viewModelProperties.displayDivider)
-                collectionView.reloadData()
-            }
-            .store(in: &cancellables)
-#endif
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -299,7 +287,7 @@ final class SectionViewController: UIViewController {
         updateNavigationBar(for: state)
 #endif
         
-        contentInsets = Self.contentInsets(for: state, displayDivider: model.configuration.viewModelProperties.displayDivider)
+        contentInsets = Self.contentInsets(for: state)
         play_setNeedsContentInsetsUpdate()
         
         DispatchQueue.global(qos: .userInteractive).async {
@@ -335,9 +323,9 @@ final class SectionViewController: UIViewController {
         initialSectionId = nil
     }
     
-    private static func contentInsets(for state: SectionViewModel.State, displayDivider: Bool) -> UIEdgeInsets {
+    private static func contentInsets(for state: SectionViewModel.State) -> UIEdgeInsets {
         let top = (state.headerSize == .zero) ? Self.layoutVerticalMargin : 0
-        let bottom = displayDivider ? 0 : Self.layoutVerticalMargin
+        let bottom = Self.layoutVerticalMargin
         return UIEdgeInsets(top: top, left: 0, bottom: bottom, right: 0)
     }
     
@@ -687,7 +675,7 @@ private extension SectionViewController {
 #if os(iOS)
                     let horizontalMargin = horizontalSizeClass == .compact ? Self.layoutHorizontalMargin : Self.layoutHorizontalMargin * 2
                     return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: horizontalMargin, spacing: Self.itemSpacing, top: top) { _, _ in
-                        return MediaCellSize.fullWidth(horizontalSizeClass: horizontalSizeClass, displayDivider: configuration.viewModelProperties.displayDivider)
+                        return MediaCellSize.fullWidth(horizontalSizeClass: horizontalSizeClass)
                     }
 #else
                     return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { layoutWidth, spacing in
@@ -697,7 +685,7 @@ private extension SectionViewController {
                 case .mediaGrid:
                     if horizontalSizeClass == .compact {
                         return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing, top: top) { _, _ in
-                            return MediaCellSize.fullWidth(displayDivider: configuration.viewModelProperties.displayDivider)
+                            return MediaCellSize.fullWidth()
                         }
                     }
                     else {
@@ -768,12 +756,11 @@ private extension SectionViewController {
                 case let .configured(configuredSection):
                     switch configuredSection {
                     case .show:
-                        let dividerStyle = configuration.viewModelProperties.displayDivider ? isLastItem ? .hidden : .display : .none as MediaCell.DividerStyle
                         if configuration.viewModelProperties.layout == .mediaList {
-                            MediaCell(media: media, style: .dateAndSummary, layout: .horizontal, dividerStyle: dividerStyle)
+                            MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
                         }
                         else {
-                            MediaCell(media: media, style: .date, dividerStyle: dividerStyle)
+                            MediaCell(media: media, style: .date)
                         }
                     case .radioEpisodesForDay, .tvEpisodesForDay:
                         MediaCell(media: media, style: .time)

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -302,7 +302,6 @@ extension SectionViewModel {
 
 protocol SectionViewModelProperties {
     var layout: SectionViewModel.SectionLayout { get }
-    var displayDivider: Bool { get }
     var pinHeadersToVisibleBounds: Bool { get }
     var userActivity: NSUserActivity? { get }
     var largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode { get }
@@ -334,10 +333,6 @@ private extension SectionViewModel {
             default:
                 return .mediaGrid
             }
-        }
-        
-        var displayDivider: Bool {
-            return false
         }
         
         var pinHeadersToVisibleBounds: Bool {
@@ -419,19 +414,6 @@ private extension SectionViewModel {
             default:
                 return .mediaGrid
             }
-        }
-        
-        var displayDivider: Bool {
-#if os(iOS) && (DEBUG || NIGHTLY || BETA)
-            switch configuredSection {
-            case .show:
-                return ApplicationSettingMediaListDividerEnabled()
-            default:
-                return false
-            }
-#else
-            return false
-#endif
         }
         
         var pinHeadersToVisibleBounds: Bool {

--- a/Application/Sources/Settings/ApplicationSettings.h
+++ b/Application/Sources/Settings/ApplicationSettings.h
@@ -46,6 +46,4 @@ OBJC_EXPORT void ApplicationSettingSetLastOpenedRadioChannel(RadioChannel *radio
 
 OBJC_EXPORT BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void);
 
-OBJC_EXPORT BOOL ApplicationSettingMediaListDividerEnabled(void);
-
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettings.m
+++ b/Application/Sources/Settings/ApplicationSettings.m
@@ -148,8 +148,3 @@ BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void)
 {
     return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingBackgroundVideoPlaybackEnabled];
 }
-
-BOOL ApplicationSettingMediaListDividerEnabled(void)
-{
-    return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingMediaListDividerEnabled];
-}

--- a/Application/Sources/Settings/ApplicationSettingsConstants.h
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.h
@@ -21,7 +21,6 @@ OBJC_EXPORT NSString * const PlaySRGSettingLastLoggedInEmailAddress;
 OBJC_EXPORT NSString * const PlaySRGSettingSelectedLivestreamURNForChannels;
 OBJC_EXPORT NSString * const PlaySRGSettingServiceIdentifier;
 OBJC_EXPORT NSString * const PlaySRGSettingUserLocation;
-OBJC_EXPORT NSString * const PlaySRGSettingMediaListDividerEnabled;
 OBJC_EXPORT NSString * const PlaySRGSettingUserConsentAcceptedServiceIds;
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 OBJC_EXPORT NSString * const PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled;

--- a/Application/Sources/Settings/ApplicationSettingsConstants.m
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.m
@@ -19,7 +19,6 @@ NSString * const PlaySRGSettingLastLoggedInEmailAddress = @"PlaySRGSettingLastLo
 NSString * const PlaySRGSettingSelectedLivestreamURNForChannels = @"PlaySRGSettingSelectedLivestreamURNForChannels";
 NSString * const PlaySRGSettingServiceIdentifier = @"PlaySRGSettingServiceIdentifier";
 NSString * const PlaySRGSettingUserLocation = @"PlaySRGSettingUserLocation";
-NSString * const PlaySRGSettingMediaListDividerEnabled = @"PlaySRGSettingMediaListDividerEnabled";
 NSString * const PlaySRGSettingUserConsentAcceptedServiceIds = @"PlaySRGSettingUserConsentAcceptedServiceIds";
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 NSString * const PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled = @"PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled";

--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -493,9 +493,6 @@ struct SettingsView: View {
         @AppStorage(PlaySRGSettingPresenterModeEnabled) var isPresenterModeEnabled = false
         @AppStorage(PlaySRGSettingStandaloneEnabled) var isStandaloneEnabled = false
         @AppStorage(PlaySRGSettingSectionWideSupportEnabled) var isSectionWideSupportEnabled = false
-#if os(iOS)
-        @AppStorage(PlaySRGSettingMediaListDividerEnabled) var isMediaListDividerEnabled = false
-#endif
         @AppStorage(PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled) var isAlwaysAskUserConsentAtLaunchEnabled = false
         
         var body: some View {
@@ -519,9 +516,6 @@ struct SettingsView: View {
                 Toggle(NSLocalizedString("Presenter mode", comment: "Presenter mode setting label"), isOn: $isPresenterModeEnabled)
                 Toggle(NSLocalizedString("Standalone playback", comment: "Standalone playback setting label"), isOn: $isStandaloneEnabled)
                 Toggle(NSLocalizedString("Section wide support", comment: "Section wide support setting label"), isOn: $isSectionWideSupportEnabled)
-#if os(iOS)
-                Toggle(NSLocalizedString("Add line dividers in episodes list in show pages", comment: "Beta tests toggle label to add line dividers in episodes list in show pages setting label"), isOn: $isMediaListDividerEnabled)
-#endif
                 NextLink {
                     PosterImagesSelectionView()
 #if os(iOS)

--- a/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
+++ b/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
@@ -25,12 +25,6 @@ extension UserDefaults {
         return string(forKey: PlaySRG.PlaySRGSettingUserLocation)
     }
     
-#if os(iOS) && (DEBUG || NIGHTLY || BETA)
-    @objc dynamic var PlaySRGSettingMediaListDividerEnabled: Bool {
-        return bool(forKey: PlaySRG.PlaySRGSettingMediaListDividerEnabled)
-    }
-#endif
-    
 #if DEBUG || NIGHTLY || BETA
     @objc dynamic var PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled: Bool {
         return bool(forKey: PlaySRG.PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled)

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -257,7 +257,7 @@ final class MediaCellSize: NSObject {
     }
     
     static func fullWidth(horizontalSizeClass: UIUserInterfaceSizeClass = .compact) -> NSCollectionLayoutSize {
-        var height = horizontalSizeClass == .compact ? constant(iOS: 84, tvOS: 120) : constant(iOS: 104, tvOS: 120)
+        let height = horizontalSizeClass == .compact ? constant(iOS: 84, tvOS: 120) : constant(iOS: 104, tvOS: 120)
         return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(CGFloat(height)))
     }
 }

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -27,16 +27,9 @@ struct MediaCell: View {
         case time
     }
     
-    enum DividerStyle {
-        case none
-        case hidden
-        case display
-    }
-    
     let media: SRGMedia?
     let style: Style
     let layout: Layout
-    let dividerStyle: DividerStyle
     let action: (() -> Void)?
     
     fileprivate var onFocusAction: ((Bool) -> Void)?
@@ -68,15 +61,10 @@ struct MediaCell: View {
         return isSelected && media != nil
     }
     
-    private var dividerSpacing: CGFloat {
-        return constant(iOS: 8, tvOS: 40)
-    }
-    
-    init(media: SRGMedia?, style: Style, layout: Layout = .adaptive, dividerStyle: DividerStyle = .none, action: (() -> Void)? = nil) {
+    init(media: SRGMedia?, style: Style, layout: Layout = .adaptive, action: (() -> Void)? = nil) {
         self.media = media
         self.style = style
         self.layout = layout
-        self.dividerStyle = dividerStyle
         self.action = action
     }
     
@@ -108,15 +96,6 @@ struct MediaCell: View {
                     if direction == .horizontal, style == .dateAndSummary, horizontalSizeClass == .regular, let media {
                         MediaMoreButton(media: media)
                     }
-                }
-                if direction == .horizontal && dividerStyle == .display {
-                    DividerView()
-                        .padding(.top, dividerSpacing)
-                }
-                if direction == .horizontal && dividerStyle == .hidden {
-                    DividerView()
-                        .padding(.top, dividerSpacing)
-                        .hidden()
                 }
             }
             .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: accessibilityTraits)
@@ -228,15 +207,6 @@ struct MediaCell: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
     }
-    
-    /// Behavior: h-exp, v-hug
-    private struct DividerView: View {
-        var body: some View {
-            Rectangle()
-                .foregroundColor(.srgGray33)
-                .frame(height: 1)
-        }
-    }
 }
 
 // MARK: Modifiers
@@ -286,11 +256,8 @@ final class MediaCellSize: NSObject {
         return LayoutGridCellSize(defaultItemWidth, aspectRatio, heightOffset, layoutWidth, spacing, 1)
     }
     
-    static func fullWidth(horizontalSizeClass: UIUserInterfaceSizeClass = .compact, displayDivider: Bool = false, dividerSpacing: CGFloat = 8) -> NSCollectionLayoutSize {
+    static func fullWidth(horizontalSizeClass: UIUserInterfaceSizeClass = .compact) -> NSCollectionLayoutSize {
         var height = horizontalSizeClass == .compact ? constant(iOS: 84, tvOS: 120) : constant(iOS: 104, tvOS: 120)
-        if displayDivider {
-            height += horizontalSizeClass == .compact ? 9 : 17
-        }
         return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(CGFloat(height)))
     }
 }


### PR DESCRIPTION
### Motivation and Context

#306 introduced a beta setting option to test divider on the vertical media list.
Options moved from public beta to internal beta.
Tests ended and options can be removed.

### Description

- Remove setting.
- Remove style and views related to divider.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
