### PR TITLE
Update Commanders Act to 5.4.2

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -137,7 +137,7 @@ name: interop-ios-for-google-sdks, nameSpecified: InteropForGoogle, owner: googl
 
 name: ios-library, nameSpecified: Airship, owner: urbanairship, version: 16.12.4, source: https://github.com/urbanairship/ios-library
 
-name: iOSV5, nameSpecified: TagCommander SDK V5, owner: CommandersAct, version: 5.4.1, source: https://github.com/CommandersAct/iOSV5
+name: iOSV5, nameSpecified: TagCommander SDK V5, owner: CommandersAct, version: 5.4.2, source: https://github.com/CommandersAct/iOSV5
 
 name: leveldb, nameSpecified: leveldb, owner: firebase, version: 1.22.2, source: https://github.com/firebase/leveldb
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -158,7 +158,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/iOSV5</string>
 			<key>Title</key>
-			<string>TagCommander SDK V5 (5.4.1)</string>
+			<string>TagCommander SDK V5 (5.4.2)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -566,15 +566,6 @@ extension Locale {
             return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
         }
     }()
-    
-    static let preferredLanguageIdentifier: String = {
-        let preferredLanguage = Locale.preferredLanguages.first ?? "en"
-        if #available(iOS 16, tvOS 16, *) {
-            return Locale(identifier: preferredLanguage).identifier(.bcp47)
-        } else {
-            return Locale(identifier: preferredLanguage).identifier.replacingOccurrences(of: "_", with: "-")
-        }
-    }()
 }
 
 extension SRGAnalyticsLabels {
@@ -583,7 +574,6 @@ extension SRGAnalyticsLabels {
         var customInfo: [String: String] = analyticsLabels.customInfo ?? [:]
         
         customInfo["navigation_app_language"] = Locale.currentLanguageIdentifier
-        customInfo["navigation_device_language"] = Locale.preferredLanguageIdentifier
         
         analyticsLabels.customInfo = customInfo
         return analyticsLabels

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CommandersAct/iOSV5.git",
       "state" : {
-        "revision" : "921c98e57e3044377ee955db5282406e11e6a787",
-        "version" : "5.4.1"
+        "revision" : "bff12bbf890409182a055999985a28b4608b9b14",
+        "version" : "5.4.2"
       }
     },
     {


### PR DESCRIPTION
Fix device language and region properties


### Motivation and Context

The current Commanders Act SDK 5.4.1 added `context.device.language` and `context.device.region` properties.
But the values are the application values, not the device values.

https://github.com/CommandersAct/iOSV5/issues/11 fixes it.

### Description

- Update Commanders Act SDK to this patch release 5.4.2: https://github.com/CommandersAct/iOSV5/releases/tag/5.4.2
- Remove `navigation_device_language` custom global label. https://github.com/SRGSSR/srganalytics-documentation/issues/8

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
