### PR TITLE
Enable subtitles first time for Play RTR

### DIFF
--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -24,7 +24,7 @@
   "continuousPlaybackBackgroundTransitionDuration": 0,
   "endToleranceRatio": 0.02,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
-  "subtitleOptionLanguage": "de",
+  "discoverySubtitleOptionLanguage": "de",
   "audioDescriptionAvailabilityHidden": true,
   "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -24,6 +24,7 @@
   "continuousPlaybackBackgroundTransitionDuration": 0,
   "endToleranceRatio": 0.02,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
+  "subtitleOptionLanguage": "de",
   "audioDescriptionAvailabilityHidden": true,
   "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -64,7 +64,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, readonly, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
 
-@property (nonatomic, readonly, copy, nullable) NSString *subtitleOptionLanguage;
+@property (nonatomic, readonly, copy, nullable) NSString *discoverySubtitleOptionLanguage;
 
 @property (nonatomic, readonly, getter=arePosterImagesEnabled) BOOL posterImagesEnabled;
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -97,7 +97,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, getter=isShowLeadPreferred) BOOL showLeadPreferred;
 
-@property (nonatomic, readonly, nullable) NSString *userConsentDefaultLanguage;
+@property (nonatomic, readonly, copy, nullable) NSString *userConsentDefaultLanguage;
 
 - (nullable RadioChannel *)radioChannelForUid:(nullable NSString *)uid;
 - (nullable RadioChannel *)radioHomepageChannelForUid:(nullable NSString *)uid;         // only returns a result if the radio channel exists and has a corresponding homepage

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -63,6 +63,9 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, readonly, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
+
+@property (nonatomic, readonly, copy, nullable) NSString *subtitleOptionLanguage;
+
 @property (nonatomic, readonly, getter=arePosterImagesEnabled) BOOL posterImagesEnabled;
 
 @property (nonatomic, readonly) NSArray<NSNumber *> *liveHomeSections;                  // wrap `HomeSection` values

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -67,10 +67,10 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
         return [AVMediaSelectionGroup mediaSelectionOptionsFromArray:matchingAudioOptions withMediaCharacteristics:characteristics].firstObject ?: matchingAudioOptions.firstObject;
     };
     
-    if (ApplicationConfiguration.sharedApplicationConfiguration.vendor == SRGVendorRTR) {
+    if (ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage != nil) {
         controller.subtitleConfigurationBlock = ^AVMediaSelectionOption * _Nullable(NSArray<AVMediaSelectionOption *> * _Nonnull subtitleOptions, AVMediaSelectionOption * _Nullable audioOption, AVMediaSelectionOption * _Nullable defaultSubtitleOption) {
             NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(AVMediaSelectionOption * _Nullable option, NSDictionary<NSString *,id> * _Nullable bindings) {
-                return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:@"de"];
+                return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage];
             }];
             return [subtitleOptions filteredArrayUsingPredicate:predicate].firstObject ?: defaultSubtitleOption;
         };
@@ -137,6 +137,9 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
+
+@property (nonatomic, copy) NSString *subtitleOptionLanguage;
+
 @property (nonatomic, getter=arePosterImagesEnabled) BOOL posterImagesEnabled;
 
 @property (nonatomic) NSArray<NSNumber *> *liveHomeSections;
@@ -388,6 +391,9 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     
     self.subtitleAvailabilityHidden = [firebaseConfiguration boolForKey:@"subtitleAvailabilityHidden"];
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];
+    
+    self.subtitleOptionLanguage = [firebaseConfiguration stringForKey:@"subtitleOptionLanguage"];
+    
     self.posterImagesEnabled = [firebaseConfiguration boolForKey:@"posterImagesEnabled"];
     
 #if TARGET_OS_IOS

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -66,6 +66,16 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
         NSArray<AVMediaCharacteristic> *characteristics = CFBridgingRelease(MAAudibleMediaCopyPreferredCharacteristics());
         return [AVMediaSelectionGroup mediaSelectionOptionsFromArray:matchingAudioOptions withMediaCharacteristics:characteristics].firstObject ?: matchingAudioOptions.firstObject;
     };
