### PR TITLE
Update romansh translation

### DIFF
--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -81,7 +81,7 @@
 "All" = "Tut";
 
 /* Always ask user consent at launch setting label */
-"Always ask user consent at launch" = "Al cumenzament adina dumandar suenter il consentiment da la utilisadra ni dal utilisader";
+"Always ask user consent at launch" = "Al cumenzament adina dumandar suenter il consentiment da l’utilisadra u da l’utilisader";
 
 /* Subtitle availability setting section footer */
 "Always visible when VoiceOver is active." = "Adina visibel cun VoiceOver activà.";


### PR DESCRIPTION
### Motivation and Context

RTR colleagues updated romansh translations. 

### Description

- Ran private script `./Configuration/Scripts/pullCrowdin.sh`.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
