### PR TITLE
Fix build with no Airship configuration

### DIFF
--- a/Application/Sources/Application/UserConsentHelper.swift
+++ b/Application/Sources/Application/UserConsentHelper.swift
@@ -283,13 +283,14 @@ enum UCService: Hashable, CaseIterable {
             switch service {
 #if os(iOS)
             case .airship:
-                // Airship analytics feature is disabled at launch. See `PushService.m`.
-                if acceptedConsent {
-                    Airship.shared.privacyManager.enableFeatures(Features.analytics)
-                }
-                else {
-                    Airship.shared.privacyManager.disableFeatures(Features.analytics)
-                }
+                if PushService.shared != nil {
+                    // Airship analytics feature is disabled at launch. See `PushService.m`.
+                    if acceptedConsent {
+                        Airship.shared.privacyManager.enableFeatures(Features.analytics)
+                    }
+                    else {
+                        Airship.shared.privacyManager.disableFeatures(Features.analytics)
+                    }}
 #endif
             case .appcenter:
                 // Only `Crashes` service is used. `Analytics` service not instantiated.


### PR DESCRIPTION
### Motivation and Context

Building `AppStore` configuration on simulator, no Airship configuration is founded.
The application crashes at launch.

This PR fixes it. 

### Description

- Apply AirShip consent only if AirShip instantiated.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
