### PR TITLE
TV program guide with all SRG vendors

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -29,5 +29,6 @@
   "searchSettingSubtitledHidden": true,
   "subtitleAvailabilityHidden": true,
   "audioDescriptionAvailabilityHidden": true,
+  "tvGuideOtherBouquets": "srf,rts",
   "userConsentDefaultLanguage": "it"
 }

--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "rsi-player-tvos-apple",
   "voiceOverLanguageCode": "it",
   "appStoreProductIdentifier": 920753497,
-  "playURL": "https://www.rsi.ch/play/",
+  "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rsi.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -4,7 +4,7 @@
   "siteName": "rtr-player-ios-v",
   "tvSiteName": "rtr-player-tvos-apple",
   "appStoreProductIdentifier": 920754925,
-  "playURL": "https://www.rtr.ch/play/",
+  "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rtr.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -26,6 +26,7 @@
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
   "discoverySubtitleOptionLanguage": "de",
   "audioDescriptionAvailabilityHidden": true,
+  "tvGuideOtherBouquets": "thirdparty,rts,rsi",
   "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"
 }

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -27,6 +27,5 @@
   "discoverySubtitleOptionLanguage": "de",
   "audioDescriptionAvailabilityHidden": true,
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
-  "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"
 }

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -31,5 +31,6 @@
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
   "searchSettingSubtitledHidden": true,
   "showLeadPreferred": true,
+  "tvGuideOtherBouquets": "srf,rsi",
   "userConsentDefaultLanguage": "fr"
 }

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "rts-player-tvos-apple",
   "voiceOverLanguageCode": "fr",
   "appStoreProductIdentifier": 920754415,
-  "playURL": "https://www.rts.ch/play/",
+  "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rts.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "identityWebserviceURL": "https://hummingbird.rts.ch/api/profile",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -27,6 +27,7 @@
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
   "audioDescriptionAvailabilityHidden": true,
   "posterImagesEnabled": true,
+  "tvGuideOtherBouquets": "thirdparty,rts,rsi",
   "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"
 }

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -28,6 +28,5 @@
   "audioDescriptionAvailabilityHidden": true,
   "posterImagesEnabled": true,
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
-  "tvThirdPartyChannelsAvailable": true,
   "userConsentDefaultLanguage": "de"
 }

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "srf-player-tvos-apple",
   "voiceOverLanguageCode": "de",
   "appStoreProductIdentifier": 638194352,
-  "playURL": "https://www.srf.ch/play/",
+  "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.srf.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "swi-player-tvos-apple",
   "voiceOverLanguageCode": "en",
   "appStoreProductIdentifier": 920785201,
-  "playURL": "https://play.swissinfo.ch/play/",
+  "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://play.swissinfo.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",
   "sourceCodeURL": "https://github.com/SRGSSR/playsrg-apple",

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -225,36 +225,7 @@ static void *s_kvoContext = &s_kvoContext;
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
     dataProvider.globalParameters = ApplicationSettingGlobalParameters();
     
-    NSString *environment = nil;
-    
-    NSString *host = serviceURL.host;
-    if ([host containsString:@"test"]) {
-        environment = @"test";
-    }
-    else if ([host containsString:@"stage"]) {
-        environment = @"stage";
-    }
-    
-    if (environment) {
-        static dispatch_once_t s_onceToken2;
-        static NSDictionary<NSNumber *, NSString *> *s_suffixes;
-        dispatch_once(&s_onceToken2, ^{
-            s_suffixes = @{ @(SRGVendorRSI) : @"rsi",
-                            @(SRGVendorRTR) : @"rtr",
-                            @(SRGVendorRTS) : @"rts",
-                            @(SRGVendorSRF) : @"srf",
-                            @(SRGVendorSWI) : @"swi" };
-        });
-        SRGVendor vendor = ApplicationConfiguration.sharedApplicationConfiguration.vendor;
-        NSString *suffix = s_suffixes[@(vendor)];
-        if (suffix) {
-            NSString *URLString = [NSString stringWithFormat:@"https://srgplayer-%@.%@.srf.ch/play/", suffix, environment];
-            [ApplicationConfiguration.sharedApplicationConfiguration setOverridePlayURL:[NSURL URLWithString:URLString]];
-        }
-    }
-    else {
-        [ApplicationConfiguration.sharedApplicationConfiguration setOverridePlayURL:nil];
-    }
+    [ApplicationConfiguration.sharedApplicationConfiguration setOverridePlayURLForVendorBasedOnServiceURL:serviceURL];
 #endif
     SRGDataProvider.currentDataProvider = dataProvider;
 }

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -38,7 +38,6 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, copy) NSNumber *appStoreProductIdentifier;
 
-@property (nonatomic, readonly) NSURL *playURL;
 @property (nonatomic, readonly) NSURL *playServiceURL;
 @property (nonatomic, readonly) NSURL *middlewareURL;
 @property (nonatomic, readonly, nullable) NSURL *identityWebserviceURL;
@@ -105,6 +104,9 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 - (nullable TVChannel *)tvChannelForUid:(nullable NSString *)uid;
 - (nullable __kindof Channel *)channelForUid:(nullable NSString *)uid;
 
+
+- (nullable NSURL *)playURLForVendor:(SRGVendor)vendor;
+
 /**
  *  URLs to be used for sharing
  */
@@ -115,9 +117,9 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 
 /**
- *  An optionnal override play URL for test and stage environnements. Use `playURL` property to get the current URL.
+ *  Optionnal override play URLs for test and stage environnements. Use `playURLForVendor:` property to get the current URL.
  */
-- (void)setOverridePlayURL:(nullable NSURL *)overridePlayURL;
+- (void)setOverridePlayURLForVendorBasedOnServiceURL:(nullable NSURL *)serviceURL;
 
 #endif
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -77,6 +77,8 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly) NSArray<TVChannel *> *tvChannels;
 @property (nonatomic, readonly) NSArray<RadioChannel *> *satelliteRadioChannels;
 
+@property (nonatomic, readonly) NSArray<NSNumber *> *tvGuideOtherBouquetsObjc;
+
 @property (nonatomic, readonly) NSUInteger pageSize;                                    // page size to be used in general throughout the app
 @property (nonatomic, readonly) NSUInteger detailPageSize;                              // page size to be used in general throughout the app
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -59,7 +59,6 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly, getter=areDownloadsHintsHidden) BOOL downloadsHintsHidden;
 @property (nonatomic, readonly, getter=areShowsUnavailable) BOOL showsUnavailable;
 @property (nonatomic, readonly, getter=isTvGuideUnavailable) BOOL tvGuideUnavailable;
-@property (nonatomic, readonly, getter=areTvThirdPartyChannelsAvailable) BOOL tvThirdPartyChannelsAvailable;
 
 @property (nonatomic, readonly, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, readonly, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -143,7 +143,6 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic, getter=areDownloadsHintsHidden) BOOL downloadsHintsHidden;
 @property (nonatomic, getter=areShowsUnavailable) BOOL showsUnavailable;
 @property (nonatomic, getter=isTvGuideUnavailable) BOOL tvGuideUnavailable;
-@property (nonatomic, getter=areTvThirdPartyChannelsAvailable) BOOL tvThirdPartyChannelsAvailable;
 
 @property (nonatomic, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
@@ -399,7 +398,6 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.downloadsHintsHidden = [firebaseConfiguration boolForKey:@"downloadsHintsHidden"];
     self.showsUnavailable = [firebaseConfiguration boolForKey:@"showsUnavailable"];
     self.tvGuideUnavailable = [firebaseConfiguration boolForKey:@"tvGuideUnavailable"];
-    self.tvThirdPartyChannelsAvailable = [firebaseConfiguration boolForKey:@"tvThirdPartyChannelsAvailable"];
     
     self.subtitleAvailabilityHidden = [firebaseConfiguration boolForKey:@"subtitleAvailabilityHidden"];
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -163,6 +163,8 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic) NSArray<RadioChannel *> *satelliteRadioChannels;
 
+@property (nonatomic) NSArray<NSNumber *> *tvGuideOtherBouquetsObjc;
+
 @property (nonatomic) NSUInteger pageSize;
 @property (nonatomic) NSUInteger detailPageSize;
 
@@ -417,6 +419,8 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.radioChannels = [firebaseConfiguration radioChannelsForKey:@"radioChannels" defaultHomeSections:self.audioHomeSections];
     self.tvChannels = [firebaseConfiguration tvChannelsForKey:@"tvChannels"];
     self.satelliteRadioChannels = [firebaseConfiguration radioChannelsForKey:@"satelliteRadioChannels" defaultHomeSections:nil];
