### PR TITLE
Application version at bottom settings view on any builds

### DIFF
--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -54,7 +54,7 @@ struct SettingsView: View {
             DeveloperSection()
 #endif
 #if DEBUG || NIGHTLY || BETA
-            DebugInformationSection(model: model)
+            BottomAdditionalInformationSection(model: model)
 #endif
         }
 #if os(tvOS)
@@ -433,9 +433,7 @@ struct SettingsView: View {
                     Button(NSLocalizedString("Become a beta tester", comment: "Label of the button to become beta tester"), action: becomeBetaTester)
                 }
 #endif
-#if !DEBUG && !NIGHTLY && !BETA
                 VersionCell(model: model)
-#endif
             } header: {
                 Text(NSLocalizedString("Information", comment: "Information section header"))
             }
@@ -796,10 +794,10 @@ struct SettingsView: View {
     }
 #endif
     
-    // MARK: Debug information section
+    // MARK: Bottom additional information section
 
 #if DEBUG || NIGHTLY || BETA
-    private struct DebugInformationSection: View {
+    private struct BottomAdditionalInformationSection: View {
         @ObservedObject var model: SettingsViewModel
         
         var body: some View {

--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -53,6 +53,9 @@ struct SettingsView: View {
 #if os(iOS) && (DEBUG || APPCENTER)
             DeveloperSection()
 #endif
+#if DEBUG || NIGHTLY || BETA
+            DebugInformationSection(model: model)
+#endif
         }
 #if os(tvOS)
         .listStyle(GroupedListStyle())
@@ -430,13 +433,15 @@ struct SettingsView: View {
                     Button(NSLocalizedString("Become a beta tester", comment: "Label of the button to become beta tester"), action: becomeBetaTester)
                 }
 #endif
+#if !DEBUG && !NIGHTLY && !BETA
                 VersionCell(model: model)
+#endif
             } header: {
                 Text(NSLocalizedString("Information", comment: "Information section header"))
             }
         }
         
-        private struct VersionCell: View {
+        fileprivate struct VersionCell: View {
             @ObservedObject var model: SettingsViewModel
             
             var body: some View {
@@ -787,6 +792,22 @@ struct SettingsView: View {
         
         private func toggleFlex() {
             FLEXManager.shared.toggleExplorer()
+        }
+    }
+#endif
+    
+    // MARK: Debug information section
+
+#if DEBUG || NIGHTLY || BETA
+    private struct DebugInformationSection: View {
+        @ObservedObject var model: SettingsViewModel
+        
+        var body: some View {
+            PlaySection {
+                InformationSection.VersionCell(model: model)
+            } header: {
+                Text(NSLocalizedString("Information", comment: "Information section header"))
+            }
         }
     }
 #endif


### PR DESCRIPTION
### Motivation and Context

As a tester at SRGSSR, they need to check the app version often.
The natural UX is to open the application settings view and scroll down.

For debug, nighty and private beta builds, additional settings sections are displayed, and application version information is not at the bottom.

This PR proposes to add application version at bottom on any builds, if not displayed.

### Description

- Add application version in an additional information section at below of the settings view for debug, nighty and private beta builds, after the advanced sections.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
