### PR TITLE
Patch analytics migration

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -261,7 +261,7 @@ static void *s_kvoContext = &s_kvoContext;
 
 - (void)setupAnalytics
 {
-    [SRGAnalyticsTracker applySetupAnalyticsWorkWorkaround];
+    [SRGAnalyticsTracker applySetupAnalyticsWorkaround];
     
     ApplicationConfiguration *applicationConfiguration = ApplicationConfiguration.sharedApplicationConfiguration;
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:applicationConfiguration.analyticsBusinessUnitIdentifier

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -37,6 +37,7 @@
 @import SRGLetterbox;
 @import SRGNetwork;
 @import SRGUserData;
+@import TCServerSide_noIDFA;
 
 static void *s_kvoContext = &s_kvoContext;
 
@@ -261,6 +262,21 @@ static void *s_kvoContext = &s_kvoContext;
 
 - (void)setupAnalytics
 {
+    // Workaround for Commanders Act migration from v4 to v5 (1 and 2)
+    
+    // 1. Migrate the TC unique id to new sdk id device property.
+    PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
+        NSString *tcUniqueId = [[NSUserDefaults standardUserDefaults] stringForKey:@"tc_unique_id"];
+        if (tcUniqueId.length != 0) {
+            [[NSUserDefaults standardUserDefaults] setObject:tcUniqueId forKey:@"#TC_SDK_ID#"];
+            [[NSUserDefaults standardUserDefaults] synchronize];
+        }
+        completionHandler(YES);
+    }, @"TCUniqueIdMigrationDone6");
+    
+    // 2. Keep the TC unique id in new ids.
+    [[TCPredefinedVariables sharedInstance] useLegacyUniqueIDForAnonymousID];
+    
     ApplicationConfiguration *applicationConfiguration = ApplicationConfiguration.sharedApplicationConfiguration;
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:applicationConfiguration.analyticsBusinessUnitIdentifier
                                                                                                        sourceKey:applicationConfiguration.analyticsSourceKey

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -37,7 +37,6 @@
 @import SRGLetterbox;
 @import SRGNetwork;
 @import SRGUserData;
-@import TCServerSide_noIDFA;
 
 static void *s_kvoContext = &s_kvoContext;
 