+    
+    self.tvGuideOtherBouquetsObjc = [firebaseConfiguration tvGuideBouquetsForKey:@"tvGuideOtherBouquets"];
     
     NSNumber *pageSize = [firebaseConfiguration numberForKey:@"pageSize"];
     self.pageSize = pageSize ? MAX(pageSize.unsignedIntegerValue, 1) : 20;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -420,7 +420,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.tvChannels = [firebaseConfiguration tvChannelsForKey:@"tvChannels"];
     self.satelliteRadioChannels = [firebaseConfiguration radioChannelsForKey:@"satelliteRadioChannels" defaultHomeSections:nil];
     
-    self.tvGuideOtherBouquetsObjc = [firebaseConfiguration tvGuideBouquetsForKey:@"tvGuideOtherBouquets"];
+    self.tvGuideOtherBouquetsObjc = [firebaseConfiguration tvGuideOtherBouquetsForKey:@"tvGuideOtherBouquets" vendor:vendor];
     
     NSNumber *pageSize = [firebaseConfiguration numberForKey:@"pageSize"];
     self.pageSize = pageSize ? MAX(pageSize.unsignedIntegerValue, 1) : 20;

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -82,16 +82,12 @@ extension ApplicationConfiguration {
         return Self.typeformUrlWithParameters(feedbackUrl)
     }
     
-    var tvProgramsVendors: [SRGVendor] {
+    var tvGuideThirdPartyBouquets: [TVGuideThirdPartyBouquet] {
         switch vendor {
-        case .RSI:
-            return [.RSI, .SRF, .RTS]
-        case .RTR:
-            return [.RTR, .RTS, .RSI]
-        case .RTS:
-            return [.RTS, .SRF, .RSI]
+        case .RTR, .SRF:
+            return [.nonSRG, .RTS, .RSI]
         default:
-            return [.SRF, .RTS, .RSI]
+            return []
         }
     }
 }
@@ -133,4 +129,12 @@ enum ConfiguredSection: Hashable {
     case notifications
     case radioShowAccess(channelUid: String)
 #endif
+}
+
+enum TVGuideThirdPartyBouquet: Hashable {
+    case nonSRG
+    
+    case RSI
+    case RTS
+    case SRF
 }

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -82,12 +82,9 @@ extension ApplicationConfiguration {
         return Self.typeformUrlWithParameters(feedbackUrl)
     }
     
