### PR TITLE
Always display subscribe buttons on iOS

### DIFF
--- a/Application/Sources/Content/ShowHeaderViewModel.swift
+++ b/Application/Sources/Content/ShowHeaderViewModel.swift
@@ -99,7 +99,7 @@ final class ShowHeaderViewModel: ObservableObject {
     
 #if os(iOS)
     var isSubscriptionPossible: Bool {
-        return PushService.shared != nil && isFavorite
+        return PushService.shared != nil
     }
     
     var subscriptionIcon: String {

--- a/Application/Sources/Favorites/Favorites.m
+++ b/Application/Sources/Favorites/Favorites.m
@@ -104,7 +104,7 @@ BOOL FavoritesIsSubscribedToShow(SRGShow *show)
 BOOL FavoritesToggleSubscriptionForShow(SRGShow *show)
 {
     if (! FavoritesContainsShow(show)) {
-        return NO;
+        FavoritesToggleShow(show);
     }
     
     if (! [PushService.sharedService toggleSubscriptionForShow:show]) {

--- a/Application/Sources/Helpers/ApplicationSectionInfo.m
+++ b/Application/Sources/Helpers/ApplicationSectionInfo.m
@@ -58,7 +58,7 @@ ApplicationSectionOptionKey const ApplicationSectionOptionShowByDateDateKey = @"
 {
     NSMutableArray<ApplicationSectionInfo *> *sectionInfos = [NSMutableArray array];
 #if TARGET_OS_IOS
-    if (PushService.sharedService.enabled) {
+    if (PushService.sharedService != nil) {
         [sectionInfos addObject:[self applicationSectionInfoWithApplicationSection:ApplicationSectionNotifications radioChannel:nil]];
     }
 #endif


### PR DESCRIPTION
### Motivation and Context

RTS case studies had users during one week. New users didn't found notifications and share interest to get new content (page 41 and 44).
One proposition should be to display more offend the bell icon, which is the subscribe button for a show and get new on demand episodes.

### Description

- Always display subscribe button on iOS show page and add show to favorite if subscription enabled.
- Always display notifications button on iOS profile page so that user knows that the application support notifications.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
