### PR TITLE
CI: Tag tvOS first, then iOS

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -378,7 +378,7 @@ platform :ios do
 
     # Tag only platfoms which not have already a tag and have a what's new for beta.
     git_pull(only_tags: true)
-    platforms = ['iOS', 'tvOS'].reject do |platform|
+    platforms = ['tvOS', 'iOS'].reject do |platform|
       tag = srg_tag(platform)
       tag_version = tag_version(platform)
       git_tag_exists(tag:) || what_s_new_for_beta(platform, tag_version).empty?


### PR DESCRIPTION
### Motivation and Context

Get iOS tag the latest on Github UI.

### Description

- Apply first tvOS tag, then iOS tag.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