-    var tvGuideOtherPartyBouquets: [TVGuideOtherPartyBouquet] {
-        switch vendor {
-        case .RTR, .SRF:
-            return [.nonSRG, .RTS, .RSI]
-        default:
-            return []
+    var tvGuideOtherBouquets: [TVGuideBouquet] {
+        return self.tvGuideOtherBouquetsObjc.map { number in
+            return TVGuideBouquet(rawValue: number.intValue)!
         }
     }
 }
@@ -129,12 +126,4 @@ enum ConfiguredSection: Hashable {
     case notifications
     case radioShowAccess(channelUid: String)
 #endif
-}
-
-enum TVGuideOtherPartyBouquet: Hashable {
-    case nonSRG
-    
-    case RSI
-    case RTS
-    case SRF
 }

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -81,6 +81,19 @@ extension ApplicationConfiguration {
         
         return Self.typeformUrlWithParameters(feedbackUrl)
     }
+    
+    var tvProgramsVendors: [SRGVendor] {
+        switch vendor {
+        case .RSI:
+            return [.RSI, .SRF, .RTS]
+        case .RTR:
+            return [.RTR, .RTS, .RSI]
+        case .RTS:
+            return [.RTS, .SRF, .RSI]
+        default:
+            return [.SRF, .RTS, .RSI]
+        }
+    }
 }
 
 enum ConfiguredSection: Hashable {

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -82,7 +82,7 @@ extension ApplicationConfiguration {
         return Self.typeformUrlWithParameters(feedbackUrl)
     }
     
-    var tvGuideThirdPartyBouquets: [TVGuideThirdPartyBouquet] {
+    var tvGuideOtherPartyBouquets: [TVGuideOtherPartyBouquet] {
         switch vendor {
         case .RTR, .SRF:
             return [.nonSRG, .RTS, .RSI]
@@ -131,7 +131,7 @@ enum ConfiguredSection: Hashable {
 #endif
 }
 
-enum TVGuideThirdPartyBouquet: Hashable {
+enum TVGuideOtherPartyBouquet: Hashable {
     case nonSRG
     
     case RSI

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.h
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.h
@@ -56,6 +56,11 @@ OBJC_EXPORT NSArray<NSNumber * /* HomeSection */> * _Nullable FirebaseConfigurat
 - (NSArray<RadioChannel *> *)radioChannelsForKey:(NSString *)key defaultHomeSections:(nullable NSArray<NSNumber * /* HomeSection */> *)defaultHomeSections;
 - (NSArray<TVChannel *> *)tvChannelsForKey:(NSString *)key;
 
+/**
+ *  TV guide bouquet accessors. Return an empty array if no valid data is found under the specified key.
+ */
+- (NSArray<NSNumber * /* TVGuideBouquet */> *)tvGuideBouquetsForKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.h
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.h
@@ -9,6 +9,7 @@
 #import "TVChannel.h"
 
 @import Foundation;
+@import SRGDataProviderModel;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -57,9 +58,9 @@ OBJC_EXPORT NSArray<NSNumber * /* HomeSection */> * _Nullable FirebaseConfigurat
 - (NSArray<TVChannel *> *)tvChannelsForKey:(NSString *)key;
 
 /**
- *  TV guide bouquet accessors. Return an empty array if no valid data is found under the specified key.
+ *  TV guide other bouquets accessor, main bouquet excluded. Return an empty array if no valid data is found under the specified key.
  */
-- (NSArray<NSNumber * /* TVGuideBouquet */> *)tvGuideBouquetsForKey:(NSString *)key;
+- (NSArray<NSNumber * /* TVGuideBouquet */> *)tvGuideOtherBouquetsForKey:(NSString *)key vendor:(SRGVendor)vendor;
 
 @end
 

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.h
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.h
@@ -62,6 +62,11 @@ OBJC_EXPORT NSArray<NSNumber * /* HomeSection */> * _Nullable FirebaseConfigurat
  */
 - (NSArray<NSNumber * /* TVGuideBouquet */> *)tvGuideOtherBouquetsForKey:(NSString *)key vendor:(SRGVendor)vendor;
 
+/**
+ *  Play URLs accessor. Return an empty dictionnary if no valid data is found under the specified key.
+ */
+- (NSDictionary<NSNumber *, NSURL *> *)playURLsForKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -59,6 +59,38 @@ NSArray<NSNumber *> *FirebaseConfigurationHomeSections(NSString *string)
     return homeSections.copy;
 }
 
+static NSNumber * TVGuideBouquetWithString(NSString *string)
+{
+    static dispatch_once_t s_onceToken;
+    static NSDictionary<NSString *, NSNumber *> *s_bouqets;
+    dispatch_once(&s_onceToken, ^{
+        s_bouqets = @{ @"thirdparty" : @(TVGuideBouquetThirdParty),
+                        @"rsi" : @(TVGuideBouquetRSI),
+                        @"rts" : @(TVGuideBouquetRTS),
+                        @"srf" : @(TVGuideBouquetSRF)
+        };
+    });
+    return s_bouqets[string];
+}
+
+NSArray<NSNumber *> *FirebaseConfigurationTVGuideBouquets(NSString *string)
+{
+    NSMutableArray<NSNumber *> *tvGuideBouquets = [NSMutableArray array];
+    
+    NSArray<NSString *> *tvGuideBouquetIdentifiers = [string componentsSeparatedByString:@","];
+    for (NSString *identifier in tvGuideBouquetIdentifiers) {
+        NSNumber * tvGuideBouquet = TVGuideBouquetWithString(identifier);
+        if (tvGuideBouquet != nil) {
+            [tvGuideBouquets addObject:tvGuideBouquet];
+        }
+        else {
+            PlayLogWarning(@"configuration", @"Unknown TV guide bouquet identifier %@. Skipped.", identifier);
+        }
+    }
+    
+    return tvGuideBouquets.copy;
+}
+
 @interface PlayFirebaseConfiguration ()
 
 @property (nonatomic) FIRRemoteConfig *remoteConfig;
@@ -244,6 +276,12 @@ NSArray<NSNumber *> *FirebaseConfigurationHomeSections(NSString *string)
         }
     }
     return tvChannels.copy;
+}
+
+- (NSArray<NSNumber *> *)tvGuideBouquetsForKey:(NSString *)key
+{
+    NSString *tvGuideBouquetsString = [self stringForKey:key];
+    return tvGuideBouquetsString ? FirebaseConfigurationTVGuideBouquets(tvGuideBouquetsString) : @[];
 }
 
 #pragma mark Update

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -303,6 +303,40 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
     return tvGuideBouquetsString ? FirebaseConfigurationTVGuideOtherBouquets(tvGuideBouquetsString, vendor) : @[];
 }
 
+- (NSDictionary<NSNumber *, NSURL *> *)playURLsForKey:(NSString *)key
+{
+    static NSDictionary<NSString *, NSNumber *> *s_vendors;
+    static dispatch_once_t s_onceToken;
+    dispatch_once(&s_onceToken, ^{
+        s_vendors = @{ @"rsi" : @(SRGVendorRSI),
+                       @"rtr" : @(SRGVendorRTR),
+                       @"rts" : @(SRGVendorRTS),
+                       @"srf" : @(SRGVendorSRF),
+                       @"swi" : @(SRGVendorSWI) };
+    });
+    
+    NSMutableDictionary<NSNumber *, NSURL *> *playURLs = [NSMutableDictionary dictionary];
+    
+    NSDictionary *playURLsDictionary = [self JSONDictionaryForKey:key];
+    for (NSString *key in playURLsDictionary) {
+        NSNumber *vendor = s_vendors[key];
+        if (vendor) {
+            NSURL *URL = [NSURL URLWithString:playURLsDictionary[key]];
+            if (URL) {
+                playURLs[vendor] = URL;
+            }
+            else {
+                PlayLogWarning(@"configuration", @"Play URL configuration is not valid. The URL of %@ is not valid.", key);
+            }
+        }
+        else {
+            PlayLogWarning(@"configuration", @"Play URL configuration business unit identifier is not valid. %@ is not valid.", key);
+        }
+    }
+    
+    return playURLs.copy;
+}
+
 #pragma mark Update
 
 - (void)update

--- a/Application/Sources/Configuration/TVChannel.h
+++ b/Application/Sources/Configuration/TVChannel.h
@@ -13,11 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NS_CLOSED_ENUM(NSInteger, TVGuideBouquet) {
     /**
-     *  Third party bouquet
+     *  Third party bouquet.
      */
     TVGuideBouquetThirdParty = 0,
     /**
-     *  SRG SSR business unit bouquets.
+     *  SRG SSR bouquets.
      */
     TVGuideBouquetRSI,
     TVGuideBouquetRTS,

--- a/Application/Sources/Configuration/TVChannel.h
+++ b/Application/Sources/Configuration/TVChannel.h
@@ -9,6 +9,22 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ *  TV guide bouquet.
+ */
+typedef NS_CLOSED_ENUM(NSInteger, TVGuideBouquet) {
+    /**
+     *  Third party bouquet
+     */
+    TVGuideBouquetThirdParty = 0,
+    /**
+     *  SRG SSR business unit bouquets.
+     */
+    TVGuideBouquetRSI,
+    TVGuideBouquetRTS,
+    TVGuideBouquetSRF
+};
+
+/**
  *  Represent a TV channel in the application configuration.
  */
 @interface TVChannel : Channel

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -204,24 +204,24 @@ extension SRGDataProvider {
             .eraseToAnyPublisher()
     }
     
-    func tvProgramsPublisher(day: SRGDay? = nil, provider: SRGProgramProvider, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
+    func tvProgramsPublisher(day: SRGDay? = nil, mainProvider: Bool, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
         let applicationConfiguration = ApplicationConfiguration.shared
-        if provider == .SRG {
+        if mainProvider {
             return SRGDataProvider.current!.tvPrograms(for: applicationConfiguration.vendor, day: day, minimal: minimal)
                 .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
                 .eraseToAnyPublisher()
         }
         else {
-            let tvThirdPartyProgramsPublishers = applicationConfiguration.tvGuideThirdPartyBouquets
-                .map { tvThirdPartyProgramsPublisher(day: day, thirdPartyBouquet: $0, minimal: minimal) }
-            return Publishers.concatenateMany(tvThirdPartyProgramsPublishers)
+            let tvOtherPartyProgramsPublishers = applicationConfiguration.tvGuideOtherPartyBouquets
+                .map { tvOtherPartyProgramsPublisher(day: day, otherPartyBouquet: $0, minimal: minimal) }
+            return Publishers.concatenateMany(tvOtherPartyProgramsPublishers)
                 .tryReduce([]) { $0 + $1 }
                 .eraseToAnyPublisher()
         }
     }
     
-    private func tvThirdPartyProgramsPublisher(day: SRGDay? = nil, thirdPartyBouquet: TVGuideThirdPartyBouquet, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
-        switch thirdPartyBouquet {
+    private func tvOtherPartyProgramsPublisher(day: SRGDay? = nil, otherPartyBouquet: TVGuideOtherPartyBouquet, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
+        switch otherPartyBouquet {
         case .RSI:
             return  SRGDataProvider.current!.tvPrograms(for: .RSI, day: day, minimal: minimal)
                 .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -204,10 +204,12 @@ extension SRGDataProvider {
             .eraseToAnyPublisher()
     }
     
-    func tvProgramsPublisher(day: SRGDay? = nil, provider: SRGProgramProvider, minimal: Bool = false) -> AnyPublisher<[SRGProgramComposition], Error> {
+    func tvProgramsPublisher(day: SRGDay? = nil, provider: SRGProgramProvider, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
         let applicationConfiguration = ApplicationConfiguration.shared
         if provider == .SRG {
             return SRGDataProvider.current!.tvPrograms(for: applicationConfiguration.vendor, day: day, minimal: minimal)
+                .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
+                .eraseToAnyPublisher()
         }
         else {
             let tvThirdPartyProgramsPublishers = applicationConfiguration.tvGuideThirdPartyBouquets
@@ -218,18 +220,42 @@ extension SRGDataProvider {
         }
     }
     
-    private func tvThirdPartyProgramsPublisher(day: SRGDay? = nil, thirdPartyBouquet: TVGuideThirdPartyBouquet, minimal: Bool = false) -> AnyPublisher<[SRGProgramComposition], Error> {
+    private func tvThirdPartyProgramsPublisher(day: SRGDay? = nil, thirdPartyBouquet: TVGuideThirdPartyBouquet, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
         switch thirdPartyBouquet {
         case .RSI:
             return  SRGDataProvider.current!.tvPrograms(for: .RSI, day: day, minimal: minimal)
+                .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
+                .eraseToAnyPublisher()
         case .RTS:
             return  SRGDataProvider.current!.tvPrograms(for: .RTS, day: day, minimal: minimal)
+                .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
+                .eraseToAnyPublisher()
         case .SRF:
             return  SRGDataProvider.current!.tvPrograms(for: .SRF, day: day, minimal: minimal)
+                .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
+                .eraseToAnyPublisher()
         case .nonSRG:
             return  SRGDataProvider.current!.tvPrograms(for: ApplicationConfiguration.shared.vendor, provider: .thirdParty, day: day, minimal: minimal)
+                .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: true) })) }
+                .eraseToAnyPublisher()
         }
     }
+}
+
+/// Input data for tv programs publisher
+struct PlayProgramComposition: Hashable {
+    let playChannel: PlayChannel
+    let programs: [SRGProgram]?
+    
+    init(channel: SRGChannel, programs: [SRGProgram]?, external: Bool) {
+        self.playChannel = PlayChannel(wrappedValue: channel, external: external)
+        self.programs = programs
+    }
+}
+
+struct PlayChannel: Hashable {
+    let wrappedValue: SRGChannel
+    let external: Bool
 }
 
 extension Publishers {

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -203,6 +203,21 @@ extension SRGDataProvider {
             .map { filter?.compatibleShows($0) ?? $0 }
             .eraseToAnyPublisher()
     }
+    
+    func tvPrograms(day: SRGDay? = nil, minimal: Bool = false) -> AnyPublisher<[SRGProgramComposition], Error> {
+        let tvProgramsVendors = ApplicationConfiguration.shared.tvProgramsVendors
+        assert(tvProgramsVendors.count == 3, "Expected 3 vendors for tv programs")
+        
+        return Publishers.CombineLatest3(
+            SRGDataProvider.current!.tvPrograms(for: tvProgramsVendors[0], day: day, minimal: minimal),
+            SRGDataProvider.current!.tvPrograms(for: tvProgramsVendors[1], day: day, minimal: minimal),
+            SRGDataProvider.current!.tvPrograms(for: tvProgramsVendors[2], day: day, minimal: minimal)
+        )
+            .map { programCompositions1, programCompositions2, programCompositions3 in
+                return programCompositions1 + programCompositions2 + programCompositions3
+            }
+            .eraseToAnyPublisher()
+    }
 }
 
 enum UserDataPublishers {

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -244,11 +244,11 @@ extension SRGDataProvider {
 
 /// Input data for tv programs publisher
 struct PlayProgramComposition: Hashable {
-    let playChannel: PlayChannel
+    let channel: PlayChannel
     let programs: [SRGProgram]?
     
     init(channel: SRGChannel, programs: [SRGProgram]?, external: Bool) {
-        self.playChannel = PlayChannel(wrappedValue: channel, external: external)
+        self.channel = PlayChannel(wrappedValue: channel, external: external)
         self.programs = programs
     }
 }

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -212,16 +212,16 @@ extension SRGDataProvider {
                 .eraseToAnyPublisher()
         }
         else {
-            let tvOtherPartyProgramsPublishers = applicationConfiguration.tvGuideOtherPartyBouquets
-                .map { tvOtherPartyProgramsPublisher(day: day, otherPartyBouquet: $0, minimal: minimal) }
+            let tvOtherPartyProgramsPublishers = applicationConfiguration.tvGuideOtherBouquets
+                .map { tvOtherPartyProgramsPublisher(day: day, bouquet: $0, minimal: minimal) }
             return Publishers.concatenateMany(tvOtherPartyProgramsPublishers)
                 .tryReduce([]) { $0 + $1 }
                 .eraseToAnyPublisher()
         }
     }
     
-    private func tvOtherPartyProgramsPublisher(day: SRGDay? = nil, otherPartyBouquet: TVGuideOtherPartyBouquet, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
-        switch otherPartyBouquet {
+    private func tvOtherPartyProgramsPublisher(day: SRGDay? = nil, bouquet: TVGuideBouquet, minimal: Bool = false) -> AnyPublisher<[PlayProgramComposition], Error> {
+        switch bouquet {
         case .RSI:
             return  SRGDataProvider.current!.tvPrograms(for: .RSI, day: day, minimal: minimal)
                 .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
@@ -234,7 +234,7 @@ extension SRGDataProvider {
             return  SRGDataProvider.current!.tvPrograms(for: .SRF, day: day, minimal: minimal)
                 .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: false) })) }
                 .eraseToAnyPublisher()
-        case .nonSRG:
+        case .thirdParty:
             return  SRGDataProvider.current!.tvPrograms(for: ApplicationConfiguration.shared.vendor, provider: .thirdParty, day: day, minimal: minimal)
                 .map { Array($0.map({ PlayProgramComposition(channel: $0.channel, programs: $0.programs, external: true) })) }
                 .eraseToAnyPublisher()

--- a/Application/Sources/Helpers/ProgramAndChannel.swift
+++ b/Application/Sources/Helpers/ProgramAndChannel.swift
@@ -8,14 +8,14 @@ import SRGDataProviderModel
 
 struct ProgramAndChannel: Hashable {
     let program: SRGProgram
-    let channel: SRGChannel
+    let channel: PlayChannel
     
     func programGuideImageUrl(size: SRGImageSize) -> URL? {
         if let image = program.image {
             return PlaySRG.url(for: image, size: size)
         }
         // Couldn't use channel image in Play SRG image service. Use raw image.
-        else if let channelRawImage = channel.rawImage {
+        else if let channelRawImage = channel.wrappedValue.rawImage {
             return PlaySRG.url(for: channelRawImage, size: size)
         }
         else {

--- a/Application/Sources/Model/Mock.swift
+++ b/Application/Sources/Model/Mock.swift
@@ -28,6 +28,10 @@ enum Mock {
         return mockObject(kind.rawValue, type: SRGChannel.self)
     }
     
+    static func playChannel(_ kind: Channel = .standard) -> PlayChannel {
+        return PlayChannel(wrappedValue: mockObject(kind.rawValue, type: SRGChannel.self), external: false)
+    }
+    
     enum ContentSection: String {
         case standard
         case overflow

--- a/Application/Sources/ProgramGuide/ProgramCell.swift
+++ b/Application/Sources/ProgramGuide/ProgramCell.swift
@@ -17,7 +17,7 @@ struct ProgramCell: View {
     
     @Environment(\.isSelected) private var isSelected
     
-    init(program: SRGProgram, channel: SRGChannel, direction: StackDirection) {
+    init(program: SRGProgram, channel: PlayChannel, direction: StackDirection) {
         _data = .constant(.init(program: program, channel: channel))
         self.direction = direction
     }
@@ -170,39 +170,39 @@ struct ProgramCell_Previews: PreviewProvider {
     private static let height: CGFloat = constant(iOS: 80, tvOS: 120)
     
     static var previews: some View {
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .horizontal)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .horizontal)
             .previewLayout(.fixed(width: size.width, height: size.height))
             .background(Color.white)
             .previewDisplayName("horizontal")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 500, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 500")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 80, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 80")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 40, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 40")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 30, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 30")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 24, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 24")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 20, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 20")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 10, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 10")
-        ProgramCell(program: Mock.program(), channel: Mock.channel(), direction: .vertical)
+        ProgramCell(program: Mock.program(), channel: Mock.playChannel(), direction: .vertical)
             .previewLayout(.fixed(width: 1, height: height))
             .background(Color.white)
             .previewDisplayName("vertical, w 1")

--- a/Application/Sources/ProgramGuide/ProgramCellViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramCellViewModel.swift
@@ -24,7 +24,7 @@ final class ProgramCellViewModel: ObservableObject {
     }
     
     var accessibilityLabel: String? {
-        return data?.program.play_accessibilityLabel(with: data?.channel)
+        return data?.program.play_accessibilityLabel(with: data?.channel.wrappedValue)
     }
     
     var timeRange: String? {
@@ -36,8 +36,7 @@ final class ProgramCellViewModel: ObservableObject {
     }
     
     var canPlay: Bool {
-        // The TV channel must be a BU channel to be playable (as declared by the application configuration)
-        guard let channel = data?.channel, ApplicationConfiguration.shared.tvChannel(forUid: channel.uid) != nil else {
+        guard let channel = data?.channel, !channel.external else {
             return false
         }
         return progress != nil || data?.program.mediaURN != nil

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
@@ -42,7 +42,7 @@ final class ProgramGuideDailyViewController: UIViewController {
             model = programGuideDailyModel
         }
         else {
-            model = ProgramGuideDailyViewModel(day: day, firstPartyChannels: programGuideModel.firstPartyChannels, thirdPartyChannels: programGuideModel.thirdPartyChannels)
+            model = ProgramGuideDailyViewModel(day: day, mainPartyChannels: programGuideModel.mainPartyChannels, otherPartyChannels: programGuideModel.otherPartyChannels)
         }
         self.programGuideModel = programGuideModel
         scrollTargetTime = programGuideModel.time

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
@@ -28,7 +28,7 @@ final class ProgramGuideDailyViewController: UIViewController {
         return model.day
     }
     
-    private static func snapshot(from state: ProgramGuideDailyViewModel.State, for channel: SRGChannel?) -> NSDiffableDataSourceSnapshot<ProgramGuideDailyViewModel.Section, ProgramGuideDailyViewModel.Item> {
+    private static func snapshot(from state: ProgramGuideDailyViewModel.State, for channel: PlayChannel?) -> NSDiffableDataSourceSnapshot<ProgramGuideDailyViewModel.Section, ProgramGuideDailyViewModel.Item> {
         var snapshot = NSDiffableDataSourceSnapshot<ProgramGuideDailyViewModel.Section, ProgramGuideDailyViewModel.Item>()
         if let channel {
             snapshot.appendSections([channel])
@@ -122,11 +122,11 @@ final class ProgramGuideDailyViewController: UIViewController {
         scrollToTime(programGuideModel.time, animated: false)
     }
     
-    private func reloadData(for channel: SRGChannel? = nil) {
+    private func reloadData(for channel: PlayChannel? = nil) {
         reloadData(for: model.state, channel: channel)
     }
     
-    private func reloadData(for state: ProgramGuideDailyViewModel.State, channel: SRGChannel? = nil) {
+    private func reloadData(for state: ProgramGuideDailyViewModel.State, channel: PlayChannel? = nil) {
         let currentChannel = channel ?? self.programGuideModel.selectedChannel
         
         switch state {

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -14,7 +14,7 @@ final class ProgramGuideDailyViewModel: ObservableObject {
     @Published private(set) var state: State
     
     /// Channels can be provided if available for more efficient content loading
-    init(day: SRGDay, firstPartyChannels: [SRGChannel], thirdPartyChannels: [SRGChannel]) {
+    init(day: SRGDay, firstPartyChannels: [PlayChannel], thirdPartyChannels: [PlayChannel]) {
         self.day = day
         self.state = .loading(firstPartyChannels: firstPartyChannels, thirdPartyChannels: thirdPartyChannels, day: day)
         
@@ -36,7 +36,7 @@ final class ProgramGuideDailyViewModel: ObservableObject {
 // MARK: Types
 
 extension ProgramGuideDailyViewModel {
-    typealias Section = SRGChannel
+    typealias Section = PlayChannel
     
     struct Item: Hashable {
         enum WrappedValue: Hashable {
@@ -77,8 +77,8 @@ extension ProgramGuideDailyViewModel {
     }
     
     enum Bouquet {
-        case loading(channels: [SRGChannel])
-        case content(programCompositions: [SRGProgramComposition])
+        case loading(channels: [PlayChannel])
+        case content(programCompositions: [PlayProgramComposition])
         
         fileprivate static var empty: Self {
             return .content(programCompositions: [])
@@ -114,24 +114,24 @@ extension ProgramGuideDailyViewModel {
             }
         }
         
-        fileprivate var channels: [SRGChannel] {
+        fileprivate var channels: [PlayChannel] {
             switch self {
             case let .loading(channels: channels):
                 return channels
             case let .content(programCompositions: programCompositions):
-                return programCompositions.map(\.channel)
+                return programCompositions.map(\.playChannel)
             }
         }
         
-        fileprivate func contains(channel: SRGChannel) -> Bool {
+        fileprivate func contains(channel: PlayChannel) -> Bool {
             return channels.contains(channel)
         }
         
-        private static func programs(for channel: SRGChannel, in programCompositions: [SRGProgramComposition]) -> [SRGProgram] {
-            return programCompositions.first(where: { $0.channel == channel })?.programs ?? []
+        private static func programs(for channel: PlayChannel, in programCompositions: [PlayProgramComposition]) -> [SRGProgram] {
+            return programCompositions.first(where: { $0.playChannel == channel })?.programs ?? []
         }
         
-        fileprivate func isEmpty(for channel: SRGChannel) -> Bool {
+        fileprivate func isEmpty(for channel: PlayChannel) -> Bool {
             switch self {
             case .loading:
                 return false
@@ -140,7 +140,7 @@ extension ProgramGuideDailyViewModel {
             }
         }
         
-        fileprivate func items(for channel: SRGChannel, day: SRGDay) -> [Item] {
+        fileprivate func items(for channel: PlayChannel, day: SRGDay) -> [Item] {
             switch self {
             case .loading:
                 return [Item(wrappedValue: .loading, section: channel, day: day)]
@@ -160,7 +160,7 @@ extension ProgramGuideDailyViewModel {
         case content(firstPartyBouquet: Bouquet, thirdPartyBouquet: Bouquet, day: SRGDay)
         case failed(error: Error)
         
-        fileprivate static func loading(firstPartyChannels: [SRGChannel], thirdPartyChannels: [SRGChannel], day: SRGDay) -> Self {
+        fileprivate static func loading(firstPartyChannels: [PlayChannel], thirdPartyChannels: [PlayChannel], day: SRGDay) -> Self {
             return .content(firstPartyBouquet: .loading(channels: firstPartyChannels), thirdPartyBouquet: .loading(channels: thirdPartyChannels), day: day)
         }
         

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -119,7 +119,7 @@ extension ProgramGuideDailyViewModel {
             case let .loading(channels: channels):
                 return channels
             case let .content(programCompositions: programCompositions):
-                return programCompositions.map(\.playChannel)
+                return programCompositions.map(\.channel)
             }
         }
         
@@ -128,7 +128,7 @@ extension ProgramGuideDailyViewModel {
         }
         
         private static func programs(for channel: PlayChannel, in programCompositions: [PlayProgramComposition]) -> [SRGProgram] {
-            return programCompositions.first(where: { $0.playChannel == channel })?.programs ?? []
+            return programCompositions.first(where: { $0.channel == channel })?.programs ?? []
         }
         
         fileprivate func isEmpty(for channel: PlayChannel) -> Bool {

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -245,7 +245,7 @@ private extension ProgramGuideDailyViewModel {
     static func state(from state: State?, for day: SRGDay) -> AnyPublisher<State, Error> {
         let applicationConfiguration = ApplicationConfiguration.shared
         let vendor = applicationConfiguration.vendor
-        if applicationConfiguration.areTvThirdPartyChannelsAvailable {
+        if !applicationConfiguration.tvGuideThirdPartyBouquets.isEmpty {
             return Publishers.CombineLatest(
                 Self.bouquet(for: vendor, provider: .SRG, day: day, from: state),
                 Self.bouquet(for: vendor, provider: .thirdParty, day: day, from: state)
@@ -275,8 +275,8 @@ private extension ProgramGuideDailyViewModel {
     
     static func bouquet(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay, from state: State?) -> AnyPublisher<Bouquet, Error> {
         let bouquet = bouquet(from: state, for: provider, day: day)
-        return SRGDataProvider.current!.tvPrograms(day: day, minimal: true)
-            .append(SRGDataProvider.current!.tvPrograms(day: day))
+        return SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider, minimal: true)
+            .append(SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider))
             .map { .content(programCompositions: $0) }
             .tryCatch { error in
                 guard bouquet.hasPrograms else { throw error }

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -275,8 +275,8 @@ private extension ProgramGuideDailyViewModel {
     
     static func bouquet(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay, from state: State?) -> AnyPublisher<Bouquet, Error> {
         let bouquet = bouquet(from: state, for: provider, day: day)
-        return SRGDataProvider.current!.tvPrograms(for: vendor, provider: provider, day: day, minimal: true)
-            .append(SRGDataProvider.current!.tvPrograms(for: vendor, provider: provider, day: day))
+        return SRGDataProvider.current!.tvPrograms(day: day, minimal: true)
+            .append(SRGDataProvider.current!.tvPrograms(day: day))
             .map { .content(programCompositions: $0) }
             .tryCatch { error in
                 guard bouquet.hasPrograms else { throw error }

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -245,7 +245,7 @@ private extension ProgramGuideDailyViewModel {
     static func state(from state: State?, for day: SRGDay) -> AnyPublisher<State, Error> {
         let applicationConfiguration = ApplicationConfiguration.shared
         let vendor = applicationConfiguration.vendor
-        if !applicationConfiguration.tvGuideOtherPartyBouquets.isEmpty {
+        if !applicationConfiguration.tvGuideOtherBouquets.isEmpty {
             return Publishers.CombineLatest(
                 Self.bouquet(for: vendor, mainProvider: true, day: day, from: state),
                 Self.bouquet(for: vendor, mainProvider: false, day: day, from: state)

--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewModel.swift
@@ -14,9 +14,9 @@ final class ProgramGuideDailyViewModel: ObservableObject {
     @Published private(set) var state: State
     
     /// Channels can be provided if available for more efficient content loading
-    init(day: SRGDay, firstPartyChannels: [PlayChannel], thirdPartyChannels: [PlayChannel]) {
+    init(day: SRGDay, mainPartyChannels: [PlayChannel], otherPartyChannels: [PlayChannel]) {
         self.day = day
-        self.state = .loading(firstPartyChannels: firstPartyChannels, thirdPartyChannels: thirdPartyChannels, day: day)
+        self.state = .loading(mainPartyChannels: mainPartyChannels, otherPartyChannels: otherPartyChannels, day: day)
         
         Publishers.PublishAndRepeat(onOutputFrom: ApplicationSignal.wokenUp()) { [weak self, $day] in
             $day
@@ -157,16 +157,16 @@ extension ProgramGuideDailyViewModel {
     }
     
     enum State {
-        case content(firstPartyBouquet: Bouquet, thirdPartyBouquet: Bouquet, day: SRGDay)
+        case content(mainPartyBouquet: Bouquet, otherPartyBouquet: Bouquet, day: SRGDay)
         case failed(error: Error)
         
-        fileprivate static func loading(firstPartyChannels: [PlayChannel], thirdPartyChannels: [PlayChannel], day: SRGDay) -> Self {
-            return .content(firstPartyBouquet: .loading(channels: firstPartyChannels), thirdPartyBouquet: .loading(channels: thirdPartyChannels), day: day)
+        fileprivate static func loading(mainPartyChannels: [PlayChannel], otherPartyChannels: [PlayChannel], day: SRGDay) -> Self {
+            return .content(mainPartyBouquet: .loading(channels: mainPartyChannels), otherPartyBouquet: .loading(channels: otherPartyChannels), day: day)
         }
         
         private var day: SRGDay? {
             switch self {
-            case let .content(firstPartyBouquet: _, thirdPartyBouquet: _, day: day):
+            case let .content(mainPartyBouquet: _, otherPartyBouquet: _, day: day):
                 return day
             case .failed:
                 return nil
@@ -175,8 +175,8 @@ extension ProgramGuideDailyViewModel {
         
         private var bouquets: [Bouquet] {
             switch self {
-            case let .content(firstPartyBouquet: firstPartyBouquet, thirdPartyBouquet: thirdPartyBouquet, day: _):
-                return [firstPartyBouquet, thirdPartyBouquet]
+            case let .content(mainPartyBouquet: mainPartyBouquet, otherPartyBouquet: otherPartyBouquet, day: _):
+                return [mainPartyBouquet, otherPartyBouquet]
             case .failed:
                 return []
             }
@@ -188,12 +188,12 @@ extension ProgramGuideDailyViewModel {
         
         private func bouquet(for section: Section) -> Bouquet? {
             switch self {
-            case let .content(firstPartyBouquet: firstPartyBouquet, thirdPartyBouquet: thirdPartyBouquet, day: _):
-                if firstPartyBouquet.contains(channel: section) {
-                    return firstPartyBouquet
+            case let .content(mainPartyBouquet: mainPartyBouquet, otherPartyBouquet: otherPartyBouquet, day: _):
+                if mainPartyBouquet.contains(channel: section) {
+                    return mainPartyBouquet
                 }
-                else if thirdPartyBouquet.contains(channel: section) {
-                    return thirdPartyBouquet
+                else if otherPartyBouquet.contains(channel: section) {
+                    return otherPartyBouquet
                 }
                 else {
                     return nil
@@ -245,38 +245,38 @@ private extension ProgramGuideDailyViewModel {
     static func state(from state: State?, for day: SRGDay) -> AnyPublisher<State, Error> {
         let applicationConfiguration = ApplicationConfiguration.shared
         let vendor = applicationConfiguration.vendor
-        if !applicationConfiguration.tvGuideThirdPartyBouquets.isEmpty {
+        if !applicationConfiguration.tvGuideOtherPartyBouquets.isEmpty {
             return Publishers.CombineLatest(
-                Self.bouquet(for: vendor, provider: .SRG, day: day, from: state),
-                Self.bouquet(for: vendor, provider: .thirdParty, day: day, from: state)
+                Self.bouquet(for: vendor, mainProvider: true, day: day, from: state),
+                Self.bouquet(for: vendor, mainProvider: false, day: day, from: state)
             )
-            .map { .content(firstPartyBouquet: $0, thirdPartyBouquet: $1, day: day) }
+            .map { .content(mainPartyBouquet: $0, otherPartyBouquet: $1, day: day) }
             .eraseToAnyPublisher()
         }
         else {
-            return Self.bouquet(for: vendor, provider: .SRG, day: day, from: state)
-                .map { .content(firstPartyBouquet: $0, thirdPartyBouquet: .empty, day: day) }
+            return Self.bouquet(for: vendor, mainProvider: true, day: day, from: state)
+                .map { .content(mainPartyBouquet: $0, otherPartyBouquet: .empty, day: day) }
                 .eraseToAnyPublisher()
         }
     }
     
-    static func bouquet(from state: State?, for provider: SRGProgramProvider, day otherDay: SRGDay) -> Bouquet {
+    static func bouquet(from state: State?, for mainProvider: Bool, day otherDay: SRGDay) -> Bouquet {
         guard let state else { return .empty }
         switch state {
-        case let .content(firstPartyBouquet: firstPartyBouquet, thirdPartyBouquet: thirdPartyBouquet, day: day):
+        case let .content(mainPartyBouquet: mainPartyBouquet, otherPartyBouquet: otherPartyBouquet, day: day):
             guard otherDay.compare(day) == .orderedSame else {
-                return provider == .thirdParty ? .loading(channels: thirdPartyBouquet.channels) : .loading(channels: firstPartyBouquet.channels)
+                return mainProvider ? .loading(channels: mainPartyBouquet.channels) : .loading(channels: otherPartyBouquet.channels)
             }
-            return provider == .thirdParty ? thirdPartyBouquet : firstPartyBouquet
+            return mainProvider ? mainPartyBouquet : otherPartyBouquet
         case .failed:
             return .empty
         }
     }
     
-    static func bouquet(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay, from state: State?) -> AnyPublisher<Bouquet, Error> {
-        let bouquet = bouquet(from: state, for: provider, day: day)
-        return SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider, minimal: true)
-            .append(SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider))
+    static func bouquet(for vendor: SRGVendor, mainProvider: Bool, day: SRGDay, from state: State?) -> AnyPublisher<Bouquet, Error> {
+        let bouquet = bouquet(from: state, for: mainProvider, day: day)
+        return SRGDataProvider.current!.tvProgramsPublisher(day: day, mainProvider: mainProvider, minimal: true)
+            .append(SRGDataProvider.current!.tvProgramsPublisher(day: day, mainProvider: mainProvider))
             .map { .content(programCompositions: $0) }
             .tryCatch { error in
                 guard bouquet.hasPrograms else { throw error }

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -84,7 +84,7 @@ final class ProgramGuideGridViewController: UIViewController {
             cell.content = ItemCell(item: item)
 #if os(tvOS)
             if let program = item.program {
-                cell.accessibilityLabel = program.play_accessibilityLabel(with: item.section)
+                cell.accessibilityLabel = program.play_accessibilityLabel(with: item.section.wrappedValue)
                 cell.accessibilityHint = PlaySRGAccessibilityLocalizedString("Opens details.", comment: "Program cell hint")
             }
             else {
@@ -102,7 +102,7 @@ final class ProgramGuideGridViewController: UIViewController {
             guard let self else { return }
             let snapshot = dataSource.snapshot()
             let channel = snapshot.sectionIdentifiers[indexPath.section]
-            view.content = ChannelHeaderView(channel: channel)
+            view.content = ChannelHeaderView(channel: channel.wrappedValue)
         }
         
         dataSource.supplementaryViewProvider = { collectionView, _, indexPath in
@@ -190,7 +190,7 @@ private extension ProgramGuideGridViewController {
         return ProgramGuideGridLayout.xOffset(centeringDate: model.date(for: time), in: collectionView, day: model.day)
     }
     
-    func yOffset(for channel: SRGChannel?) -> CGFloat? {
+    func yOffset(for channel: PlayChannel?) -> CGFloat? {
         guard let channel, let sectionIndex = dataSource.snapshot().sectionIdentifiers.firstIndex(of: channel) else { return nil }
         return ProgramGuideGridLayout.yOffset(forSectionIndex: sectionIndex, in: collectionView)
     }
@@ -222,16 +222,16 @@ private extension ProgramGuideGridViewController {
 
 private extension ProgramGuideGridViewController {
     struct ScrollTarget {
-        let channel: SRGChannel?
+        let channel: PlayChannel?
         let time: TimeInterval?
         
-        init?(channel: SRGChannel?, time: TimeInterval?) {
+        init?(channel: PlayChannel?, time: TimeInterval?) {
             guard channel != nil || time != nil else { return nil }
             self.channel = channel
             self.time = time
         }
         
-        init(channel: SRGChannel) {
+        init(channel: PlayChannel) {
             self.channel = channel
             self.time = nil
         }
@@ -283,7 +283,7 @@ extension ProgramGuideGridViewController: UICollectionViewDelegate {
         }
         
 #if os(tvOS)
-        navigateToProgram(program, in: channel)
+        navigateToProgram(program, in: channel.wrappedValue)
 #else
         AnalyticsClickEvent.tvGuideOpenInfoBox(program: program, programGuideLayout: .grid).send()
         // Deselection is managed here rather than in view appearance methods, as those are not called with the

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -38,7 +38,7 @@ final class ProgramGuideGridViewController: UIViewController {
             self.dailyModel = dailyModel
         }
         else {
-            self.dailyModel = ProgramGuideDailyViewModel(day: model.day, firstPartyChannels: model.firstPartyChannels, thirdPartyChannels: model.thirdPartyChannels)
+            self.dailyModel = ProgramGuideDailyViewModel(day: model.day, mainPartyChannels: model.mainPartyChannels, otherPartyChannels: model.otherPartyChannels)
         }
         super.init(nibName: nil, bundle: nil)
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
@@ -207,7 +207,7 @@ enum ProgramGuideHeaderViewSize {
             return (horizontalSizeClass == .compact) ? 216 : 136
         }
 #else
-        return ApplicationConfiguration.shared.areTvThirdPartyChannelsAvailable ? 650 : 760
+        return ApplicationConfiguration.shared.tvGuideOtherBouquets.isEmpty ? 760 : 650
 #endif
     }
 }

--- a/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideHeaderView.swift
@@ -168,15 +168,15 @@ struct ProgramGuideHeaderView: View {
                 ScrollViewReader { proxy in
                     HStack(spacing: 10) {
                         if !model.channels.isEmpty {
-                            ForEach(model.channels, id: \.uid) { channel in
-                                ChannelButton(channel: channel) {
+                            ForEach(model.channels, id: \.wrappedValue.uid) { channel in
+                                ChannelButton(channel: channel.wrappedValue) {
                                     model.selectedChannel = channel
                                 }
                                 .environment(\.isSelected, channel == model.selectedChannel)
                             }
                             .onAppear {
                                 if let selectedChannel = model.selectedChannel {
-                                    proxy.scrollTo(selectedChannel.uid)
+                                    proxy.scrollTo(selectedChannel.wrappedValue.uid)
                                 }
                             }
                         }

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -164,7 +164,7 @@ private extension ProgramGuideViewModel {
     //       remove the day parameter.
     static func channels(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay) -> AnyPublisher<[PlayChannel], Error> {
         return SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider, minimal: true)
-            .map { $0.map(\.playChannel) }
+            .map { $0.map(\.channel) }
             .eraseToAnyPublisher()
     }
     

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -163,7 +163,7 @@ private extension ProgramGuideViewModel {
     // TODO: Once an IL request is available to get the channel list without any day, use this request and
     //       remove the day parameter.
     static func channels(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay) -> AnyPublisher<[SRGChannel], Error> {
-        return SRGDataProvider.current!.tvPrograms(day: day, minimal: true)
+        return SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider, minimal: true)
             .map { $0.map(\.channel) }
             .eraseToAnyPublisher()
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -163,7 +163,7 @@ private extension ProgramGuideViewModel {
     // TODO: Once an IL request is available to get the channel list without any day, use this request and
     //       remove the day parameter.
     static func channels(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay) -> AnyPublisher<[SRGChannel], Error> {
-        return SRGDataProvider.current!.tvPrograms(for: vendor, provider: provider, day: day, minimal: true)
+        return SRGDataProvider.current!.tvPrograms(day: day, minimal: true)
             .map { $0.map(\.channel) }
             .eraseToAnyPublisher()
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -172,7 +172,7 @@ private extension ProgramGuideViewModel {
         let applicationConfiguration = ApplicationConfiguration.shared
         let vendor = applicationConfiguration.vendor
         
-        if !applicationConfiguration.tvGuideOtherPartyBouquets.isEmpty {
+        if !applicationConfiguration.tvGuideOtherBouquets.isEmpty {
             return Publishers.CombineLatest(
                 channels(for: vendor, mainProvider: true, day: day),
                 channels(for: vendor, mainProvider: false, day: day)

--- a/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideViewModel.swift
@@ -29,19 +29,19 @@ final class ProgramGuideViewModel: ObservableObject {
         return date.timeIntervalSince(day.date)
     }
     
-    var channels: [SRGChannel] {
+    var channels: [PlayChannel] {
         return data.channels
     }
     
-    var firstPartyChannels: [SRGChannel] {
+    var firstPartyChannels: [PlayChannel] {
         return data.firstPartyChannels
     }
     
-    var thirdPartyChannels: [SRGChannel] {
+    var thirdPartyChannels: [PlayChannel] {
         return data.thirdPartyChannels
     }
     
-    var selectedChannel: SRGChannel? {
+    var selectedChannel: PlayChannel? {
         get {
             return data.selectedChannel
         }
@@ -126,15 +126,15 @@ final class ProgramGuideViewModel: ObservableObject {
 
 extension ProgramGuideViewModel {
     struct Data {
-        let firstPartyChannels: [SRGChannel]
-        let thirdPartyChannels: [SRGChannel]
-        let selectedChannel: SRGChannel?
+        let firstPartyChannels: [PlayChannel]
+        let thirdPartyChannels: [PlayChannel]
+        let selectedChannel: PlayChannel?
         
         static var empty: Self {
             return Self(firstPartyChannels: [], thirdPartyChannels: [], selectedChannel: nil)
         }
         
-        var channels: [SRGChannel] {
+        var channels: [PlayChannel] {
             return firstPartyChannels + thirdPartyChannels
         }
     }
@@ -144,14 +144,14 @@ extension ProgramGuideViewModel {
         case day(SRGDay)
         case time(TimeInterval)
         case dayAndTime(day: SRGDay, time: TimeInterval)
-        case channel(SRGChannel)
+        case channel(PlayChannel)
     }
 }
 
 // MARK: Publishers
 
 private extension ProgramGuideViewModel {
-    static func matchingChannel(_ channel: SRGChannel?, in channels: [SRGChannel]) -> SRGChannel? {
+    static func matchingChannel(_ channel: PlayChannel?, in channels: [PlayChannel]) -> PlayChannel? {
         if let channel, channels.contains(channel) {
             return channel
         }
@@ -162,9 +162,9 @@ private extension ProgramGuideViewModel {
     
     // TODO: Once an IL request is available to get the channel list without any day, use this request and
     //       remove the day parameter.
-    static func channels(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay) -> AnyPublisher<[SRGChannel], Error> {
+    static func channels(for vendor: SRGVendor, provider: SRGProgramProvider, day: SRGDay) -> AnyPublisher<[PlayChannel], Error> {
         return SRGDataProvider.current!.tvProgramsPublisher(day: day, provider: provider, minimal: true)
-            .map { $0.map(\.channel) }
+            .map { $0.map(\.playChannel) }
             .eraseToAnyPublisher()
     }
     

--- a/Application/Sources/ProgramGuide/ProgramPreview.swift
+++ b/Application/Sources/ProgramGuide/ProgramPreview.swift
@@ -88,9 +88,9 @@ struct ProgramPreview: View {
 struct ProgramPreview_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            ProgramPreview(data: ProgramAndChannel(program: Mock.program(), channel: Mock.channel()))
-            ProgramPreview(data: ProgramAndChannel(program: Mock.program(.overflow), channel: Mock.channel()))
-            ProgramPreview(data: ProgramAndChannel(program: Mock.program(.fallbackImageUrl), channel: Mock.channel()))
+            ProgramPreview(data: ProgramAndChannel(program: Mock.program(), channel: Mock.playChannel()))
+            ProgramPreview(data: ProgramAndChannel(program: Mock.program(.overflow), channel: Mock.playChannel()))
+            ProgramPreview(data: ProgramAndChannel(program: Mock.program(.fallbackImageUrl), channel: Mock.playChannel()))
             ProgramPreview(data: nil)
         }
         .previewLayout(.fixed(width: 1920, height: 700))

--- a/Application/Sources/ProgramGuide/ProgramView.swift
+++ b/Application/Sources/ProgramGuide/ProgramView.swift
@@ -14,11 +14,11 @@ struct ProgramView: View {
     @Binding var data: ProgramAndChannel
     @StateObject private var model = ProgramViewModel()
     
-    static func viewController(for program: SRGProgram, channel: SRGChannel) -> UIViewController {
+    static func viewController(for program: SRGProgram, channel: PlayChannel) -> UIViewController {
         return ProgramViewController(program: program, channel: channel)
     }
     
-    init(program: SRGProgram, channel: SRGChannel) {
+    init(program: SRGProgram, channel: PlayChannel) {
         _data = .constant(.init(program: program, channel: channel))
     }
     
@@ -285,7 +285,7 @@ struct ProgramView: View {
 // MARK: View controller
 
 private final class ProgramViewController: UIHostingController<ProgramView> {
-    init(program: SRGProgram, channel: SRGChannel) {
+    init(program: SRGProgram, channel: PlayChannel) {
         super.init(rootView: ProgramView(program: program, channel: channel))
     }
     
@@ -313,9 +313,9 @@ struct ProgramView_Previews: PreviewProvider {
     
     static var previews: some View {
         Group {
-            ProgramView(program: Mock.program(), channel: Mock.channel())
-            ProgramView(program: Mock.program(.overflow), channel: Mock.channel())
-            ProgramView(program: Mock.program(.fallbackImageUrl), channel: Mock.channel())
+            ProgramView(program: Mock.program(), channel: Mock.playChannel())
+            ProgramView(program: Mock.program(.overflow), channel: Mock.playChannel())
+            ProgramView(program: Mock.program(.fallbackImageUrl), channel: Mock.playChannel())
         }
         .previewLayout(.fixed(width: size.width, height: size.height))
     }

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -19,10 +19,10 @@ final class ProgramViewModel: ObservableObject {
             Self.mediaDataPublisher(for: data?.program)
                 .receive(on: DispatchQueue.main)
                 .assign(to: &$mediaData)
-            Self.livestreamMediaPublisher(for: data?.channel)
+            Self.livestreamMediaPublisher(for: data?.channel.wrappedValue)
                 .receive(on: DispatchQueue.main)
                 .assign(to: &$livestreamMedia)
-            eventEditViewDelegateObject.channel = data?.channel
+            eventEditViewDelegateObject.channel = data?.channel.wrappedValue
         }
     }
     
@@ -52,7 +52,7 @@ final class ProgramViewModel: ObservableObject {
     }
     
     private var channel: SRGChannel? {
-        return data?.channel
+        return data?.channel.wrappedValue
     }
     
     private var isLive: Bool {
@@ -191,10 +191,10 @@ final class ProgramViewModel: ObservableObject {
             return { [self] in
                 if let data {
                     if media.contentType == .livestream {
-                        AnalyticsClickEvent.tvGuidePlayLivestream(program: data.program, channel: data.channel).send()
+                        AnalyticsClickEvent.tvGuidePlayLivestream(program: data.program, channel: data.channel.wrappedValue).send()
                     }
                     else {
-                        AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: isLive, channel: data.channel).send()
+                        AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: isLive, channel: data.channel.wrappedValue).send()
                     }
                 }
                 
@@ -214,7 +214,7 @@ final class ProgramViewModel: ObservableObject {
         guard isLive, let media, media.blockingReason(at: Date()) == .none else { return nil }
         
         let data = self.data
-        let analyticsClickEvent = data != nil ? AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: true, channel: data!.channel) : nil
+        let analyticsClickEvent = data != nil ? AnalyticsClickEvent.tvGuidePlayMedia(media: media, programIsLive: true, channel: data!.channel.wrappedValue) : nil
         return ButtonProperties(
             icon: .startOver,
             label: NSLocalizedString("Watch from start", comment: "Button to watch some program from the start"),
@@ -310,7 +310,7 @@ final class ProgramViewModel: ObservableObject {
                         guard let self else { return }
                         if granted {
                             let event = EKEvent(eventStore: eventStore)
-                            event.title = "\(program.title) - \(channel.title)"
+                            event.title = "\(program.title) - \(channel.wrappedValue.title)"
                             event.startDate = program.startDate
                             event.endDate = program.endDate
                             event.url = self.calendarUrl

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -198,7 +198,7 @@ final class ProgramViewModel: ObservableObject {
                     }
                 }
                 
-                tabBarController.play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
+                tabBarController.dismissAndPresentMediaPlayer(with: media, position: nil)
             }
         }
         else {
@@ -227,12 +227,12 @@ final class ProgramViewModel: ObservableObject {
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Resume", comment: "Alert choice to resume playback"), style: .default, handler: { _ in
                         analyticsClickEvent?.send()
                         
-                        tabBarController.play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
+                        tabBarController.dismissAndPresentMediaPlayer(with: media, position: nil)
                     }))
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Watch from start", comment: "Alert choice to watch content from start"), style: .default, handler: { _ in
                         analyticsClickEvent?.send()
                         
-                        tabBarController.play_presentMediaPlayer(with: media, position: .default, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
+                        tabBarController.dismissAndPresentMediaPlayer(with: media, position: .default)
                     }))
                     alertController.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Title of a cancel button"), style: .cancel, handler: nil))
                     tabBarController.play_top.present(alertController, animated: true, completion: nil)
@@ -240,7 +240,7 @@ final class ProgramViewModel: ObservableObject {
                 else {
                     analyticsClickEvent?.send()
                     
-                    tabBarController.play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
+                    tabBarController.dismissAndPresentMediaPlayer(with: media, position: nil)
                 }
             }
         )
@@ -486,6 +486,21 @@ extension ProgramViewModel {
         let show: SRGShow
         let isFavorite: Bool
         let action: () -> Void
+    }
+}
+
+fileprivate extension TabBarController {
+    func dismissAndPresentMediaPlayer(with media: SRGMedia, position: SRGPosition?) {
+        var presentMediaPlayer: Void { self.play_presentMediaPlayer(with: media, position: position, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil) }
+        
+        if let presentedViewController = self.presentedViewController {
+            presentedViewController.dismiss(animated: true) {
+                presentMediaPlayer
+            }
+        }
+        else {
+            presentMediaPlayer
+        }
     }
 }
 

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -367,7 +367,7 @@ final class ProgramViewModel: ObservableObject {
             return ApplicationConfiguration.shared.sharingURL(for: show)
         }
         else {
-            return ApplicationConfiguration.shared.playURL
+            return ApplicationConfiguration.shared.playURL(for: ApplicationConfiguration.shared.vendor)
         }
     }
     

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -30,7 +30,7 @@ If a remote configuration is found to be invalid (usually a mandatory parameter 
 * `identityWebsiteURL` (optional, string): The URL of the identity web portal.
 * `userDataServiceURL` (optional, string): The URL of the service with which user data can be synchronized (history, preferences, playlists).
 * `middlewareURL` (mandatory, string): The URL of the Play application middleware.
-* `playURL` (mandatory, string): The base URL of the Play web portal, used when building sharing URLs.
+* `playURLs` (mandatory, JSON): A JSON dictionary describing all base URLs of the Play web portals, used when building sharing URLs. Key (string) is the identifier of the business unit, value (string) is the base URL of the Play web portal. The `businessUnit` property value MUST be in the keys.
 * `playServiceURL` (mandatory, string): The base URL of the Play web service.
 * `sourceCodeURL` (optional, string); The URL where the application source code can be found.
 * `termsAndConditionsURL` (optional, string): The URL of the terms and conditions page.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -133,6 +133,15 @@ Feeds
 * `continuousPlaybackForegroundTransitionDuration` (optional, number): Duration in seconds for continuous playback when the application runs in foreground and the player view is not displayed. If empty, continuous playback is disabled; if equal to 0, upcoming media playback starts immediately.
 * `continuousPlaybackBackgroundTransitionDuration` (optional, number): Duration in seconds for continuous playback when the application runs in background. If empty, continuous playback is disabled; if equal to 0, upcoming media playback starts immediately.
 
+## TV guide
+
+* `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.
+* `tvGuideOtherBouquets` (optional, string, multiple): TV guide other bouquets to display below the main vendor bouquet. Available values:
+	* `thirdparty`: Third party bouquet delivered for the vendor.
+	* `	rsi`: RSI vendor bouquet.
+	* `rts`: RT vendor bouquet.
+	* `srf`: SR vendor bouquet.
+
 ## Other functionalities
 
 * `audioDescriptionAvailabilityHidden` (optional, boolean): Set to `true` to hide audio description availability setting.
@@ -144,4 +153,3 @@ Feeds
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
 * `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
-* `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -145,4 +145,3 @@ Feeds
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
 * `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
 * `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.
-* `tvThirdPartyChannelsAvailable` (optional, boolean): if set to `true`, third-party TV channel content is available in the TV guide.


### PR DESCRIPTION
### Motivation and Context

Play SRG apps are BU (business unit) centric, for their content and languages.
In the TV program guide, #239 and previous commit introduced bouquets for BU channels and Third party channels, used in Play SRF.
Users asked to also have other RSI and RTS TV channel programs, as Play web have and other TV guide services.

Goal is to add it with a correct UX.

### Description

- Introduce remote configuration `tvGuideOtherBouquets` to list other channel bouquets to display, after the vendor bouquet.
- During the content loading of the TV guide, the logic is updated:
  - first publisher loads the BU channel programs, an second publisher loads other channels from other bouquets.
  - `SRGChannel` is replaced by `PlayChannel` in publishers to share if the channel is "SRG" or external. 
- Other BU media and show can be displayed in the application, from the "TV Guide" button. Add to calendar and share buttons have valid urls from BU web app. `playURLs` replaces `playURL` mandatory remote configuration, to have all Play web base urls. 

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
