### PR TITLE
Don't stop playback because of displayed user consent banner

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -104,11 +104,6 @@ static void *s_kvoContext = &s_kvoContext;
                                                name:SRGLetterboxPlaybackDidContinueAutomaticallyNotification
                                              object:nil];
     
-    [NSNotificationCenter.defaultCenter addObserver:self
-                                           selector:@selector(userConsentWillShowBanner:)
-                                               name:UserConsentHelper.userConsentWillShowBannerNotification
-                                             object:nil];
-    
     [PushService.sharedService setupWithLaunchingWithOptions:launchOptions];
     [PushService.sharedService updateApplicationBadge];
     
@@ -377,11 +372,6 @@ static void *s_kvoContext = &s_kvoContext;
                                                        mediaUrn:media.URN]
          send];
     }
-}
-
-- (void)userConsentWillShowBanner:(NSNotification *)notification
-{
-    [SRGLetterboxService.sharedService.controller pause];
 }
 
 - (void)userDidCancelLogin:(NSNotification *)notification

--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -54,18 +54,9 @@ extension UIViewController {
                 }
                 .store(in: &cancellables)
             
-            NotificationCenter.default.weakPublisher(for: UserConsentHelper.userConsentWillShowBannerNotification)
-                .sink { _ in
-                    controller.pause()
-                }
-                .store(in: &cancellables)
-            
             let position = HistoryResumePlaybackPositionForMedia(media)
-            controller.prepare(toPlay: media, at: position, withPreferredSettings: nil, completionHandler: {
-                if !UserConsentHelper.isShowingBanner {
-                    controller.play()
-                }
-            })
+            controller.playMedia(media, at: position, withPreferredSettings: nil)
+            
             present(letterboxViewController, animated: animated) {
                 SRGAnalyticsTracker.shared.trackPageView(withTitle: AnalyticsPageTitle.player.rawValue, type: AnalyticsPageType.detail.rawValue, levels: [AnalyticsPageLevel.play.rawValue])
                 if let completion {

--- a/Application/Sources/Helpers/Categories/UIViewController+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UIViewController+PlaySRG.m
@@ -206,9 +206,7 @@ static void *s_isViewCurrentKey = &s_isViewCurrentKey;
                 && letterboxController.playbackState != SRGMediaPlayerPlaybackStatePreparing
                 && letterboxController.playbackState != SRGMediaPlayerPlaybackStateEnded) {
             [letterboxController seekToPosition:position withCompletionHandler:^(BOOL finished) {
-                if (![UserConsentHelper isShowingBanner]) {
-                    [letterboxController play];
-                }
+                [letterboxController play];
             }];
         }
         else {

--- a/Application/Sources/Helpers/Categories/UIViewController+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UIViewController+PlaySRG.m
@@ -212,11 +212,7 @@ static void *s_isViewCurrentKey = &s_isViewCurrentKey;
             }];
         }
         else {
-            [letterboxController prepareToPlayMedia:media atPosition:position withPreferredSettings:ApplicationSettingPlaybackSettings()completionHandler:^{
-                if (![UserConsentHelper isShowingBanner]) {
-                    [letterboxController play];
-                }
-            }];
+            [letterboxController playMedia:media atPosition:position withPreferredSettings:ApplicationSettingPlaybackSettings()];
         }
         completion ? completion() : nil;
     }

