### PR TITLE
Update SRGDataProvider with RTS image service update

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -167,7 +167,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 19.0.1, source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -167,7 +167,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 19.0.2, source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -302,7 +302,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>srgdataprovider-apple</string>
+			<string>SRGDataProvider (19.0.2)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -302,7 +302,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>SRGDataProvider (19.0.1)</string>
+			<string>srgdataprovider-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19306,8 +19306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 19.0.2;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19306,7 +19306,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = "feature/47-use-play-srg-image-service-for-rts";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19306,8 +19306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 19.0.1;
+				branch = "feature/47-use-play-srg-image-service-for-rts";
+				kind = branch;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "9be423f396f61104976c251852a15610c281ec4d",
-        "version" : "19.0.1"
+        "branch" : "feature/47-use-play-srg-image-service-for-rts",
+        "revision" : "29098c75804346abd03f4d0f361ed0cc5ee20673"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "branch" : "develop",
-        "revision" : "64b2e3a7767e53e832beadbf4ae9a80234cdcd93"
+        "revision" : "b29c4e796d0c1dbe4bb05b1f79834f4560ee6347",
+        "version" : "19.0.2"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "branch" : "feature/47-use-play-srg-image-service-for-rts",
-        "revision" : "29098c75804346abd03f4d0f361ed0cc5ee20673"
+        "branch" : "develop",
+        "revision" : "64b2e3a7767e53e832beadbf4ae9a80234cdcd93"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

All image urls can now use Play SRG image service, RTS image included.
RTS service image has been updated to support the _aspect ratio_ sub path without _width_ or _height_ requested values.
https://github.com/SRGSSR/srgdataprovider-apple/issues/47

### Description

- Update `SRGDataProvider` with this fix: https://github.com/SRGSSR/srgdataprovider-apple/pull/51

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
