### PR TITLE
CI: don't erase existing Play SRF tvOS screenshots

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -66,7 +66,7 @@
 	- Play RSI tvOS: `fastlane ios tvOSrsiScreenshots`
 	- Play RTR tvOS: `fastlane ios tvOSrtrScreenshots`
 	- Play RTS tvOS: `fastlane ios tvOSrtsScreenshots`
-	- Play SRF tvOS: `fastlane ios tvOSsrfScreenshots`
+	- Play SRF tvOS: `fastlane ios tvOSsrfScreenshots` (No upload to ASC, due to some marketing images)
 	- Play SWI tvOS: `fastlane ios tvOSswiScreenshots`
 - Application status (Ready for sale, In review, etc…)
 	- All published apps: `fastlane ios appStoreAppStatus`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -418,12 +418,12 @@ platform :ios do
     upload_screenshots(platform)
   end
 
-  desc 'SRF: Makes iOS screenshots. !!! No replacement made on App Store Connect !!!'
+  desc 'SRF: Makes iOS screenshots. No replacement made on App Store Connect.'
   lane :iOSsrfScreenshots do
     platform = 'iOS'
 
     screenshots(platform, 'SRF')
-    # upload_screenshots(platform) # Don't erase existing ones, from SRF marketing team.
+    # Don't erase existing screenshots, from SRF marketing team.
   end
 
   desc 'SWI: Makes iOS screenshots and replaces current ones on App Store Connect.'
@@ -588,12 +588,12 @@ platform :ios do
     upload_screenshots(platform)
   end
 
-  desc 'SRF: Makes tvOS screenshots and replaces current ones on App Store Connect.'
+  desc 'SRF: Makes tvOS screenshots. No replacement made on App Store Connect.'
   lane :tvOSsrfScreenshots do
     platform = 'tvOS'
 
     screenshots(platform, 'SRF')
-    upload_screenshots(platform)
+    # Don't erase existing screenshots, from SRF marketing team.
   end
 
   desc 'SWI: Makes tvOS screenshots and replaces current ones on App Store Connect.'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -213,7 +213,7 @@ RTS: Makes iOS screenshots and replaces current ones on App Store Connect.
 [bundle exec] fastlane ios iOSsrfScreenshots
 ```
 
-SRF: Makes iOS screenshots. !!! No replacement made on App Store Connect !!!
+SRF: Makes iOS screenshots. No replacement made on App Store Connect.
 
 ### ios iOSswiScreenshots
 
@@ -413,7 +413,7 @@ RTS: Makes tvOS screenshots and replaces current ones on App Store Connect.
 [bundle exec] fastlane ios tvOSsrfScreenshots
 ```
 
-SRF: Makes tvOS screenshots and replaces current ones on App Store Connect.
+SRF: Makes tvOS screenshots. No replacement made on App Store Connect.
 
 ### ios tvOSswiScreenshots
 


### PR DESCRIPTION
### Motivation and Context

SRF marketing team did great tvOS AppStore image preview for the AppStore detail page.
The fastlane script must not erase it now.

### Description

- Remove the upload screenshots step in script.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