+    
+    if (ApplicationConfiguration.sharedApplicationConfiguration.vendor == SRGVendorRTR) {
+        controller.subtitleConfigurationBlock = ^AVMediaSelectionOption * _Nullable(NSArray<AVMediaSelectionOption *> * _Nonnull subtitleOptions, AVMediaSelectionOption * _Nullable audioOption, AVMediaSelectionOption * _Nullable defaultSubtitleOption) {
+            NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(AVMediaSelectionOption * _Nullable option, NSDictionary<NSString *,id> * _Nullable bindings) {
+                return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:@"de"];
+            }];
+            return [subtitleOptions filteredArrayUsingPredicate:predicate].firstObject ?: defaultSubtitleOption;
+        };
+    }
+    
     [controller reloadMediaConfiguration];
     
     controller.serviceURL = SRGDataProvider.currentDataProvider.serviceURL;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -67,7 +67,7 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
         return [AVMediaSelectionGroup mediaSelectionOptionsFromArray:matchingAudioOptions withMediaCharacteristics:characteristics].firstObject ?: matchingAudioOptions.firstObject;
     };
     
-    if (ApplicationConfiguration.sharedApplicationConfiguration.discoverySubtitleOptionLanguage != nil) {
+    if (ApplicationConfiguration.sharedApplicationConfiguration.discoverySubtitleOptionLanguage != nil && !ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce()) {
         controller.subtitleConfigurationBlock = ^AVMediaSelectionOption * _Nullable(NSArray<AVMediaSelectionOption *> * _Nonnull subtitleOptions, AVMediaSelectionOption * _Nullable audioOption, AVMediaSelectionOption * _Nullable defaultSubtitleOption) {
             NSString *subtitleOptionLanguage = ApplicationConfiguration.sharedApplicationConfiguration.discoverySubtitleOptionLanguage;
             NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(AVMediaSelectionOption * _Nullable option, NSDictionary<NSString *,id> * _Nullable bindings) {
@@ -77,6 +77,7 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
             AVMediaSelectionOption *subtitleOption = [subtitleOptions filteredArrayUsingPredicate:predicate].firstObject;
             if (subtitleOption != nil) {
                 MACaptionAppearanceAddSelectedLanguage(kMACaptionAppearanceDomainUser, (__bridge CFStringRef _Nonnull)(subtitleOptionLanguage));
+                ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(YES);
                 return subtitleOption;
             }
             else {

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -69,10 +69,19 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
     
     if (ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage != nil) {
         controller.subtitleConfigurationBlock = ^AVMediaSelectionOption * _Nullable(NSArray<AVMediaSelectionOption *> * _Nonnull subtitleOptions, AVMediaSelectionOption * _Nullable audioOption, AVMediaSelectionOption * _Nullable defaultSubtitleOption) {
+            NSString *subtitleOptionLanguage = ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage;
             NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(AVMediaSelectionOption * _Nullable option, NSDictionary<NSString *,id> * _Nullable bindings) {
-                return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage];
+                return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:subtitleOptionLanguage];
             }];
-            return [subtitleOptions filteredArrayUsingPredicate:predicate].firstObject ?: defaultSubtitleOption;
+            
+            AVMediaSelectionOption *subtitleOption = [subtitleOptions filteredArrayUsingPredicate:predicate].firstObject;
+            if (subtitleOption != nil) {
+                MACaptionAppearanceAddSelectedLanguage(kMACaptionAppearanceDomainUser, (__bridge CFStringRef _Nonnull)(subtitleOptionLanguage));
+                return subtitleOption;
+            }
+            else {
+                return defaultSubtitleOption;
+            }
         };
     }
     

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -67,9 +67,9 @@ void ApplicationConfigurationApplyControllerSettings(SRGLetterboxController *con
         return [AVMediaSelectionGroup mediaSelectionOptionsFromArray:matchingAudioOptions withMediaCharacteristics:characteristics].firstObject ?: matchingAudioOptions.firstObject;
     };
     
-    if (ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage != nil) {
+    if (ApplicationConfiguration.sharedApplicationConfiguration.discoverySubtitleOptionLanguage != nil) {
         controller.subtitleConfigurationBlock = ^AVMediaSelectionOption * _Nullable(NSArray<AVMediaSelectionOption *> * _Nonnull subtitleOptions, AVMediaSelectionOption * _Nullable audioOption, AVMediaSelectionOption * _Nullable defaultSubtitleOption) {
-            NSString *subtitleOptionLanguage = ApplicationConfiguration.sharedApplicationConfiguration.subtitleOptionLanguage;
+            NSString *subtitleOptionLanguage = ApplicationConfiguration.sharedApplicationConfiguration.discoverySubtitleOptionLanguage;
             NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(AVMediaSelectionOption * _Nullable option, NSDictionary<NSString *,id> * _Nullable bindings) {
                 return [[option.locale objectForKey:NSLocaleLanguageCode] isEqualToString:subtitleOptionLanguage];
             }];
@@ -147,7 +147,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
 
-@property (nonatomic, copy) NSString *subtitleOptionLanguage;
+@property (nonatomic, copy) NSString *discoverySubtitleOptionLanguage;
 
 @property (nonatomic, getter=arePosterImagesEnabled) BOOL posterImagesEnabled;
 
@@ -401,7 +401,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.subtitleAvailabilityHidden = [firebaseConfiguration boolForKey:@"subtitleAvailabilityHidden"];
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];
     
-    self.subtitleOptionLanguage = [firebaseConfiguration stringForKey:@"subtitleOptionLanguage"];
+    self.discoverySubtitleOptionLanguage = [firebaseConfiguration stringForKey:@"discoverySubtitleOptionLanguage"];
     
     self.posterImagesEnabled = [firebaseConfiguration boolForKey:@"posterImagesEnabled"];
     

--- a/Application/Sources/Settings/ApplicationSettings+Common.h
+++ b/Application/Sources/Settings/ApplicationSettings+Common.h
@@ -52,4 +52,7 @@ OBJC_EXPORT NSURL *ApplicationSettingServiceURL(void);
 
 OBJC_EXPORT BOOL ApplicationSettingAutoplayEnabled(void);
 
+OBJC_EXPORT BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void);
+OBJC_EXPORT void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce);
+
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettings+Common.m
+++ b/Application/Sources/Settings/ApplicationSettings+Common.m
@@ -160,3 +160,15 @@ BOOL ApplicationSettingAutoplayEnabled(void)
 {
     return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingAutoplayEnabled];
 }