--- a/Application/Sources/MiniPlayer/PlayMiniPlayerView.m
+++ b/Application/Sources/MiniPlayer/PlayMiniPlayerView.m
@@ -379,11 +379,7 @@
     else {
         controller = [[SRGLetterboxController alloc] init];
         ApplicationConfigurationApplyControllerSettings(controller);
-        [controller prepareToPlayMedia:media atPosition:position withPreferredSettings:ApplicationSettingPlaybackSettings()completionHandler:^{
-            if (![UserConsentHelper isShowingBanner]) {
-                [controller play];
-            }
-        }];
+        [controller playMedia:media atPosition:position withPreferredSettings:ApplicationSettingPlaybackSettings()];
         [SRGLetterboxService.sharedService enableWithController:controller pictureInPictureDelegate:nil];
     }
     

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -434,18 +434,10 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         };
         
         if (self.originalMedia) {
-            [self.letterboxController prepareToPlayMedia:self.originalMedia atPosition:self.originalPosition withPreferredSettings:ApplicationSettingPlaybackSettings() completionHandler:^{
-                if (![UserConsentHelper isShowingBanner]) {
-                    [self.letterboxController play];
-                }
-            }];
+            [self.letterboxController playMedia:self.originalMedia atPosition:self.originalPosition withPreferredSettings:ApplicationSettingPlaybackSettings()];
         }
         else {
-            [self.letterboxController prepareToPlayURN:self.originalURN atPosition:self.originalPosition withPreferredSettings:ApplicationSettingPlaybackSettings() completionHandler:^{
-                if (![UserConsentHelper isShowingBanner]) {
-                    [self.letterboxController play];
-                }
-            }];
+            [self.letterboxController playURN:self.originalURN atPosition:self.originalPosition withPreferredSettings:ApplicationSettingPlaybackSettings()];
         }
     }
     

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -423,9 +423,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     
     if (self.originalLetterboxController) {
         // Always resume playback if the original controller was not playing
-        if (![UserConsentHelper isShowingBanner]) {
-            [self.letterboxController play];
-        }
+        [self.letterboxController play];
     }
     else {
         self.letterboxController.contentURLOverridingBlock = ^(NSString *URN) {

--- a/Application/Sources/Player/MediaPreviewViewController.m
+++ b/Application/Sources/Player/MediaPreviewViewController.m
@@ -107,11 +107,7 @@
     };
     ApplicationConfigurationApplyControllerSettings(self.letterboxController);
     
-    [self.letterboxController prepareToPlayMedia:self.media atPosition:HistoryResumePlaybackPositionForMedia(self.media) withPreferredSettings:ApplicationSettingPlaybackSettings() completionHandler:^{
-        if (![UserConsentHelper isShowingBanner]) {
-            [self.letterboxController play];
-        }
-    }];
+    [self.letterboxController playMedia:self.media atPosition:HistoryResumePlaybackPositionForMedia(self.media) withPreferredSettings:ApplicationSettingPlaybackSettings()];
     [self.letterboxView setUserInterfaceHidden:YES animated:NO togglable:NO];
     [self.letterboxView setTimelineAlwaysHidden:YES animated:NO];
     

--- a/Application/Sources/Player/MediaPreviewViewController.m
+++ b/Application/Sources/Player/MediaPreviewViewController.m
@@ -157,9 +157,7 @@
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             if (self.shouldRestoreServicePlayback) {
                 [[AVAudioSession sharedInstance] setCategory:self.previousAudioSessionCategory error:nil];
-                if (![UserConsentHelper isShowingBanner]) {
-                    [SRGLetterboxService.sharedService.controller play];
-                }
+                [SRGLetterboxService.sharedService.controller play];
             }
         });
     }

--- a/Application/Sources/Player/SongsViewController.m
+++ b/Application/Sources/Player/SongsViewController.m
@@ -290,9 +290,7 @@
     SRGSong *song = self.items[indexPath.row];
     NSDate *seekDate = [song.date dateByAddingTimeInterval:0.3];
     [self.letterboxController seekToPosition:[SRGPosition positionAtDate:seekDate] withCompletionHandler:^(BOOL finished) {
-        if (![UserConsentHelper isShowingBanner]) {
-            [self.letterboxController play];
-        }
+        [self.letterboxController play];
     }];
 }
 


### PR DESCRIPTION
### Motivation and Context

UX feedbacks after 1 month with the user consent banner:
- Siri shortcut can't play audio automatically content if banner is displayed.
- Playing video in Picture in Picture and displaying user consent second banner from the settings view pause the content.

Strange for the users.

### Description

- Don't stop playback because of user consent banner displayed.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
