### PR TITLE
Fix fastlane private betas workflow

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1856,7 +1856,7 @@ def bump_build_number_beta
 
   bump_build_number_commit
   git_pull(rebase: true)
-  push_to_git_remote
+  push_to_git_remote(tags: false)
 end
 
 def cherrypick_beta_on_develop(commits)
@@ -1909,8 +1909,8 @@ def gitflow_release_platforms(platforms, branch_name)
     bump_marketing_version_commit(platforms[index])
   end
 
-  push_to_git_remote(local_branch: 'master', remote_branch: 'master')
-  push_to_git_remote(local_branch: 'develop', remote_branch: 'develop')
+  push_to_git_remote(local_branch: 'master', remote_branch: 'master', tags: true)
+  push_to_git_remote(local_branch: 'develop', remote_branch: 'develop', tags: false)
 end
 
 def gitflow_release(tags, branch_name)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1844,7 +1844,7 @@ def tag_beta(platform)
   else
     add_git_tag(tag:, sign: true)
     UI.message "Tag \"#{tag}\" created. ✅"
-    push_to_git_remote
+    push_git_tags
   end
 end
 


### PR DESCRIPTION
### Motivation and Context

Running in parallel the iOS and tvOS private betas workflow, the [second workflow](https://playcity.eu.ngrok.io/buildConfiguration/playsrgios_BetasIOS/387008?buildTab=log&focusLine=16791&logView=flowAware&linesState=103) ended with an error.

```
push_to_git_remote

* [new tag]           ios/3.7.8-430 -> ios/3.7.8-430
! [rejected]          develop -> develop (non-fast-forward)
error: failed to push some refs to 'github.com:SRGSSR/playsrg-apple.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

### Description

- change action on tags step to [push_git_tags](http://docs.fastlane.tools/actions/push_git_tags/#push_git_tags)-
- Improve when to push tags and branches. 

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
