### PR TITLE
Update dependencies

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -113,7 +113,7 @@ name: Comscore-Swift-Package-Manager, nameSpecified: Comscore-Swift-Package-Mana
 
 name: DZNEmptyDataSet, nameSpecified: DZNEmptyDataSet, owner: dzenbot, version: , source: https://github.com/dzenbot/DZNEmptyDataSet
 
-name: firebase-ios-sdk, nameSpecified: Firebase, owner: firebase, version: 10.14.0, source: https://github.com/firebase/firebase-ios-sdk
+name: firebase-ios-sdk, nameSpecified: Firebase, owner: firebase, version: 10.15.0, source: https://github.com/firebase/firebase-ios-sdk
 
 name: FSCalendar, nameSpecified: FSCalendar, owner: WenchaoD, version: 2.8.4, source: https://github.com/WenchaoD/FSCalendar
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -107,7 +107,7 @@ name: abseil-cpp-binary, nameSpecified: abseil, owner: google, version: 1.202206
 
 name: Aiolos, nameSpecified: Aiolos, owner: IdeasOnCanvas, version: 1.9.7, source: https://github.com/IdeasOnCanvas/Aiolos
 
-name: appcenter-sdk-apple, nameSpecified: AppCenter, owner: microsoft, version: 5.0.3, source: https://github.com/microsoft/appcenter-sdk-apple
+name: appcenter-sdk-apple, nameSpecified: AppCenter, owner: microsoft, version: 5.0.4, source: https://github.com/microsoft/appcenter-sdk-apple
 
 name: Comscore-Swift-Package-Manager, nameSpecified: Comscore-Swift-Package-Manager, owner: comScore, version: 6.10.2, source: https://github.com/comScore/Comscore-Swift-Package-Manager
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -62,7 +62,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/firebase-ios-sdk</string>
 			<key>Title</key>
-			<string>Firebase (10.14.0)</string>
+			<string>Firebase (10.15.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -30,7 +30,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/appcenter-sdk-apple</string>
 			<key>Title</key>
-			<string>AppCenter (5.0.3)</string>
+			<string>AppCenter (5.0.4)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "2bfe6abe1014aafe5cf28401708f7d39f9926a76",
-        "version" : "10.14.0"
+        "revision" : "8a8ec57a272e0d31480fb0893dda0cf4f769b57e",
+        "version" : "10.15.0"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -419,8 +419,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk",
       "state" : {
-        "revision" : "c3943c73144327d4d168fab0efb314b029041e3c",
-        "version" : "2.8.3"
+        "revision" : "4737612c73ae37cf3f2d5729c994ceaa388685a0",
+        "version" : "2.8.4"
       }
     },
     {
@@ -428,8 +428,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://bitbucket.org/usercentricscode/usercentrics-spm-ui",
       "state" : {
-        "revision" : "f15804092487750001e02230f571035e11ade1f1",
-        "version" : "2.8.3"
+        "revision" : "2a435ad5495970b2f2f6a2b60eab4124a6076f18",
+        "version" : "2.8.4"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
       "state" : {
-        "revision" : "5756ddb0f09041e91bdb3b73c17296ac005ad11a",
-        "version" : "5.0.3"
+        "revision" : "1120c26835925f8314d035127c580bc71689c620",
+        "version" : "5.0.4"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

Code maintenance and be update to date.

### Description

- Update [Usercentrics](https://docs.usercentrics.com/cmp_in_app_sdk/latest/about/history/) to `2.8.4`. TCF update. Not used in Play.
- Update [AppCenter](https://github.com/microsoft/appcenter-sdk-apple/releases/tag/5.0.4) to `5.0.4`. New Code privacy file.
- Update [Firebase](https://firebase.google.com/support/release-notes/ios#10.15.0) to `10.15.0`.  Cloud Firestore update. Not used in Play.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