+
+BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void)
+{
+    return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
+}
+
+void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce)
+{
+    NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
+    [userDefaults setBool:discoverySubtitleOptionLanguageRunOnce forKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
+    [userDefaults synchronize];
+}

--- a/Application/Sources/Settings/ApplicationSettings.h
+++ b/Application/Sources/Settings/ApplicationSettings.h
@@ -31,8 +31,6 @@ OBJC_EXPORT SRGLetterboxPlaybackSettings *ApplicationSettingPlaybackSettings(voi
 
 OBJC_EXPORT NSTimeInterval ApplicationSettingContinuousPlaybackTransitionDuration(void);
 
-OBJC_EXPORT BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void);
-
 OBJC_EXPORT NSString * _Nullable ApplicationSettingSelectedLivestreamURNForChannelUid(NSString * _Nullable channelUid);
 OBJC_EXPORT void ApplicationSettingSetSelectedLivestreamURNForChannelUid(NSString *channelUid, NSString * _Nullable mediaURN);
 

--- a/Application/Sources/Settings/ApplicationSettings.h
+++ b/Application/Sources/Settings/ApplicationSettings.h
@@ -46,4 +46,7 @@ OBJC_EXPORT void ApplicationSettingSetLastOpenedRadioChannel(RadioChannel *radio
 
 OBJC_EXPORT BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void);
 
+OBJC_EXPORT BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void);
+OBJC_EXPORT void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce);
+
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettings.h
+++ b/Application/Sources/Settings/ApplicationSettings.h
@@ -44,7 +44,4 @@ OBJC_EXPORT void ApplicationSettingSetLastOpenedRadioChannel(RadioChannel *radio
 
 OBJC_EXPORT BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void);
 
-OBJC_EXPORT BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void);
-OBJC_EXPORT void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce);
-
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Settings/ApplicationSettings.m
+++ b/Application/Sources/Settings/ApplicationSettings.m
@@ -148,15 +148,3 @@ BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void)
 {
     return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingBackgroundVideoPlaybackEnabled];
 }
-
-BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void)
-{
-    return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
-}
-
-void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce)
-{
-    NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
-    [userDefaults setBool:discoverySubtitleOptionLanguageRunOnce forKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
-    [userDefaults synchronize];
-}

--- a/Application/Sources/Settings/ApplicationSettings.m
+++ b/Application/Sources/Settings/ApplicationSettings.m
@@ -148,3 +148,15 @@ BOOL ApplicationSettingBackgroundVideoPlaybackEnabled(void)
 {
     return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingBackgroundVideoPlaybackEnabled];
 }
