### PR TITLE
Better image resolution on tvOS program guide

### DIFF
--- a/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreviewModel.swift
@@ -69,7 +69,7 @@ final class ProgramPreviewModel: ObservableObject {
     }
     
     var imageUrl: URL? {
-        return data?.programGuideImageUrl(size: .medium)
+        return data?.programGuideImageUrl(size: .large)
     }
     
     init() {


### PR DESCRIPTION
### Motivation and Context

On tvOS big screen, the program images are usually blurred.
It's use the medium resolution.
Using large takes a bit more time to download it but the image has a better quality.

### Description

- Use `.large` image url for tvOS program images.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
