### PR TITLE
Customise Github automated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+---
+changelog:
+  exclude:
+    authors:
+      - rts-devops
+    labels:
+      - internal
+  categories:
+    - title: Improvements
+      labels:
+        - improvement
+    - title: Fixes
+      labels:
+        - bug
+    - title: Maintenances
+      labels:
+        - maintenance
+    - title: CI and dev tools
+      labels:
+        - CI
+        - 'dev tool'
+    - title: Other changes
+      labels:
+        - '*'


### PR DESCRIPTION
### Motivation and Context

Github release note can be autogenerated when creating it. Customisation is possible, linked to labels:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

### Description

- Add yml file for GitHub release notes.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