+
+BOOL ApplicationSettingDiscoverySubtitleOptionLanguageRunOnce(void)
+{
+    return [NSUserDefaults.standardUserDefaults boolForKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
+}
+
+void ApplicationSettingSetDiscoverySubtitleOptionLanguageRunOnce(BOOL discoverySubtitleOptionLanguageRunOnce)
+{
+    NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
+    [userDefaults setBool:discoverySubtitleOptionLanguageRunOnce forKey:PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce];
+    [userDefaults synchronize];
+}

--- a/Application/Sources/Settings/ApplicationSettingsConstants.h
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.h
@@ -17,6 +17,7 @@ OBJC_EXPORT NSString * const PlaySRGSettingAutoplayEnabled;
 OBJC_EXPORT NSString * const PlaySRGSettingBackgroundVideoPlaybackEnabled;
 OBJC_EXPORT NSString * const PlaySRGSettingSubtitleAvailabilityDisplayed;
 OBJC_EXPORT NSString * const PlaySRGSettingAudioDescriptionAvailabilityDisplayed;
+OBJC_EXPORT NSString * const PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce;
 OBJC_EXPORT NSString * const PlaySRGSettingLastLoggedInEmailAddress;
 OBJC_EXPORT NSString * const PlaySRGSettingSelectedLivestreamURNForChannels;
 OBJC_EXPORT NSString * const PlaySRGSettingServiceIdentifier;

--- a/Application/Sources/Settings/ApplicationSettingsConstants.m
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.m
@@ -15,6 +15,7 @@ NSString * const PlaySRGSettingAutoplayEnabled = @"PlaySRGSettingAutoplayEnabled
 NSString * const PlaySRGSettingBackgroundVideoPlaybackEnabled = @"PlaySRGSettingBackgroundVideoPlaybackEnabled";
 NSString * const PlaySRGSettingSubtitleAvailabilityDisplayed = @"PlaySRGSettingSubtitleAvailabilityDisplayed";
 NSString * const PlaySRGSettingAudioDescriptionAvailabilityDisplayed = @"PlaySRGSettingAudioDescriptionAvailabilityDisplayed";
+NSString * const PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce = @"PlaySRGSettingDiscoverySubtitleOptionLanguageRunOnce";
 NSString * const PlaySRGSettingLastLoggedInEmailAddress = @"PlaySRGSettingLastLoggedInEmailAddress";
 NSString * const PlaySRGSettingSelectedLivestreamURNForChannels = @"PlaySRGSettingSelectedLivestreamURNForChannels";
 NSString * const PlaySRGSettingServiceIdentifier = @"PlaySRGSettingServiceIdentifier";

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -143,6 +143,6 @@ Feeds
 * `posterImagesEnabled` (optional, boolean): If set to `true`, poster images are displayed where appropriate. 
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
-* `subtitleOptionLanguage` (optional, string): Set subtitle language to display subtitles in every playback session if available. 
+* `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
 * `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.
 * `tvThirdPartyChannelsAvailable` (optional, boolean): if set to `true`, third-party TV channel content is available in the TV guide.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -143,5 +143,6 @@ Feeds
 * `posterImagesEnabled` (optional, boolean): If set to `true`, poster images are displayed where appropriate. 
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
+* `subtitleOptionLanguage` (optional, string): Set subtitle language to display subtitles in every playback session if available. 
 * `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.
 * `tvThirdPartyChannelsAvailable` (optional, boolean): if set to `true`, third-party TV channel content is available in the TV guide.


### PR DESCRIPTION
### Motivation and Context

As a RTR user, I want to have the German subtitle active the first time, so that I can easy read what is spoken in Rätoromanisch.

Many RTR videos have German subtitles included, in the HLS manifest.
First time, enable German subtitles if the video has it. Let the user decide after to keep it or disable it.

### Description

- Add `discoverySubtitleOptionLanguage` remote configuration to enable subtitles in the selected language at first time a video with subtitles is played.
- To keep this setting on next video, apply the language choice on the system level.
- Save in User Default that it has been run one. No more execution after.
- Set `discoverySubtitleOptionLanguage` to `de` for Play RTR.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