@@ -262,20 +261,7 @@ static void *s_kvoContext = &s_kvoContext;
 
 - (void)setupAnalytics
 {
-    // Workaround for Commanders Act migration from v4 to v5 (1 and 2)
-    
-    // 1. Migrate the TC unique id to new sdk id device property.
-    PlayApplicationRunOnce(^(void (^completionHandler)(BOOL success)) {
-        NSString *tcUniqueId = [[NSUserDefaults standardUserDefaults] stringForKey:@"tc_unique_id"];
-        if (tcUniqueId.length != 0) {
-            [[NSUserDefaults standardUserDefaults] setObject:tcUniqueId forKey:@"#TC_SDK_ID#"];
-            [[NSUserDefaults standardUserDefaults] synchronize];
-        }
-        completionHandler(YES);
-    }, @"TCUniqueIdMigrationDone6");
-    
-    // 2. Keep the TC unique id in new ids.
-    [[TCPredefinedVariables sharedInstance] useLegacyUniqueIDForAnonymousID];
+    [SRGAnalyticsTracker applySetupAnalyticsWorkWorkaround];
     
     ApplicationConfiguration *applicationConfiguration = ApplicationConfiguration.sharedApplicationConfiguration;
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:applicationConfiguration.analyticsBusinessUnitIdentifier

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -9,6 +9,7 @@ import Foundation
 import SRGAppearanceSwift
 import SRGDataProviderCombine
 import SwiftUI
+import TCServerSide_noIDFA
 
 func constant<T>(iOS: T, tvOS: T) -> T {
 #if os(tvOS)
@@ -577,5 +578,24 @@ extension SRGAnalyticsLabels {
         
         analyticsLabels.customInfo = customInfo
         return analyticsLabels
+    }
+}
+
+extension SRGAnalyticsTracker {
+    @objc class func applySetupAnalyticsWorkWorkaround() {
+        // Workaround for Commanders Act migration from v4 to v5
+        
+        // 1. Migrate the TC unique id to new sdk id device property.
+        PlayApplicationRunOnce({ completionHandler in
+            let tcUniqueId = UserDefaults.standard.string(forKey: "tc_unique_id")
+            if let tcUniqueId, !tcUniqueId.isEmpty {
+                UserDefaults.standard.set(tcUniqueId, forKey: "#TC_SDK_ID#")
+                UserDefaults.standard.synchronize()
+            }
+            completionHandler(true)
+        }, "TCUniqueIdMigrationDone")
+        
+        // 2. Keep the TC unique id in new ids.
+        TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
     }
 }

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -582,10 +582,10 @@ extension SRGAnalyticsLabels {
 }
 
 extension SRGAnalyticsTracker {
-    @objc class func applySetupAnalyticsWorkWorkaround() {
+    @objc class func applySetupAnalyticsWorkaround() {
         // Workaround for Commanders Act migration from v4 to v5
         
-        // 1. Migrate the TC unique id to new sdk id device property.
+        // 1. Migrate the TC unique id value to new `device.sdk_id` property.
         PlayApplicationRunOnce({ completionHandler in
             let tcUniqueId = UserDefaults.standard.string(forKey: "tc_unique_id")
             if let tcUniqueId, !tcUniqueId.isEmpty {
@@ -595,7 +595,7 @@ extension SRGAnalyticsTracker {
             completionHandler(true)
         }, "TCUniqueIdMigrationDone")
         
-        // 2. Keep the TC unique id in new ids.
+        // 2. Keep the TC unique id value to the new `user.consistent_anonymous_id` property.
         TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
     }
 }

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -585,17 +585,12 @@ extension SRGAnalyticsTracker {
     @objc class func applySetupAnalyticsWorkaround() {
         // Workaround for Commanders Act migration from v4 to v5
         
-        // 1. Migrate the TC unique id value to new `device.sdk_id` property.
-        PlayApplicationRunOnce({ completionHandler in
-            let tcUniqueId = UserDefaults.standard.string(forKey: "tc_unique_id")
-            if let tcUniqueId, !tcUniqueId.isEmpty {
-                UserDefaults.standard.set(tcUniqueId, forKey: "#TC_SDK_ID#")
-                UserDefaults.standard.synchronize()
-            }
-            completionHandler(true)
-        }, "TCUniqueIdMigrationDone")
+        // 1. Use the TC unique id value for new `device.sdk_id` property.
+        if let tcUniqueID = TCPredefinedVariables.sharedInstance().uniqueIdentifier(), !tcUniqueID.isEmpty {
+            TCDevice.sharedInstance().sdkID = tcUniqueID
+        }
         
-        // 2. Keep the TC unique id value to the new `user.consistent_anonymous_id` property.
+        // 2. Use the TC unique id value for the new `user.consistent_anonymous_id` property.
         TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
     }
 }

--- a/TV Application/Sources/AppDelegate.swift
+++ b/TV Application/Sources/AppDelegate.swift
@@ -88,7 +88,7 @@ extension AppDelegate: UIApplicationDelegate {
         
         UserConsentHelper.setup()
         
-        SRGAnalyticsTracker.applySetupAnalyticsWorkWorkaround()
+        SRGAnalyticsTracker.applySetupAnalyticsWorkaround()
         
         let analyticsConfiguration = SRGAnalyticsConfiguration(
             businessUnitIdentifier: configuration.analyticsBusinessUnitIdentifier,

--- a/TV Application/Sources/AppDelegate.swift
+++ b/TV Application/Sources/AppDelegate.swift
@@ -88,6 +88,8 @@ extension AppDelegate: UIApplicationDelegate {
         
         UserConsentHelper.setup()
         
+        SRGAnalyticsTracker.applySetupAnalyticsWorkWorkaround()
+        
         let analyticsConfiguration = SRGAnalyticsConfiguration(
             businessUnitIdentifier: configuration.analyticsBusinessUnitIdentifier,
             sourceKey: configuration.analyticsSourceKey,


### PR DESCRIPTION
### Motivation and Context

#326 and #387 introduced Commanders Act v5.x update.
From v4 to v5, the unique id property changed.
The current version 5.4.2 introduced ServerSide method `useLegacyUniqueIDForAnonymousID()`.
Not enough to still in use `TC_UNIQUEID` value in the new `context.device.sdk_id` new used property.
A manual migration as to be done, before a fix is implemented in SRGAnalytics and / or Commanders Act SDK.

Related links:
- Commanders Act SDK discussion https://github.com/CommandersAct/iOSV5/issues/13.
- Commanders Act SDK properties documentation: https://doc.commandersact.com/developers/tracking/about-events/mobile-sdk-event-specificity

### Description

- ~Apply once a copy of the `TC_UNIQUEID` value in `tc_unique_id` property to `#TC_SDK_ID#` property in User Default used for _device.sdk_id_ property in all event payloads.~
- Apply at application launch a value copy of `uniqueIdentifier` to `TCDevice` `sdkID` property, to have `TC_UNIQUEID` value in the _device.sdk_id_ property in all event payloads.
- Apply at application launch the  `useLegacyUniqueIDForAnonymousID()` method, to have `TC_UNIQUEID` value as well in the _user.consistent_anonymous_id_ property in all event payloads.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
