### PR TITLE
Editorialized TV show page

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Accessibility.strings
@@ -100,9 +100,6 @@
 /* Accessibility introductory text for the logged in user */
 "Logged in user: %@" = "Utente connesso: %@";
 
-/* Accessibility text for the login / signup header */
-"Login or sign up" = "Login o registrazione";
-
 /* Accessibility hint for the profile header when user is logged in */
 "Manages account information" = "Gestire le informazioni sull'account";
 
@@ -113,9 +110,6 @@
 /* A more episode button label
    Button to access more episodes */
 "More episodes" = "Più episodi";
-
-/* Text displayed when a user is logged in but no information has been retrieved yet */
-"My account" = "Il mio account";
 
 /* Next day button label in program guide */
 "Next day" = "Giorno successivo";
@@ -186,7 +180,9 @@
 /* Settings button label on home view */
 "Settings" = "Impostazioni";
 
-/* Share button label on player view */
+/* Share button label on content page view
+   Share button label on player view
+   Share button label on section detail view */
 "Share" = "Condividi";
 
 /* Accessibility label of the song list handle when closed */

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Accessibility.strings
@@ -100,9 +100,6 @@
 /* Accessibility introductory text for the logged in user */
 "Logged in user: %@" = "Utilisader annunzià: %@";
 
-/* Accessibility text for the login / signup header */
-"Login or sign up" = "Login u registrar\n";
-
 /* Accessibility hint for the profile header when user is logged in */
 "Manages account information" = "Organisescha las infurmaziuns da l'account";
 
@@ -113,9 +110,6 @@
 /* A more episode button label
    Button to access more episodes */
 "More episodes" = "Dapli episodas";
-
-/* Text displayed when a user is logged in but no information has been retrieved yet */
-"My account" = "Mes conto";
 
 /* Next day button label in program guide */
 "Next day" = "Di suandant";
@@ -186,7 +180,9 @@
 /* Settings button label on home view */
 "Settings" = "Opziuns";
 
-/* Share button label on player view */
+/* Share button label on content page view
+   Share button label on player view
+   Share button label on section detail view */
 "Share" = "Divida";
 
 /* Accessibility label of the song list handle when closed */

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Accessibility.strings
@@ -100,9 +100,6 @@
 /* Accessibility introductory text for the logged in user */
 "Logged in user: %@" = "Utilisateur connecté : %@";
 
-/* Accessibility text for the login / signup header */
-"Login or sign up" = "Connexion ou inscription";
-
 /* Accessibility hint for the profile header when user is logged in */
 "Manages account information" = "Gère les informations du compte";
 
@@ -113,9 +110,6 @@
 /* A more episode button label
    Button to access more episodes */
 "More episodes" = "Autres épisodes";
-
-/* Text displayed when a user is logged in but no information has been retrieved yet */
-"My account" = "Mon compte";
 
 /* Next day button label in program guide */
 "Next day" = "Jour suivant";
@@ -186,7 +180,9 @@
 /* Settings button label on home view */
 "Settings" = "Paramètres";
 
-/* Share button label on player view */
+/* Share button label on content page view
+   Share button label on player view
+   Share button label on section detail view */
 "Share" = "Partager";
 
 /* Accessibility label of the song list handle when closed */

--- a/Application/Resources/Apps/Play SRF/de.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Accessibility.strings
@@ -100,9 +100,6 @@
 /* Accessibility introductory text for the logged in user */
 "Logged in user: %@" = "Angemeldeter Nutzer: %@";
 
-/* Accessibility text for the login / signup header */
-"Login or sign up" = "Anmelden oder registrieren";
-
 /* Accessibility hint for the profile header when user is logged in */
 "Manages account information" = "Anmeldeinformationen verwalten";
 
@@ -113,9 +110,6 @@
 /* A more episode button label
    Button to access more episodes */
 "More episodes" = "Mehr zur Sendung";
-
-/* Text displayed when a user is logged in but no information has been retrieved yet */
-"My account" = "Mein Konto";
 
 /* Next day button label in program guide */
 "Next day" = "Nächster Tag";
@@ -186,7 +180,9 @@
 /* Settings button label on home view */
 "Settings" = "Einstellungen";
 
-/* Share button label on player view */
+/* Share button label on content page view
+   Share button label on player view
+   Share button label on section detail view */
 "Share" = "Inhalt teilen";
 
 /* Accessibility label of the song list handle when closed */

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -16,6 +16,7 @@
   "whatsNewURL": "https://srgssr.github.io/playsrg-apple/releases/release_notes-ios-swi.html",
   "downloadsHintsHidden": true,
   "showsUnavailable": true,
+  "predefinedShowPagePreferred": true,
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,

--- a/Application/Resources/Apps/Play SWI/en.lproj/Accessibility.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Accessibility.strings
@@ -100,9 +100,6 @@
 /* Accessibility introductory text for the logged in user */
 "Logged in user: %@" = "Logged in user: %@";
 
-/* Accessibility text for the login / signup header */
-"Login or sign up" = "Login or sign up";
-
 /* Accessibility hint for the profile header when user is logged in */
 "Manages account information" = "Manages account information";
 
@@ -113,9 +110,6 @@
 /* A more episode button label
    Button to access more episodes */
 "More episodes" = "More episodes";
-
-/* Text displayed when a user is logged in but no information has been retrieved yet */
-"My account" = "My account";
 
 /* Next day button label in program guide */
 "Next day" = "Next day";
@@ -186,7 +180,9 @@
 /* Settings button label on home view */
 "Settings" = "Settings";
 
-/* Share button label on player view */
+/* Share button label on content page view
+   Share button label on player view
+   Share button label on section detail view */
 "Share" = "Share";
 
 /* Accessibility label of the song list handle when closed */

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -159,13 +159,13 @@ name: PLCrashReporter, nameSpecified: PLCrashReporter, owner: microsoft, version
 
 name: promises, nameSpecified: Promises, owner: google, version: 2.3.1, source: https://github.com/google/promises
 
-name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.0.1, source: https://github.com/SRGSSR/srganalytics-apple
+name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.0.2, source: https://github.com/SRGSSR/srganalytics-apple
 
 name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version: 5.2.1, source: https://github.com/SRGSSR/srgappearance-apple
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 18.1.0, source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -165,7 +165,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 18.0.0, source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: srgdataprovider-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -270,7 +270,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srganalytics-apple</string>
 			<key>Title</key>
-			<string>SRGAnalytics (9.0.1)</string>
+			<string>SRGAnalytics (9.0.2)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>
@@ -294,7 +294,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>srgdataprovider-apple</string>
+			<string>SRGDataProvider (18.1.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -294,7 +294,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>SRGDataProvider (18.0.0)</string>
+			<string>srgdataprovider-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -67,12 +67,12 @@ extension UIViewController {
     }
     
     func navigateToShow(_ show: SRGShow, animated: Bool = true, completion: (() -> Void)? = nil) {
-        let showViewController = SectionViewController(section: .configured(.show(show)))
+        let showViewController = PageViewController.showViewController(for: show)
         present(showViewController, animated: animated, completion: completion)
     }
     
     func navigateToTopic(_ topic: SRGTopic, animated: Bool = true, completion: (() -> Void)? = nil) {
-        let pageViewController = PageViewController(id: .topic(topic))
+        let pageViewController = PageViewController.topicViewController(for: topic)
         present(pageViewController, animated: animated, completion: completion)
     }
     
@@ -224,7 +224,7 @@ extension UIViewController {
                     }
                 } receiveValue: { [weak self] show in
                     guard let navigationController = self?.navigationController else { return }
-                    let showViewController = SectionViewController.showViewController(for: show)
+                    let showViewController = PageViewController.showViewController(for: show)
                     navigationController.pushViewController(showViewController, animated: animated)
                     
                     AnalyticsEvent.notification(action: .displayShow,
@@ -266,11 +266,11 @@ extension UIViewController {
             play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: animated, completion: nil)
         case let .show(show):
             guard let navigationController else { return }
-            let showViewController = SectionViewController.showViewController(for: show)
+            let showViewController = PageViewController.showViewController(for: show)
             navigationController.pushViewController(showViewController, animated: animated)
         case let .topic(topic):
             guard let navigationController else { return }
-            let pageViewController = PageViewController(id: .topic(topic))
+            let pageViewController = PageViewController.topicViewController(for: topic)
             navigationController.pushViewController(pageViewController, animated: animated)
         case let .download(download):
             navigateToDownload(download, animated: animated)

--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -72,8 +72,8 @@ extension UIViewController {
     }
     
     func navigateToTopic(_ topic: SRGTopic, animated: Bool = true, completion: (() -> Void)? = nil) {
-        let pageViewController = PageViewController.topicViewController(for: topic)
-        present(pageViewController, animated: animated, completion: completion)
+        let topicViewController = PageViewController.topicViewController(for: topic)
+        present(topicViewController, animated: animated, completion: completion)
     }
     
     func navigateToProgram(_ program: SRGProgram, in channel: SRGChannel, animated: Bool = true, completion: (() -> Void)? = nil) {
@@ -270,8 +270,8 @@ extension UIViewController {
             navigationController.pushViewController(showViewController, animated: animated)
         case let .topic(topic):
             guard let navigationController else { return }
-            let pageViewController = PageViewController.topicViewController(for: topic)
-            navigationController.pushViewController(pageViewController, animated: animated)
+            let topicViewController = PageViewController.topicViewController(for: topic)
+            navigationController.pushViewController(topicViewController, animated: animated)
         case let .download(download):
             navigateToDownload(download, animated: animated)
         case let .notification(notification):

--- a/Application/Sources/Application/Navigation.swift
+++ b/Application/Sources/Application/Navigation.swift
@@ -67,13 +67,13 @@ extension UIViewController {
     }
     
     func navigateToShow(_ show: SRGShow, animated: Bool = true, completion: (() -> Void)? = nil) {
-        let showViewController = PageViewController.showViewController(for: show)
-        present(showViewController, animated: animated, completion: completion)
+        let pageViewController = PageViewController(id: .show(show))
+        present(pageViewController, animated: animated, completion: completion)
     }
     
     func navigateToTopic(_ topic: SRGTopic, animated: Bool = true, completion: (() -> Void)? = nil) {
-        let topicViewController = PageViewController.topicViewController(for: topic)
-        present(topicViewController, animated: animated, completion: completion)
+        let pageViewController = PageViewController(id: .topic(topic))
+        present(pageViewController, animated: animated, completion: completion)
     }
     
     func navigateToProgram(_ program: SRGProgram, in channel: SRGChannel, animated: Bool = true, completion: (() -> Void)? = nil) {
@@ -224,8 +224,8 @@ extension UIViewController {
                     }
                 } receiveValue: { [weak self] show in
                     guard let navigationController = self?.navigationController else { return }
-                    let showViewController = PageViewController.showViewController(for: show)
-                    navigationController.pushViewController(showViewController, animated: animated)
+                    let pageViewController = PageViewController(id: .show(show))
+                    navigationController.pushViewController(pageViewController, animated: animated)
                     
                     AnalyticsEvent.notification(action: .displayShow,
                                                 from: .application,
@@ -266,12 +266,12 @@ extension UIViewController {
             play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: animated, completion: nil)
         case let .show(show):
             guard let navigationController else { return }
-            let showViewController = PageViewController.showViewController(for: show)
-            navigationController.pushViewController(showViewController, animated: animated)
+            let pageViewController = PageViewController(id: .show(show))
+            navigationController.pushViewController(pageViewController, animated: animated)
         case let .topic(topic):
             guard let navigationController else { return }
-            let topicViewController = PageViewController.topicViewController(for: topic)
-            navigationController.pushViewController(topicViewController, animated: animated)
+            let pageViewController = PageViewController(id: .topic(topic))
+            navigationController.pushViewController(pageViewController, animated: animated)
         case let .download(download):
             navigateToDownload(download, animated: animated)
         case let .notification(notification):

--- a/Application/Sources/Application/SceneDelegate.m
+++ b/Application/Sources/Application/SceneDelegate.m
@@ -458,14 +458,14 @@ static void *s_kvoContext = &s_kvoContext;
 {
     [UserConsentHelper waitCollectingConsentRetain];
     if (show) {
-        SectionViewController *showViewController = [SectionViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+        UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
         [self.rootTabBarController pushViewController:showViewController animated:YES];
         [UserConsentHelper waitCollectingConsentRelease];
     }
     else {
         [[SRGDataProvider.currentDataProvider showWithURN:showURN completionBlock:^(SRGShow * _Nullable show, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
             if (show) {
-                SectionViewController *showViewController = [SectionViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+                UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
                 [self.rootTabBarController pushViewController:showViewController animated:YES];
             }
             else {

--- a/Application/Sources/Application/SceneDelegate.m
+++ b/Application/Sources/Application/SceneDelegate.m
@@ -458,15 +458,15 @@ static void *s_kvoContext = &s_kvoContext;
 {
     [UserConsentHelper waitCollectingConsentRetain];
     if (show) {
-        UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
-        [self.rootTabBarController pushViewController:showViewController animated:YES];
+        UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+        [self.rootTabBarController pushViewController:pageViewController animated:YES];
         [UserConsentHelper waitCollectingConsentRelease];
     }
     else {
         [[SRGDataProvider.currentDataProvider showWithURN:showURN completionBlock:^(SRGShow * _Nullable show, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
             if (show) {
-                UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
-                [self.rootTabBarController pushViewController:showViewController animated:YES];
+                UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+                [self.rootTabBarController pushViewController:pageViewController animated:YES];
             }
             else {
                 NSError *error = [NSError errorWithDomain:PlayErrorDomain
@@ -486,8 +486,8 @@ static void *s_kvoContext = &s_kvoContext;
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @keypath(SRGTopic.new, URN), topicURN];
         SRGTopic *topic = [topics filteredArrayUsingPredicate:predicate].firstObject;
         if (topic) {
-            UIViewController *topicViewController = [PageViewController topicViewControllerFor:topic];
-            [self.rootTabBarController pushViewController:topicViewController animated:YES];
+            UIViewController *pageViewController = [PageViewController topicViewControllerFor:topic];
+            [self.rootTabBarController pushViewController:pageViewController animated:YES];
         }
         else {
             NSError *error = [NSError errorWithDomain:PlayErrorDomain

--- a/Application/Sources/Application/SceneDelegate.m
+++ b/Application/Sources/Application/SceneDelegate.m
@@ -458,14 +458,14 @@ static void *s_kvoContext = &s_kvoContext;
 {
     [UserConsentHelper waitCollectingConsentRetain];
     if (show) {
-        UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+        PageViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
         [self.rootTabBarController pushViewController:pageViewController animated:YES];
         [UserConsentHelper waitCollectingConsentRelease];
     }
     else {
         [[SRGDataProvider.currentDataProvider showWithURN:showURN completionBlock:^(SRGShow * _Nullable show, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
             if (show) {
-                UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
+                PageViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:fromPushNotification];
                 [self.rootTabBarController pushViewController:pageViewController animated:YES];
             }
             else {
@@ -486,7 +486,7 @@ static void *s_kvoContext = &s_kvoContext;
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @keypath(SRGTopic.new, URN), topicURN];
         SRGTopic *topic = [topics filteredArrayUsingPredicate:predicate].firstObject;
         if (topic) {
-            UIViewController *pageViewController = [PageViewController topicViewControllerFor:topic];
+            PageViewController *pageViewController = [PageViewController topicViewControllerFor:topic];
             [self.rootTabBarController pushViewController:pageViewController animated:YES];
         }
         else {

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -95,7 +95,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, readonly, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
-@property (nonatomic, readonly, getter=isLegacyShowPagePreferred) BOOL legacyShowPagePreferred;
+@property (nonatomic, readonly, getter=isPredefinedShowPagePreferred) BOOL predefinedShowPagePreferred;
 @property (nonatomic, readonly, getter=isShowLeadPreferred) BOOL showLeadPreferred;
 
 @property (nonatomic, readonly, copy, nullable) NSString *userConsentDefaultLanguage;

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -95,6 +95,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 @property (nonatomic, readonly, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, readonly, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
+@property (nonatomic, readonly, getter=isLegacyShowPagePreferred) BOOL legacyShowPagePreferred;
 @property (nonatomic, readonly, getter=isShowLeadPreferred) BOOL showLeadPreferred;
 
 @property (nonatomic, readonly, copy, nullable) NSString *userConsentDefaultLanguage;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -180,6 +180,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
+@property (nonatomic, getter=isLegacyShowPagePreferred) BOOL legacyShowPagePreferred;
 @property (nonatomic, getter=isShowLeadPreferred) BOOL showLeadPreferred;
 
 @property (nonatomic, copy) NSString *userConsentDefaultLanguage;
@@ -484,6 +485,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.searchSettingSubtitledHidden = [firebaseConfiguration boolForKey:@"searchSettingSubtitledHidden"];
     self.showsSearchHidden = [firebaseConfiguration boolForKey:@"showsSearchHidden"];
     
+    self.legacyShowPagePreferred = [firebaseConfiguration boolForKey:@"legacyShowPagePreferred"];
     self.showLeadPreferred = [firebaseConfiguration boolForKey:@"showLeadPreferred"];
     
     self.userConsentDefaultLanguage = [firebaseConfiguration stringForKey:@"userConsentDefaultLanguage"];

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -180,7 +180,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 @property (nonatomic, getter=isSearchSettingSubtitledHidden) BOOL searchSettingSubtitledHidden;
 @property (nonatomic, getter=isShowsSearchHidden) BOOL showsSearchHidden;
 
-@property (nonatomic, getter=isLegacyShowPagePreferred) BOOL legacyShowPagePreferred;
+@property (nonatomic, getter=isPredefinedShowPagePreferred) BOOL predefinedShowPagePreferred;
 @property (nonatomic, getter=isShowLeadPreferred) BOOL showLeadPreferred;
 
 @property (nonatomic, copy) NSString *userConsentDefaultLanguage;
@@ -485,7 +485,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     self.searchSettingSubtitledHidden = [firebaseConfiguration boolForKey:@"searchSettingSubtitledHidden"];
     self.showsSearchHidden = [firebaseConfiguration boolForKey:@"showsSearchHidden"];
     
-    self.legacyShowPagePreferred = [firebaseConfiguration boolForKey:@"legacyShowPagePreferred"];
+    self.predefinedShowPagePreferred = [firebaseConfiguration boolForKey:@"predefinedShowPagePreferred"];
     self.showLeadPreferred = [firebaseConfiguration boolForKey:@"showLeadPreferred"];
     
     self.userConsentDefaultLanguage = [firebaseConfiguration stringForKey:@"userConsentDefaultLanguage"];

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -90,7 +90,7 @@ extension ApplicationConfiguration {
 }
 
 enum ConfiguredSection: Hashable {
-    case show(SRGShow)
+    case availableEpisodes(SRGShow)
     
     case favoriteShows
     case history

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -312,6 +312,8 @@ private extension Content {
                     return AnalyticsPageTitle.watchLater.rawValue
                 case .topicSelector:
                     return AnalyticsPageTitle.topics.rawValue
+                case .availableEpisodes:
+                    return AnalyticsPageTitle.availableEpisodes.rawValue
                 default:
                     return nil
                 }
@@ -334,7 +336,12 @@ private extension Content {
             case .medias, .showAndMedias, .shows:
                 return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, AnalyticsPageLevel.section.rawValue]
             case .predefined:
-                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
+                switch presentation.type {
+                case .availableEpisodes:
+                    return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, show?.title ?? ""]
+                default:
+                    return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
+                }
             case .none:
                 return nil
             }
@@ -683,8 +690,8 @@ private extension Content {
         
         var analyticsTitle: String? {
             switch configuredSection {
-            case let .availableEpisodes(show):
-                return show.title
+            case .availableEpisodes:
+                return AnalyticsPageTitle.availableEpisodes.rawValue
             case .history:
                 return AnalyticsPageTitle.history.rawValue
             case .radioAllShows, .tvAllShows:
@@ -720,7 +727,7 @@ private extension Content {
         
         var analyticsType: String? {
             switch configuredSection {
-            case .availableEpisodes, .radioAllShows, .tvAllShows:
+            case .radioAllShows, .tvAllShows:
                 return AnalyticsPageType.overview.rawValue
             case .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll, .tvLiveCenterEpisodes, .tvLiveCenterEpisodesAll, .tvScheduledLivestreams, .tvScheduledLivestreamsSignLanguage, .tvLive, .radioLive, .radioLiveSatellite:
                 return AnalyticsPageType.live.rawValue
@@ -733,7 +740,7 @@ private extension Content {
             switch configuredSection {
             case let .availableEpisodes(show):
                 let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
-                return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
+                return [AnalyticsPageLevel.play.rawValue, level1, show.title]
             case let .radioAllShows(channelUid),
                 let .radioFavoriteShows(channelUid: channelUid),
                 let .radioLatest(channelUid: channelUid),

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -606,12 +606,7 @@ private extension Content {
         }
         
         var displaysTitle: Bool {
-            switch configuredSection {
-            case .show:
-                return false
-            default:
-                return true
-            }
+            return true
         }
         
         var supportsEdition: Bool {

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -729,7 +729,7 @@ private extension Content {
         var analyticsLevels: [String]? {
             switch configuredSection {
             case let .show(show):
-                let level1 = (show.transmission == .radio) ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
+                let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
                 return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
             case let .radioAllShows(channelUid),
                 let .radioFavoriteShows(channelUid: channelUid),

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -560,8 +560,6 @@ private extension Content {
                 return NSLocalizedString("Resume playback", comment: "Title label used to present medias whose playback can be resumed")
             case .radioWatchLater, .watchLater:
                 return NSLocalizedString("Later", comment: "Title Label used to present the audio later list")
-            case let .show(show):
-                return show.title
             case .tvLive:
                 return NSLocalizedString("TV channels", comment: "Title label to present main TV livestreams")
             case .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll:

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -654,7 +654,7 @@ private extension Content {
         }
         
         var displayedShow: SRGShow? {
-            if case let .show(show) = configuredSection {
+            if case let .availableEpisodes(show) = configuredSection {
                 return show
             }
             else {
@@ -664,7 +664,7 @@ private extension Content {
 #if os(iOS)
         var sharingItem: SharingItem? {
             switch configuredSection {
-            case let .show(show):
+            case let .availableEpisodes(show):
                 return SharingItem(for: show)
             default:
                 return nil
@@ -683,7 +683,7 @@ private extension Content {
         
         var analyticsTitle: String? {
             switch configuredSection {
-            case let .show(show):
+            case let .availableEpisodes(show):
                 return show.title
             case .history:
                 return AnalyticsPageTitle.history.rawValue
@@ -720,7 +720,7 @@ private extension Content {
         
         var analyticsType: String? {
             switch configuredSection {
-            case .show, .radioAllShows, .tvAllShows:
+            case .availableEpisodes, .radioAllShows, .tvAllShows:
                 return AnalyticsPageType.overview.rawValue
             case .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll, .tvLiveCenterEpisodes, .tvLiveCenterEpisodesAll, .tvScheduledLivestreams, .tvScheduledLivestreamsSignLanguage, .tvLive, .radioLive, .radioLiveSatellite:
                 return AnalyticsPageType.live.rawValue
@@ -731,7 +731,7 @@ private extension Content {
         
         var analyticsLevels: [String]? {
             switch configuredSection {
-            case let .show(show):
+            case let .availableEpisodes(show):
                 let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
                 return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
             case let .radioAllShows(channelUid),
@@ -793,7 +793,7 @@ private extension Content {
         
         var placeholderRowItems: [Content.Item] {
             switch configuredSection {
-            case .show, .history, .watchLater, .radioEpisodesForDay, .radioLatest, .radioLatestEpisodes, .radioLatestVideos,
+            case .availableEpisodes, .history, .watchLater, .radioEpisodesForDay, .radioLatest, .radioLatestEpisodes, .radioLatestVideos,
                     .radioMostPopular, .tvEpisodesForDay, .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll,
                     .tvLiveCenterEpisodes, .tvLiveCenterEpisodesAll, .tvScheduledLivestreams, .tvScheduledLivestreamsSignLanguage:
                 return (0..<kDefaultNumberOfPlaceholders).map { .mediaPlaceholder(index: $0) }
@@ -821,7 +821,7 @@ private extension Content {
             let vendor = configuration.vendor
             
             switch configuredSection {
-            case let .show(show):
+            case let .availableEpisodes(show):
                 return dataProvider.latestMediasForShow(withUrn: show.urn, pageSize: pageSize, paginatedBy: paginator)
                     .map { $0.map { .media($0) } }
                     .eraseToAnyPublisher()

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -13,13 +13,13 @@ private let kDefaultNumberOfLivestreamPlaceholders = 4
 
 enum Content {
     enum Section: Hashable {
-        case content(SRGContentSection, displayedShow: SRGShow? = nil)
+        case content(SRGContentSection, show: SRGShow? = nil)
         case configured(ConfiguredSection)
         
         var properties: SectionProperties {
             switch self {
-            case let .content(section, displayedShow):
-                return ContentSectionProperties(contentSection: section, displayedShow: displayedShow)
+            case let .content(section, show):
+                return ContentSectionProperties(contentSection: section, show: show)
             case let .configured(section):
                 return ConfiguredSectionProperties(configuredSection: section)
             }
@@ -175,7 +175,7 @@ protocol SectionProperties {
 private extension Content {
     struct ContentSectionProperties: SectionProperties {
         let contentSection: SRGContentSection
-        let displayedShow: SRGShow?
+        let show: SRGShow?
         
         private var presentation: SRGContentPresentation {
             return contentSection.presentation
@@ -281,6 +281,10 @@ private extension Content {
         
         var hasHighlightedItem: Bool {
             return presentation.type == .showPromotion
+        }
+        
+        var displayedShow: SRGShow? {
+            return show
         }
 #if os(iOS)
         var sharingItem: SharingItem? {
@@ -446,7 +450,7 @@ private extension Content {
                         .eraseToAnyPublisher()
 #endif
                 case .availableEpisodes:
-                    if let show = displayedShow {
+                    if let show {
                         return dataProvider.latestMediasForShow(withUrn: show.urn, pageSize: pageSize, paginatedBy: paginator)
                             .map { $0.map { .media($0) } }
                             .eraseToAnyPublisher()

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -537,6 +537,24 @@ extension PageViewController: SectionHeaderViewAction {
     }
 }
 
+extension PageViewController: ShowHeaderViewAction {
+    func showMore(sender: Any?, event: ShowMoreEvent?) {
+        guard let event else { return }
+        
+#if os(iOS)
+        let sheetTextViewController = UIHostingController(rootView: SheetTextView(content: event.content))
+        if #available(iOS 15.0, *) {
+            if let sheet = sheetTextViewController.sheetPresentationController {
+                sheet.detents = [.medium()]
+            }
+        }
+        present(sheetTextViewController, animated: true, completion: nil)
+#else
+        navigateToText(event.content)
+#endif
+    }
+}
+
 extension PageViewController: TabBarActionable {
     func performActiveTabAction(animated: Bool) {
         collectionView?.play_scrollToTop(animated: animated)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -86,7 +86,7 @@ final class PageViewController: UIViewController {
         let view = UIView(frame: UIScreen.main.bounds)
         view.backgroundColor = .srgGray16
         
-        let collectionView = CollectionView(frame: .zero, collectionViewLayout: layout(for: model, layoutWidth: 0, horizontalSizeClass: .unspecified))
+        let collectionView = CollectionView(frame: .zero, collectionViewLayout: layout(for: model))
         collectionView.delegate = self
         collectionView.backgroundColor = .clear
         view.addSubview(collectionView)
@@ -186,7 +186,9 @@ final class PageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.collectionView.setCollectionViewLayout(layout(for: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass), animated: true)
+        if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
+            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass)
+        }
         model.reload()
         deselectItems(in: collectionView, animated: animated)
 #if os(iOS)
@@ -197,8 +199,10 @@ final class PageViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        // Update configuration suplementary views layouts (ie: show header).
-        self.collectionView.setCollectionViewLayout(layout(for: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass), animated: false)
+        // Update configuration suplementary views layouts (ie: show header layout).
+        if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
+            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass)
+        }
     }
     
     private func reloadData(for state: PageViewModel.State) {
@@ -587,7 +591,7 @@ private extension PageViewController {
         return configuration
     }
     
-    private func layout(for model: PageViewModel, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> UICollectionViewLayout {
+    private func layout(for model: PageViewModel) -> UICollectionViewLayout {
         return UICollectionViewCompositionalLayout(sectionProvider: { [weak self] sectionIndex, layoutEnvironment in
             let layoutWidth = layoutEnvironment.container.effectiveContentSize.width
             let horizontalSizeClass = layoutEnvironment.traitCollection.horizontalSizeClass
@@ -709,7 +713,7 @@ private extension PageViewController {
             let layoutSection = layoutSection(for: section)
             layoutSection.boundarySupplementaryItems = sectionSupplementaryItems(for: section, horizontalMargin: horizontalMargin(for: section))
             return layoutSection
-        }, configuration: Self.layoutConfiguration(model: model, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass))
+        }, configuration: Self.layoutConfiguration(model: model, layoutWidth: 0, horizontalSizeClass: .unspecified))
     }
 }
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -17,6 +17,7 @@ import GoogleCast
 
 final class PageViewController: UIViewController {
     private let model: PageViewModel
+    private let fromPushNotification: Bool
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -65,7 +66,8 @@ final class PageViewController: UIViewController {
 #endif
     
     init(id: PageViewModel.Id, fromPushNotification: Bool = false) {
-        model = PageViewModel(id: id, fromPushNotification: fromPushNotification)
+        model = PageViewModel(id: id)
+        self.fromPushNotification = fromPushNotification
         super.init(nibName: nil, bundle: nil)
         title = id.title
     }
@@ -323,11 +325,11 @@ final class PageViewController: UIViewController {
             guard !self.analyticsPageViewTracked else { return }
             self.analyticsPageViewTracked = true
             
-            SRGAnalyticsTracker.shared.trackPageView(withTitle: model.analyticsPageViewTitle,
-                                                     type: model.analyticsPageViewType,
-                                                     levels: model.analyticsPageViewLevels,
-                                                     labels: model.analyticsPageViewLabels(pageUid: pageUid),
-                                                     fromPushNotification: model.analyticsPageViewFromPushNotification)
+            SRGAnalyticsTracker.shared.trackPageView(withTitle: model.id.analyticsPageViewTitle,
+                                                     type: model.id.analyticsPageViewType,
+                                                     levels: model.id.analyticsPageViewLevels,
+                                                     labels: model.id.analyticsPageViewLabels(pageUid: pageUid),
+                                                     fromPushNotification: fromPushNotification)
         }
     }
 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -198,6 +198,7 @@ final class PageViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         updateLayoutConfiguation()
+        reloadData(for: self.model.state)
     }
     
     private func updateLayoutConfiguation() {
@@ -207,14 +208,20 @@ final class PageViewController: UIViewController {
         }
     }
     
+    private func emptyViewEdgeInsets() -> EdgeInsets {
+        let configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)
+        let supplementaryItemsHeight = configuration.boundarySupplementaryItems.map { $0.layoutSize.heightDimension.dimension }.reduce(0, +)
+        return EdgeInsets(top: supplementaryItemsHeight, leading: 0, bottom: 0, trailing: 0)
+    }
+    
     private func reloadData(for state: PageViewModel.State) {
         switch state {
         case .loading:
-            emptyContentView.content = EmptyContentView(state: .loading)
+            emptyContentView.content = EmptyContentView(state: .loading, insets: emptyViewEdgeInsets())
         case let .failed(error: error, _):
-            emptyContentView.content = EmptyContentView(state: .failed(error: error))
+            emptyContentView.content = EmptyContentView(state: .failed(error: error), insets: emptyViewEdgeInsets())
         case let .loaded(rows: rows, _):
-            emptyContentView.content = rows.isEmpty ? EmptyContentView(state: .empty(type: .generic)) : nil
+            emptyContentView.content = rows.isEmpty ? EmptyContentView(state: .empty(type: .generic), insets: emptyViewEdgeInsets()) : nil
         }
         
         DispatchQueue.global(qos: .userInteractive).async {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -67,7 +67,7 @@ final class PageViewController: UIViewController {
     init(id: PageViewModel.Id, fromPushNotification: Bool = false) {
         model = PageViewModel(id: id, fromPushNotification: fromPushNotification)
         super.init(nibName: nil, bundle: nil)
-        title = model.title
+        title = id.title
     }
     
     required init?(coder: NSCoder) {
@@ -129,7 +129,7 @@ final class PageViewController: UIViewController {
         
 #if os(iOS)
         navigationItem.largeTitleDisplayMode = model.id.isLargeTitleDisplayMode ? .always : .never
-        showHeaderVisible = model.displayedShow != nil
+        showHeaderVisible = model.id.displayedShow != nil
 #endif
         
         let cellRegistration = UICollectionView.CellRegistration<HostCollectionViewCell<ItemCell>, PageViewModel.Item> { [model] cell, _, item in
@@ -142,12 +142,12 @@ final class PageViewController: UIViewController {
         
         let globalHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<TitleView>>(elementKind: Header.global.rawValue) { [weak self] view, _, _ in
             guard let self else { return }
-            view.content = TitleView(text: model.displayedTitle)
+            view.content = TitleView(text: model.id.displayedTitle)
         }
         
         let showHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<ShowHeaderView>>(elementKind: Header.showHeader.rawValue) { [weak self] view, _, _ in
             guard let self else { return }
-            view.content = ShowHeaderView(show: model.displayedShow, horizontalPadding: Self.layoutHorizontalMargin)
+            view.content = ShowHeaderView(show: model.id.displayedShow, horizontalPadding: Self.layoutHorizontalMargin)
         }
         
         let sectionHeaderViewRegistration = UICollectionView.SupplementaryRegistration<HostSupplementaryView<SectionHeaderView>>(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] view, _, indexPath in
@@ -380,7 +380,7 @@ extension PageViewController: ContentInsets {
     
     var play_paddingContentInsets: UIEdgeInsets {
 #if os(iOS)
-        let top = isNavigationBarHidden || (model.displayedShow != nil) ? 0 : Self.layoutVerticalMargin
+        let top = isNavigationBarHidden || (model.id.displayedShow != nil) ? 0 : Self.layoutVerticalMargin
 #else
         let top = Self.layoutVerticalMargin
 #endif
@@ -626,11 +626,11 @@ private extension PageViewController {
         configuration.interSectionSpacing = constant(iOS: 35, tvOS: 70)
         configuration.contentInsetsReference = constant(iOS: .automatic, tvOS: .layoutMargins)
         
-        if let show = model.displayedShow {
+        if let show = model.id.displayedShow {
             let showHeaderSize = ShowHeaderViewSize.recommended(for: show, horizontalPadding: layoutHorizontalMargin, layoutWidth: layoutWidth - layoutHorizontalConfigurationViewMargin * 2, horizontalSizeClass: horizontalSizeClass)
             configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: showHeaderSize, elementKind: Header.showHeader.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX + layoutHorizontalConfigurationViewMargin, y: 0)) ]
         }
-        else if let title = model.displayedTitle {
+        else if let title = model.id.displayedTitle {
             let globalHeaderSize = TitleViewSize.recommended(forText: title)
             configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: globalHeaderSize, elementKind: Header.global.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX, y: 0)) ]
         }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -374,7 +374,7 @@ extension PageViewController: ContentInsets {
     
     var play_paddingContentInsets: UIEdgeInsets {
 #if os(iOS)
-        let top = isNavigationBarHidden ? 0 : Self.layoutVerticalMargin
+        let top = isNavigationBarHidden || (model.displayedShow != nil) ? 0 : Self.layoutVerticalMargin
 #else
         let top = Self.layoutVerticalMargin
 #endif

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -364,12 +364,7 @@ extension PageViewController {
     }
     
     @objc static func showViewController(for show: SRGShow, fromPushNotification: Bool = false) -> UIViewController {
-        if ApplicationConfiguration().isLegacyShowPagePreferred {
-            return SectionViewController(section: .configured(.show(show)), fromPushNotification: fromPushNotification)
-        }
-        else {
-            return PageViewController(id: .show(show), fromPushNotification: fromPushNotification)
-        }
+        return PageViewController(id: .show(show), fromPushNotification: fromPushNotification)
     }
 }
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -631,6 +631,17 @@ private extension PageViewController {
                         return ShowAccessCellSize.fullWidth()
                     }
 #endif
+                case .mediaList:
+#if os(iOS)
+                    let horizontalMargin = horizontalSizeClass == .compact ? Self.layoutHorizontalMargin : Self.layoutHorizontalMargin * 2
+                    return NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: horizontalMargin, spacing: Self.itemSpacing) { _, _ in
+                        return MediaCellSize.fullWidth(horizontalSizeClass: horizontalSizeClass)
+                    }
+#else
+                    return NSCollectionLayoutSection.grid(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { layoutWidth, spacing in
+                        return MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
+                    }
+#endif
                 }
             }
             
@@ -664,7 +675,9 @@ private extension PageViewController {
             case .liveMediaSwimlane, .liveMediaGrid:
                 LiveMediaCell(media: media)
             case .mediaGrid:
-                PlaySRG.MediaCell(media: media, style: .show)
+                PlaySRG.MediaCell(media: media, style: section.properties.displayedShow != nil ? .date : .show)
+            case .mediaList:
+                PlaySRG.MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
             default:
                 PlaySRG.MediaCell(media: media, style: .show, layout: .vertical)
             }
@@ -698,6 +711,7 @@ private extension PageViewController {
                 case .mediaPlaceholder:
                     MediaCell(media: nil, section: item.section)
                 case let .media(media):
+                    
                     MediaCell(media: media, section: item.section)
                 case .showPlaceholder:
                     ShowCell(show: nil, section: item.section)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -212,7 +212,6 @@ final class PageViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         updateLayoutConfiguation()
-        reloadData(for: self.model.state)
     }
     
     private func updateLayoutConfiguation() {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -186,9 +186,7 @@ final class PageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
-            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)
-        }
+        updateLayoutConfiguation()
         model.reload()
         deselectItems(in: collectionView, animated: animated)
 #if os(iOS)
@@ -199,6 +197,10 @@ final class PageViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
+        updateLayoutConfiguation()
+    }
+    
+    private func updateLayoutConfiguation() {
         // Update configuration suplementary views layouts (ie: show header layout).
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
             collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -313,6 +313,10 @@ extension PageViewController {
     @objc static func topicViewController(for topic: SRGTopic) -> UIViewController {
         return PageViewController(id: .topic(topic))
     }
+    
+    @objc static func showViewController(for show: SRGShow) -> UIViewController {
+        return show.transmission == .radio ? SectionViewController.showViewController(for: show) : PageViewController(id: .show(show))
+    }
 }
 
 // MARK: Protocols
@@ -357,18 +361,18 @@ extension PageViewController: UICollectionViewDelegate {
                 play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
             case let .show(show):
                 if let navigationController {
-                    let showViewController = SectionViewController.showViewController(for: show)
+                    let showViewController = PageViewController.showViewController(for: show)
                     navigationController.pushViewController(showViewController, animated: true)
                 }
             case let .topic(topic):
                 if let navigationController {
-                    let pageViewController = PageViewController(id: .topic(topic))
+                    let pageViewController = PageViewController.topicViewController(for: topic)
                     navigationController.pushViewController(pageViewController, animated: true)
                 }
             case let .highlight(_, highlightedItem):
                 if let navigationController {
                     if case let .show(show) = highlightedItem {
-                        let showViewController = SectionViewController.showViewController(for: show)
+                        let showViewController = PageViewController.showViewController(for: show)
                         navigationController.pushViewController(showViewController, animated: true)
                     }
                     else {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -192,6 +192,12 @@ final class PageViewController: UIViewController {
 #if os(iOS)
         updateNavigationBar(animated: animated)
 #endif
+        userActivity = model.userActivity
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        userActivity = nil
     }
     
     override func viewDidLayoutSubviews() {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -63,8 +63,8 @@ final class PageViewController: UIViewController {
     }
 #endif
     
-    init(id: PageViewModel.Id) {
-        model = PageViewModel(id: id)
+    init(id: PageViewModel.Id, fromPushNotification: Bool = false) {
+        model = PageViewModel(id: id, fromPushNotification: fromPushNotification)
         super.init(nibName: nil, bundle: nil)
         title = model.title
     }
@@ -324,7 +324,7 @@ final class PageViewController: UIViewController {
                                                      type: model.analyticsPageViewType,
                                                      levels: model.analyticsPageViewLevels,
                                                      labels: model.analyticsPageViewLabels(pageUid: pageUid),
-                                                     fromPushNotification: false)
+                                                     fromPushNotification: model.analyticsPageViewFromPushNotification)
         }
     }
 }
@@ -368,7 +368,7 @@ extension PageViewController {
             return SectionViewController(section: .configured(.show(show)), fromPushNotification: fromPushNotification)
         }
         else {
-            return PageViewController(id: .show(show))
+            return PageViewController(id: .show(show), fromPushNotification: fromPushNotification)
         }
     }
 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -215,7 +215,7 @@ final class PageViewController: UIViewController {
     }
     
     private func updateLayoutConfiguration() {
-        // Update configuration suplementary views layouts (ie: show header layout).
+        // Update configuration supplementary views layouts (ie: show header layout).
         // Update configuration forces a collection view layout refresh. Updating only configuration.boundarySupplementaryItems does not.
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
             collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -131,7 +131,7 @@ final class PageViewController: UIViewController {
         
 #if os(iOS)
         navigationItem.largeTitleDisplayMode = model.id.isLargeTitleDisplayMode ? .always : .never
-        showHeaderVisible = model.id.displayedShow != nil
+        showHeaderVisible = model.id.hasShowHeaderView
 #endif
         
         let cellRegistration = UICollectionView.CellRegistration<HostCollectionViewCell<ItemCell>, PageViewModel.Item> { [model] cell, _, item in
@@ -382,7 +382,7 @@ extension PageViewController: ContentInsets {
     
     var play_paddingContentInsets: UIEdgeInsets {
 #if os(iOS)
-        let top = isNavigationBarHidden || (model.id.displayedShow != nil) ? 0 : Self.layoutVerticalMargin
+        let top = (isNavigationBarHidden || model.id.hasShowHeaderView) ? 0 : Self.layoutVerticalMargin
 #else
         let top = Self.layoutVerticalMargin
 #endif

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -216,6 +216,7 @@ final class PageViewController: UIViewController {
     
     private func updateLayoutConfiguration() {
         // Update configuration suplementary views layouts (ie: show header layout).
+        // Update configuration forces a collection view layout refresh. Updating only configuration.boundarySupplementaryItems does not.
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
             collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)
         }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -350,7 +350,7 @@ extension PageViewController {
     }
     
     @objc static func showViewController(for show: SRGShow) -> UIViewController {
-        return show.transmission == .radio ? SectionViewController.showViewController(for: show) : PageViewController(id: .show(show))
+        return PageViewController(id: .show(show))
     }
 }
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -135,10 +135,7 @@ final class PageViewController: UIViewController {
         super.viewDidLoad()
         
 #if os(iOS)
-        // Avoid iOS automatic scroll insets / offset bugs occurring if large titles are desired by a view controller
-        // but the navigation bar is hidden. The scroll insets are incorrect and sometimes the scroll offset might
-        // be incorrect at the top.
-        navigationItem.largeTitleDisplayMode = model.id.isNavigationBarHidden ? .never : .always
+        navigationItem.largeTitleDisplayMode = model.id.isLargeTitleDisplayMode ? .always : .never
 #endif
         
         let cellRegistration = UICollectionView.CellRegistration<HostCollectionViewCell<ItemCell>, PageViewModel.Item> { [model] cell, _, item in

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -356,23 +356,23 @@ private extension PageViewController {
 // MARK: Objective-C API
 
 extension PageViewController {
-    @objc static func videosViewController() -> UIViewController {
+    @objc static func videosViewController() -> PageViewController {
         return PageViewController(id: .video)
     }
     
-    @objc static func audiosViewController(forRadioChannel channel: RadioChannel) -> UIViewController {
+    @objc static func audiosViewController(forRadioChannel channel: RadioChannel) -> PageViewController {
         return PageViewController(id: .audio(channel: channel))
     }
     
-    @objc static func liveViewController() -> UIViewController {
+    @objc static func liveViewController() -> PageViewController {
         return PageViewController(id: .live)
     }
     
-    @objc static func topicViewController(for topic: SRGTopic) -> UIViewController {
+    @objc static func topicViewController(for topic: SRGTopic) -> PageViewController {
         return PageViewController(id: .topic(topic))
     }
     
-    @objc static func showViewController(for show: SRGShow, fromPushNotification: Bool = false) -> UIViewController {
+    @objc static func showViewController(for show: SRGShow, fromPushNotification: Bool = false) -> PageViewController {
         return PageViewController(id: .show(show), fromPushNotification: fromPushNotification)
     }
 }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -187,7 +187,7 @@ final class PageViewController: UIViewController {
         super.viewWillAppear(animated)
         
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
-            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass)
+            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)
         }
         model.reload()
         deselectItems(in: collectionView, animated: animated)
@@ -201,7 +201,7 @@ final class PageViewController: UIViewController {
         
         // Update configuration suplementary views layouts (ie: show header layout).
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
-            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.frame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass)
+            collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)
         }
     }
     
@@ -574,18 +574,18 @@ private extension PageViewController {
     private static let layoutHorizontalMargin: CGFloat = constant(iOS: 16, tvOS: 0)
     private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
     
-    private static func layoutConfiguration(model: PageViewModel, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> UICollectionViewCompositionalLayoutConfiguration {
+    private static func layoutConfiguration(model: PageViewModel, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass, offsetX: CGFloat) -> UICollectionViewCompositionalLayoutConfiguration {
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
         configuration.interSectionSpacing = constant(iOS: 35, tvOS: 70)
         configuration.contentInsetsReference = constant(iOS: .automatic, tvOS: .layoutMargins)
         
         if let show = model.displayedShow {
             let showHeaderSize = ShowHeaderViewSize.recommended(for: show, horizontalPadding: Self.layoutHorizontalMargin, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
-            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: showHeaderSize, elementKind: Header.showHeader.rawValue, alignment: .topLeading) ]
+            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: showHeaderSize, elementKind: Header.showHeader.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX, y: 0)) ]
         }
         else if let title = model.displayedTitle {
             let globalHeaderSize = TitleViewSize.recommended(forText: title)
-            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: globalHeaderSize, elementKind: Header.global.rawValue, alignment: .topLeading) ]
+            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: globalHeaderSize, elementKind: Header.global.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX, y: 0)) ]
         }
         
         return configuration
@@ -713,7 +713,7 @@ private extension PageViewController {
             let layoutSection = layoutSection(for: section)
             layoutSection.boundarySupplementaryItems = sectionSupplementaryItems(for: section, horizontalMargin: horizontalMargin(for: section))
             return layoutSection
-        }, configuration: Self.layoutConfiguration(model: model, layoutWidth: 0, horizontalSizeClass: .unspecified))
+        }, configuration: Self.layoutConfiguration(model: model, layoutWidth: 0, horizontalSizeClass: .unspecified, offsetX: 0))
     }
 }
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -254,6 +254,18 @@ final class PageViewController: UIViewController {
         }
         
         navigationController?.setNavigationBarHidden(isNavigationBarHidden, animated: animated)
+        
+        if model.id.sharingItem != nil {
+            let shareButtonItem = UIBarButtonItem(image: UIImage(named: "share"),
+                                                  style: .plain,
+                                                  target: self,
+                                                  action: #selector(self.shareContent(_:)))
+            shareButtonItem.accessibilityLabel = PlaySRGAccessibilityLocalizedString("Share", comment: "Share button label on content page view")
+            navigationItem.rightBarButtonItem = shareButtonItem
+        }
+        else {
+            navigationItem.rightBarButtonItem = nil
+        }
     }
     
     @objc private func pullToRefresh(_ refreshControl: RefreshControl) {
@@ -261,6 +273,18 @@ final class PageViewController: UIViewController {
             refreshControl.endRefreshing()
         }
         refreshTriggered = true
+    }
+    
+    @objc private func shareContent(_ barButtonItem: UIBarButtonItem) {
+        guard let sharingItem = model.id.sharingItem else { return }
+        
+        let activityViewController = UIActivityViewController(sharingItem: sharingItem, from: .button)
+        activityViewController.modalPresentationStyle = .popover
+        
+        let popoverPresentationController = activityViewController.popoverPresentationController
+        popoverPresentationController?.barButtonItem = barButtonItem
+        
+        self.present(activityViewController, animated: true, completion: nil)
     }
 #endif
     

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -419,8 +419,8 @@ extension PageViewController: UICollectionViewDelegate {
                 }
             case let .topic(topic):
                 if let navigationController {
-                    let pageViewController = PageViewController.topicViewController(for: topic)
-                    navigationController.pushViewController(pageViewController, animated: true)
+                    let topicViewController = PageViewController.topicViewController(for: topic)
+                    navigationController.pushViewController(topicViewController, animated: true)
                 }
             case let .highlight(_, highlightedItem):
                 if let navigationController {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -537,6 +537,14 @@ extension PageViewController: SectionHeaderViewAction {
     }
 }
 
+extension PageViewController: TabBarActionable {
+    func performActiveTabAction(animated: Bool) {
+        collectionView?.play_scrollToTop(animated: animated)
+    }
+}
+
+#endif
+
 extension PageViewController: ShowHeaderViewAction {
     func showMore(sender: Any?, event: ShowMoreEvent?) {
         guard let event else { return }
@@ -554,14 +562,6 @@ extension PageViewController: ShowHeaderViewAction {
 #endif
     }
 }
-
-extension PageViewController: TabBarActionable {
-    func performActiveTabAction(animated: Bool) {
-        collectionView?.play_scrollToTop(animated: animated)
-    }
-}
-
-#endif
 
 // MARK: Layout
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -779,7 +779,6 @@ private extension PageViewController {
                 case .mediaPlaceholder:
                     MediaCell(media: nil, section: item.section)
                 case let .media(media):
-                    
                     MediaCell(media: media, section: item.section)
                 case .showPlaceholder:
                     ShowCell(show: nil, section: item.section)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -419,19 +419,19 @@ extension PageViewController: UICollectionViewDelegate {
                 play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
             case let .show(show):
                 if let navigationController {
-                    let showViewController = PageViewController.showViewController(for: show)
-                    navigationController.pushViewController(showViewController, animated: true)
+                    let pageViewController = PageViewController(id: .show(show))
+                    navigationController.pushViewController(pageViewController, animated: true)
                 }
             case let .topic(topic):
                 if let navigationController {
-                    let topicViewController = PageViewController.topicViewController(for: topic)
-                    navigationController.pushViewController(topicViewController, animated: true)
+                    let pageViewController = PageViewController(id: .topic(topic))
+                    navigationController.pushViewController(pageViewController, animated: true)
                 }
             case let .highlight(_, highlightedItem):
                 if let navigationController {
                     if case let .show(show) = highlightedItem {
-                        let showViewController = PageViewController.showViewController(for: show)
-                        navigationController.pushViewController(showViewController, animated: true)
+                        let pageViewController = PageViewController(id: .show(show))
+                        navigationController.pushViewController(pageViewController, animated: true)
                     }
                     else {
                         let sectionViewController = SectionViewController(section: section.wrappedValue, filter: model.id)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -34,6 +34,7 @@ final class PageViewController: UIViewController {
     }
     
     private var refreshTriggered = false
+    private var showHeaderVisible = false
 #endif
     
     private var analyticsPageViewTracked = false
@@ -128,6 +129,7 @@ final class PageViewController: UIViewController {
         
 #if os(iOS)
         navigationItem.largeTitleDisplayMode = model.id.isLargeTitleDisplayMode ? .always : .never
+        showHeaderVisible = model.displayedShow != nil
 #endif
         
         let cellRegistration = UICollectionView.CellRegistration<HostCollectionViewCell<ItemCell>, PageViewModel.Item> { [model] cell, _, item in
@@ -277,6 +279,7 @@ final class PageViewController: UIViewController {
             self.googleCastButton?.removeFromSuperview()
         }
         
+        navigationItem.title = !showHeaderVisible ? title : nil
         navigationController?.setNavigationBarHidden(isNavigationBarHidden, animated: animated)
         
         if model.id.sharingItem != nil {
@@ -463,6 +466,26 @@ extension PageViewController: UICollectionViewDelegate {
     
     func collectionView(_ collectionView: UICollectionView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         return preview(for: configuration, in: collectionView)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, willDisplaySupplementaryView view: UICollectionReusableView, forElementKind elementKind: String, at indexPath: IndexPath) {
+        switch elementKind {
+        case Header.showHeader.rawValue:
+            showHeaderVisible = true
+            updateNavigationBar(animated: true)
+        default:
+            break
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didEndDisplayingSupplementaryView view: UICollectionReusableView, forElementOfKind elementKind: String, at indexPath: IndexPath) {
+        switch elementKind {
+        case Header.showHeader.rawValue:
+                showHeaderVisible = false
+                updateNavigationBar(animated: true)
+        default:
+            break
+        }
     }
     
     private func preview(for configuration: UIContextMenuConfiguration, in collectionView: UICollectionView) -> UITargetedPreview? {

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -593,6 +593,7 @@ private extension PageViewController {
     private static let itemSpacing: CGFloat = constant(iOS: 8, tvOS: 40)
     private static let layoutHorizontalMargin: CGFloat = constant(iOS: 16, tvOS: 0)
     private static let layoutVerticalMargin: CGFloat = constant(iOS: 8, tvOS: 0)
+    private static let layoutHorizontalConfigurationViewMargin: CGFloat = constant(iOS: 0, tvOS: 8)
     
     private static func layoutConfiguration(model: PageViewModel, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass, offsetX: CGFloat) -> UICollectionViewCompositionalLayoutConfiguration {
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
@@ -600,8 +601,8 @@ private extension PageViewController {
         configuration.contentInsetsReference = constant(iOS: .automatic, tvOS: .layoutMargins)
         
         if let show = model.displayedShow {
-            let showHeaderSize = ShowHeaderViewSize.recommended(for: show, horizontalPadding: Self.layoutHorizontalMargin, layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass)
-            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: showHeaderSize, elementKind: Header.showHeader.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX, y: 0)) ]
+            let showHeaderSize = ShowHeaderViewSize.recommended(for: show, horizontalPadding: layoutHorizontalMargin, layoutWidth: layoutWidth - layoutHorizontalConfigurationViewMargin * 2, horizontalSizeClass: horizontalSizeClass)
+            configuration.boundarySupplementaryItems = [ NSCollectionLayoutBoundarySupplementaryItem(layoutSize: showHeaderSize, elementKind: Header.showHeader.rawValue, alignment: .topLeading, absoluteOffset: CGPoint(x: offsetX + layoutHorizontalConfigurationViewMargin, y: 0)) ]
         }
         else if let title = model.displayedTitle {
             let globalHeaderSize = TitleViewSize.recommended(forText: title)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -100,6 +100,14 @@ final class PageViewController: UIViewController {
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         
+#if os(iOS)
+        if #available(iOS 17.0, *) {
+            collectionView.registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (collectionView: CollectionView, _) in
+                collectionView.collectionViewLayout.invalidateLayout()
+            }
+        }
+#endif
+        
         let emptyContentView = HostView<EmptyContentView>(frame: .zero)
         collectionView.backgroundView = emptyContentView
         self.emptyContentView = emptyContentView

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -194,7 +194,7 @@ final class PageViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        updateLayoutConfiguation()
+        updateLayoutConfiguration()
         model.reload()
         deselectItems(in: collectionView, animated: animated)
 #if os(iOS)
@@ -211,10 +211,10 @@ final class PageViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         
-        updateLayoutConfiguation()
+        updateLayoutConfiguration()
     }
     
-    private func updateLayoutConfiguation() {
+    private func updateLayoutConfiguration() {
         // Update configuration suplementary views layouts (ie: show header layout).
         if let collectionViewLayout = self.collectionView.collectionViewLayout as? UICollectionViewCompositionalLayout {
             collectionViewLayout.configuration = Self.layoutConfiguration(model: model, layoutWidth: view.safeAreaLayoutGuide.layoutFrame.width, horizontalSizeClass: view.traitCollection.horizontalSizeClass, offsetX: view.safeAreaLayoutGuide.layoutFrame.minX)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -76,6 +76,10 @@ final class PageViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    var id: PageViewModel.Id {
+        return model.id
+    }
+    
     @objc var radioChannel: RadioChannel? {
         if case let .audio(channel: channel) = model.id {
             return channel

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -355,8 +355,13 @@ extension PageViewController {
         return PageViewController(id: .topic(topic))
     }
     
-    @objc static func showViewController(for show: SRGShow) -> UIViewController {
-        return PageViewController(id: .show(show))
+    @objc static func showViewController(for show: SRGShow, fromPushNotification: Bool = false) -> UIViewController {
+        if ApplicationConfiguration().isLegacyShowPagePreferred {
+            return SectionViewController(section: .configured(.show(show)), fromPushNotification: fromPushNotification)
+        }
+        else {
+            return PageViewController(id: .show(show))
+        }
     }
 }
 

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -10,66 +10,14 @@ import SRGDataProviderCombine
 
 final class PageViewModel: Identifiable, ObservableObject {
     let id: Id
-    let fromPushNotification: Bool
     
     @Published private(set) var state: State = .loading
     @Published private(set) var serviceMessage: ServiceMessage?
     
-    var analyticsPageViewTitle: String {
-        switch id {
-        case .video, .audio, .live:
-            return AnalyticsPageTitle.home.rawValue
-        case let .topic(topic):
-            return topic.title
-        case let .show(show):
-            return show.title
-        }
-    }
-    
-    var analyticsPageViewType: String {
-        switch id {
-        case .video, .audio:
-            return AnalyticsPageType.landingPage.rawValue
-        case  .live:
-            return AnalyticsPageType.live.rawValue
-        case .topic, .show:
-            return AnalyticsPageType.overview.rawValue
-        }
-    }
-    
-    var analyticsPageViewLevels: [String]? {
-        switch id {
-        case .video:
-            return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
-        case let .audio(channel: channel):
-            return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.audio.rawValue, channel.name]
-        case .live:
-            return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.live.rawValue]
-        case .topic:
-            return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, AnalyticsPageLevel.topic.rawValue]
-        case let .show(show):
-            let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
-            return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
-        }
-    }
-    
-    func analyticsPageViewLabels(pageUid: String?) -> SRGAnalyticsPageViewLabels? {
-        guard let pageUid else { return nil }
-        
-        let pageViewLabels = SRGAnalyticsPageViewLabels()
-        pageViewLabels.customInfo = ["pac_page_id": pageUid]
-        return pageViewLabels
-    }
-    
-    var analyticsPageViewFromPushNotification: Bool {
-        return fromPushNotification
-    }
-    
     private let trigger = Trigger()
     
-    init(id: Id, fromPushNotification: Bool = false) {
+    init(id: Id) {
         self.id = id
-        self.fromPushNotification = fromPushNotification
         
         Publishers.Publish(onOutputFrom: reloadSignal()) { [weak self] in
             return Self.pagePublisher(id: id)
@@ -279,6 +227,52 @@ extension PageViewModel {
 #else
             return nil
 #endif
+        }
+        
+        var analyticsPageViewTitle: String {
+            switch self {
+            case .video, .audio, .live:
+                return AnalyticsPageTitle.home.rawValue
+            case let .topic(topic):
+                return topic.title
+            case let .show(show):
+                return show.title
+            }
+        }
+        
+        var analyticsPageViewType: String {
+            switch self {
+            case .video, .audio:
+                return AnalyticsPageType.landingPage.rawValue
+            case  .live:
+                return AnalyticsPageType.live.rawValue
+            case .topic, .show:
+                return AnalyticsPageType.overview.rawValue
+            }
+        }
+        
+        var analyticsPageViewLevels: [String]? {
+            switch self {
+            case .video:
+                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
+            case let .audio(channel: channel):
+                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.audio.rawValue, channel.name]
+            case .live:
+                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.live.rawValue]
+            case .topic:
+                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, AnalyticsPageLevel.topic.rawValue]
+            case let .show(show):
+                let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
+                return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
+            }
+        }
+        
+        func analyticsPageViewLabels(pageUid: String?) -> SRGAnalyticsPageViewLabels? {
+            guard let pageUid else { return nil }
+            
+            let pageViewLabels = SRGAnalyticsPageViewLabels()
+            pageViewLabels.customInfo = ["pac_page_id": pageUid]
+            return pageViewLabels
         }
         
         func canContain(show: SRGShow) -> Bool {

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -221,6 +221,15 @@ extension PageViewModel {
                 return false
             }
         }
+        
+        var sharingItem: SharingItem? {
+            switch self {
+            case let .show(show):
+                return SharingItem(for: show)
+            default:
+                return nil
+            }
+        }
 #endif
         
         var supportsCastButton: Bool {

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -462,7 +462,7 @@ private extension PageViewModel {
         case let .show(show):
             if show.transmission == .TV && !ApplicationConfiguration.shared.isPredefinedShowPagePreferred {
                 return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
-                    .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0, displayedShow: show), index: $1) }) }
+                    .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0, show: show), index: $1) }) }
                     .eraseToAnyPublisher()
             }
             else {

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -213,6 +213,18 @@ extension PageViewModel {
         case show(_ show: SRGShow)
         
 #if os(iOS)
+        var isLargeTitleDisplayMode: Bool {
+            if case .show = self {
+                return false
+            }
+            else {
+                // Avoid iOS automatic scroll insets / offset bugs occurring if large titles are desired by a view controller
+                // but the navigation bar is hidden. The scroll insets are incorrect and sometimes the scroll offset might
+                // be incorrect at the top.
+                return !isNavigationBarHidden
+            }
+        }
+        
         var isNavigationBarHidden: Bool {
             switch self {
             case .video:

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -466,7 +466,7 @@ private extension PageViewModel {
                     .eraseToAnyPublisher()
             }
             else {
-                return Just(Page(uid: nil, sections: [ Section(.configured(.show(show)), index: 0) ] ))
+                return Just(Page(uid: nil, sections: [ Section(.configured(.availableEpisodes(show)), index: 0) ] ))
                     .setFailureType(to: Error.self)
                     .eraseToAnyPublisher()
             }
@@ -629,7 +629,7 @@ private extension PageViewModel {
             case .radioShowAccess:
                 return .showAccess
 #endif
-            case .show:
+            case .availableEpisodes:
 #if os(iOS)
                 return .mediaList
 #else

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -216,6 +216,10 @@ extension PageViewModel {
             }
         }
         
+        var hasShowHeaderView: Bool {
+            return displayedShow != nil
+        }
+        
         var displayedTitle: String? {
 #if os(tvOS)
             if case .topic = self {

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -21,6 +21,8 @@ final class PageViewModel: Identifiable, ObservableObject {
             return NSLocalizedString("Livestreams", comment: "Title displayed at the top of the livestreams view")
         case let .topic(topic):
             return topic.title
+        case let .show(show):
+            return show.title
         }
     }
     
@@ -33,6 +35,8 @@ final class PageViewModel: Identifiable, ObservableObject {
             return AnalyticsPageTitle.home.rawValue
         case let .topic(topic):
             return topic.title
+        case let .show(show):
+            return show.title
         }
     }
     
@@ -42,7 +46,7 @@ final class PageViewModel: Identifiable, ObservableObject {
             return AnalyticsPageType.landingPage.rawValue
         case  .live:
             return AnalyticsPageType.live.rawValue
-        case .topic:
+        case .topic, .show:
             return AnalyticsPageType.overview.rawValue
         }
     }
@@ -57,6 +61,9 @@ final class PageViewModel: Identifiable, ObservableObject {
             return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.live.rawValue]
         case .topic:
             return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, AnalyticsPageLevel.topic.rawValue]
+        case let .show(show):
+            let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
+            return [AnalyticsPageLevel.play.rawValue, level1, AnalyticsPageLevel.show.rawValue]
         }
     }
     
@@ -194,6 +201,7 @@ extension PageViewModel {
         case audio(channel: RadioChannel)
         case live
         case topic(_ topic: SRGTopic)
+        case show(_ show: SRGShow)
         
 #if os(iOS)
         var isNavigationBarHidden: Bool {
@@ -366,6 +374,10 @@ private extension PageViewModel {
                 .eraseToAnyPublisher()
         case let .topic(topic):
             return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, topicWithUrn: topic.urn)
+                .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
+                .eraseToAnyPublisher()
+        case let .show(show):
+            return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .audio(channel: channel):

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -12,43 +12,6 @@ final class PageViewModel: Identifiable, ObservableObject {
     let id: Id
     let fromPushNotification: Bool
     
-    var title: String? {
-        switch id {
-        case .video:
-            return NSLocalizedString("Videos", comment: "Title displayed at the top of the video view")
-        case .audio:
-            return NSLocalizedString("Audios", comment: "Title displayed at the top of the audio view")
-        case .live:
-            return NSLocalizedString("Livestreams", comment: "Title displayed at the top of the livestreams view")
-        case let .topic(topic):
-            return topic.title
-        case let .show(show):
-            return show.title
-        }
-    }
-    
-    var displayedShow: SRGShow? {
-        if case let .show(show) = id {
-            return show
-        }
-        else {
-            return nil
-        }
-    }
-    
-    var displayedTitle: String? {
-#if os(tvOS)
-        if case .topic = id {
-            return title
-        }
-        else {
-            return nil
-        }
-#else
-        return nil
-#endif
-    }
-    
     @Published private(set) var state: State = .loading
     @Published private(set) var serviceMessage: ServiceMessage?
     
@@ -279,6 +242,43 @@ extension PageViewModel {
             default:
                 return false
             }
+        }
+        
+        var title: String? {
+            switch self {
+            case .video:
+                return NSLocalizedString("Videos", comment: "Title displayed at the top of the video view")
+            case .audio:
+                return NSLocalizedString("Audios", comment: "Title displayed at the top of the audio view")
+            case .live:
+                return NSLocalizedString("Livestreams", comment: "Title displayed at the top of the livestreams view")
+            case let .topic(topic):
+                return topic.title
+            case let .show(show):
+                return show.title
+            }
+        }
+        
+        var displayedShow: SRGShow? {
+            if case let .show(show) = self {
+                return show
+            }
+            else {
+                return nil
+            }
+        }
+        
+        var displayedTitle: String? {
+#if os(tvOS)
+            if case .topic = self {
+                return title
+            }
+            else {
+                return nil
+            }
+#else
+            return nil
+#endif
         }
         
         func canContain(show: SRGShow) -> Bool {

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -462,7 +462,7 @@ private extension PageViewModel {
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .show(show):
-            if show.transmission == .TV && !ApplicationConfiguration.shared.areShowsUnavailable {
+            if show.transmission == .TV && !ApplicationConfiguration.shared.isPredefinedShowPagePreferred {
                 return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
                     .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0, displayedShow: show), index: $1) }) }
                     .eraseToAnyPublisher()

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -10,6 +10,7 @@ import SRGDataProviderCombine
 
 final class PageViewModel: Identifiable, ObservableObject {
     let id: Id
+    let fromPushNotification: Bool
     
     var title: String? {
         switch id {
@@ -97,10 +98,15 @@ final class PageViewModel: Identifiable, ObservableObject {
         return pageViewLabels
     }
     
+    var analyticsPageViewFromPushNotification: Bool {
+        return fromPushNotification
+    }
+    
     private let trigger = Trigger()
     
-    init(id: Id) {
+    init(id: Id, fromPushNotification: Bool = false) {
         self.id = id
+        self.fromPushNotification = fromPushNotification
         
         Publishers.Publish(onOutputFrom: reloadSignal()) { [weak self] in
             return Self.pagePublisher(id: id)

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -456,7 +456,7 @@ private extension PageViewModel {
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .show(show):
-            if show.transmission == .TV {
+            if show.transmission == .TV && !ApplicationConfiguration.shared.areShowsUnavailable {
                 return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
                     .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0, displayedShow: show), index: $1) }) }
                     .eraseToAnyPublisher()

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -35,6 +35,19 @@ final class PageViewModel: Identifiable, ObservableObject {
         }
     }
     
+    var displayedTitle: String? {
+#if os(tvOS)
+        if case .topic = id {
+            return title
+        }
+        else {
+            return nil
+        }
+#else
+        return nil
+#endif
+    }
+    
     @Published private(set) var state: State = .loading
     @Published private(set) var serviceMessage: ServiceMessage?
     

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -591,8 +591,8 @@ extension SectionViewController: SectionShowHeaderViewAction {
         navigateToShow(event.show)
 #else
         if let navigationController {
-            let showViewController = PageViewController.showViewController(for: event.show)
-            navigationController.pushViewController(showViewController, animated: true)
+            let pageViewController = PageViewController(id: .show(event.show))
+            navigationController.pushViewController(pageViewController, animated: true)
         }
 #endif
     }

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -250,7 +250,7 @@ final class SectionViewController: UIViewController {
                                                       style: .plain,
                                                       target: self,
                                                       action: #selector(self.shareContent(_:)))
-                shareButtonItem.accessibilityLabel = PlaySRGAccessibilityLocalizedString("Share", comment: "Share button label on player view")
+                shareButtonItem.accessibilityLabel = PlaySRGAccessibilityLocalizedString("Share", comment: "Share button label on section detail view")
                 navigationItem.rightBarButtonItem = shareButtonItem
             }
             else {

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -742,7 +742,7 @@ private extension SectionViewController {
                     }
                 case let .configured(configuredSection):
                     switch configuredSection {
-                    case .show:
+                    case .availableEpisodes:
                         if configuration.viewModelProperties.layout == .mediaList {
                             MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
                         }

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -449,14 +449,6 @@ extension SectionViewController {
     @objc static func showsViewController(forChannelUid channelUid: String?) -> SectionViewController {
         return showsViewController(forChannelUid: channelUid, initialSectionId: nil)
     }
-    
-    @objc static func showViewController(for show: SRGShow, fromPushNotification: Bool) -> SectionViewController {
-        return SectionViewController(section: .configured(.show(show)), fromPushNotification: fromPushNotification)
-    }
-    
-    @objc static func showViewController(for show: SRGShow) -> SectionViewController {
-        return showViewController(for: show, fromPushNotification: false)
-    }
 }
 
 // MARK: Protocols

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -782,7 +782,7 @@ private extension SectionViewController {
             case let .show(show):
                 let imageVariant = configuration.properties.imageVariant
                 switch configuration.wrappedValue {
-                case let .content(contentSection):
+                case let .content(contentSection, _):
                     switch contentSection.type {
                     case .predefined:
                         switch contentSection.presentation.type {

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -630,7 +630,7 @@ extension SectionViewController: SectionShowHeaderViewAction {
         navigateToShow(event.show)
 #else
         if let navigationController {
-            let showViewController = SectionViewController.showViewController(for: event.show)
+            let showViewController = PageViewController.showViewController(for: event.show)
             navigationController.pushViewController(showViewController, animated: true)
         }
 #endif

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -405,7 +405,7 @@ private extension SectionViewModel {
             case .notifications:
                 return .notificationList
 #endif
-            case .show:
+            case .availableEpisodes:
 #if os(iOS)
                 return .mediaList
 #else

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -160,7 +160,6 @@ extension SectionViewModel {
         case none
         case title(String)
         case item(Content.Item)
-        case show(SRGShow)
         
         var sectionTopInset: CGFloat {
             switch self {
@@ -175,7 +174,7 @@ extension SectionViewModel {
             switch self {
             case .title:
                 return .small
-            case .item, .show:
+            case .item:
                 return .large
             case .none:
                 return .zero
@@ -303,7 +302,6 @@ extension SectionViewModel {
 protocol SectionViewModelProperties {
     var layout: SectionViewModel.SectionLayout { get }
     var pinHeadersToVisibleBounds: Bool { get }
-    var userActivity: NSUserActivity? { get }
     var largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode { get }
     
     func rows(from items: [SectionViewModel.Item]) -> [SectionViewModel.Row]
@@ -327,6 +325,12 @@ private extension SectionViewModel {
                     return .liveMediaGrid
                 case .swimlane, .grid:
                     return (contentSection.type == .shows) ? .showGrid : .mediaGrid
+                case .availableEpisodes:
+#if os(iOS)
+                    return .mediaList
+#else
+                    return .mediaGrid
+#endif
                 default:
                     return .mediaGrid
                 }
@@ -352,10 +356,6 @@ private extension SectionViewModel {
 #else
             return false
 #endif
-        }
-        
-        var userActivity: NSUserActivity? {
-            return nil
         }
         
         var largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode {
@@ -429,44 +429,8 @@ private extension SectionViewModel {
 #endif
         }
         
-        var userActivity: NSUserActivity? {
-            guard let bundleIdentifier = Bundle.main.bundleIdentifier,
-                  let applicationVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") else {
-                return nil
-            }
-            
-            switch configuredSection {
-            case let .show(show):
-                guard let data = try? NSKeyedArchiver.archivedData(withRootObject: show, requiringSecureCoding: false) else { return nil }
-                let userActivity = NSUserActivity(activityType: bundleIdentifier.appending(".displaying"))
-                userActivity.title = String(format: NSLocalizedString("Display %@ episodes", comment: "User activity title when displaying a show page"), show.title)
-                userActivity.webpageURL = ApplicationConfiguration.shared.sharingURL(for: show)
-                userActivity.addUserInfoEntries(from: [
-                    "URNString": show.urn,
-                    "SRGShowData": data,
-                    "applicationVersion": applicationVersion
-                ])
-                
-#if os(iOS)
-                userActivity.isEligibleForPrediction = true
-                userActivity.persistentIdentifier = show.urn
-                let suggestedInvocationPhraseFormat = show.transmission == .radio ? NSLocalizedString("Listen to %@", comment: "Suggested invocation phrase to listen to a show") : NSLocalizedString("Watch %@", comment: "Suggested invocation phrase to watch a show")
-                userActivity.suggestedInvocationPhrase = String(format: suggestedInvocationPhraseFormat, show.title)
-#endif
-                
-                return userActivity
-            default:
-                return nil
-            }
-        }
-        
         var largeTitleDisplayMode: UINavigationItem.LargeTitleDisplayMode {
-            switch configuredSection {
-            case .show:
-                return .never
-            default:
-                return .always
-            }
+            return .always
         }
         
         func rows(from items: [SectionViewModel.Item]) -> [SectionViewModel.Row] {
@@ -475,8 +439,6 @@ private extension SectionViewModel {
                 return SectionViewModel.alphabeticalRows(from: items, smart: true)
             case .radioAllShows, .tvAllShows:
                 return SectionViewModel.alphabeticalRows(from: items, smart: false)
-            case let .show(show):
-                return SectionViewModel.consolidatedRows(with: items, header: .show(show))
 #if os(iOS)
             case .downloads:
                 return SectionViewModel.consolidatedRows(with: items, footer: .diskInfo)

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -450,7 +450,7 @@ private extension SectionViewModel {
 #if os(iOS)
                 userActivity.isEligibleForPrediction = true
                 userActivity.persistentIdentifier = show.urn
-                let suggestedInvocationPhraseFormat = (show.transmission == .radio) ? NSLocalizedString("Listen to %@", comment: "Suggested invocation phrase to listen to a show") : NSLocalizedString("Watch %@", comment: "Suggested invocation phrase to watch a show")
+                let suggestedInvocationPhraseFormat = show.transmission == .radio ? NSLocalizedString("Listen to %@", comment: "Suggested invocation phrase to listen to a show") : NSLocalizedString("Watch %@", comment: "Suggested invocation phrase to watch a show")
                 userActivity.suggestedInvocationPhrase = String(format: suggestedInvocationPhraseFormat, show.title)
 #endif
                 

--- a/Application/Sources/Content/SectionViewModel.swift
+++ b/Application/Sources/Content/SectionViewModel.swift
@@ -142,7 +142,7 @@ extension SectionViewModel {
         
         var viewModelProperties: SectionViewModelProperties {
             switch wrappedValue {
-            case let .content(section):
+            case let .content(section, _):
                 return ContentSectionProperties(contentSection: section)
             case let .configured(section):
                 return ConfiguredSectionProperties(configuredSection: section)

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -30,14 +30,14 @@ class ShowMoreEvent: UIEvent {
 
 /// Behavior: h-hug, v-hug
 struct ShowHeaderView: View {
-    @Binding private(set) var show: SRGShow
+    @Binding private(set) var show: SRGShow?
     let horizontalPadding: CGFloat
     
     @StateObject private var model = ShowHeaderViewModel()
     
     fileprivate static let verticalSpacing: CGFloat = 24
     
-    init(show: SRGShow, horizontalPadding: CGFloat) {
+    init(show: SRGShow?, horizontalPadding: CGFloat) {
         _show = .constant(show)
         self.horizontalPadding = horizontalPadding
     }
@@ -242,12 +242,17 @@ struct ShowHeaderView: View {
 // MARK: Size
 
 enum ShowHeaderViewSize {
-    static func recommended(for show: SRGShow, horizontalPadding: CGFloat, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
-        let fittingSize = CGSize(width: layoutWidth, height: UIView.layoutFittingExpandedSize.height)
-        let model = ShowHeaderViewModel()
-        model.show = show
-        let size = ShowHeaderView.MainView(model: model, horizontalPadding: horizontalPadding).adaptiveSizeThatFits(in: fittingSize, for: horizontalSizeClass)
-        return NSCollectionLayoutSize(widthDimension: .absolute(layoutWidth), heightDimension: .absolute(size.height))
+    static func recommended(for show: SRGShow?, horizontalPadding: CGFloat, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> NSCollectionLayoutSize {
+        if let show {
+            let fittingSize = CGSize(width: layoutWidth, height: UIView.layoutFittingExpandedSize.height)
+            let model = ShowHeaderViewModel()
+            model.show = show
+            let size = ShowHeaderView.MainView(model: model, horizontalPadding: horizontalPadding).adaptiveSizeThatFits(in: fittingSize, for: horizontalSizeClass)
+            return NSCollectionLayoutSize(widthDimension: .absolute(layoutWidth), heightDimension: .absolute(size.height))
+        }
+        else {
+            return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))
+        }
     }
 }
 

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -248,7 +248,7 @@ enum ShowHeaderViewSize {
             let model = ShowHeaderViewModel()
             model.show = show
             let size = ShowHeaderView.MainView(model: model, horizontalPadding: horizontalPadding).adaptiveSizeThatFits(in: fittingSize, for: horizontalSizeClass)
-            return NSCollectionLayoutSize(widthDimension: .absolute(layoutWidth), heightDimension: .absolute(size.height))
+            return NSCollectionLayoutSize(widthDimension: .absolute(size.width), heightDimension: .absolute(size.height))
         }
         else {
             return NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(LayoutHeaderHeightZero))

--- a/Application/Sources/Helpers/AnalyticsConstants.h
+++ b/Application/Sources/Helpers/AnalyticsConstants.h
@@ -37,6 +37,7 @@ OBJC_EXPORT AnalyticsPageLevel const AnalyticsPageLevelVideo;
  */
 typedef NSString * AnalyticsPageTitle NS_STRING_ENUM;
 
+OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleAvailableEpisodes;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleDevices;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleDownloads;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleFavorites;

--- a/Application/Sources/Helpers/AnalyticsConstants.m
+++ b/Application/Sources/Helpers/AnalyticsConstants.m
@@ -27,6 +27,7 @@ AnalyticsPageLevel const AnalyticsPageLevelTopic = @"topic";
 AnalyticsPageLevel const AnalyticsPageLevelUser = @"user";
 AnalyticsPageLevel const AnalyticsPageLevelVideo = @"video";
 
+AnalyticsPageTitle const AnalyticsPageTitleAvailableEpisodes = @"available episodes";
 AnalyticsPageTitle const AnalyticsPageTitleDevices = @"devices";
 AnalyticsPageTitle const AnalyticsPageTitleDownloads = @"downloads";
 AnalyticsPageTitle const AnalyticsPageTitleFavorites = @"favorites";

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -2100,7 +2100,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     SceneDelegate *sceneDelegate = UIApplication.sharedApplication.mainSceneDelegate;
     [sceneDelegate.rootTabBarController openApplicationSectionInfo:applicationSectionInfo];
     
-    SectionViewController *showViewController = [SectionViewController showViewControllerFor:show];
+    UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:NO];
     [sceneDelegate.rootTabBarController pushViewController:showViewController animated:NO];
     [sceneDelegate.window play_dismissAllViewControllersWithAnimated:YES completion:nil];
 }

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -2100,7 +2100,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     SceneDelegate *sceneDelegate = UIApplication.sharedApplication.mainSceneDelegate;
     [sceneDelegate.rootTabBarController openApplicationSectionInfo:applicationSectionInfo];
     
-    UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:NO];
+    PageViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:NO];
     [sceneDelegate.rootTabBarController pushViewController:pageViewController animated:NO];
     [sceneDelegate.window play_dismissAllViewControllersWithAnimated:YES completion:nil];
 }

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -2100,8 +2100,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     SceneDelegate *sceneDelegate = UIApplication.sharedApplication.mainSceneDelegate;
     [sceneDelegate.rootTabBarController openApplicationSectionInfo:applicationSectionInfo];
     
-    UIViewController *showViewController = [PageViewController showViewControllerFor:show fromPushNotification:NO];
-    [sceneDelegate.rootTabBarController pushViewController:showViewController animated:NO];
+    UIViewController *pageViewController = [PageViewController showViewControllerFor:show fromPushNotification:NO];
+    [sceneDelegate.rootTabBarController pushViewController:pageViewController animated:NO];
     [sceneDelegate.window play_dismissAllViewControllersWithAnimated:YES completion:nil];
 }
 

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -349,7 +349,7 @@ final class ProgramViewModel: ObservableObject {
                       let window = UIApplication.shared.mainWindow else {
                     return
                 }
-                let showViewController = SectionViewController.showViewController(for: show)
+                let showViewController = PageViewController.showViewController(for: show)
                 tabBarController.pushViewController(showViewController, animated: false)
                 window.play_dismissAllViewControllers(animated: true, completion: nil)
             }

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -349,8 +349,8 @@ final class ProgramViewModel: ObservableObject {
                       let window = UIApplication.shared.mainWindow else {
                     return
                 }
-                let showViewController = PageViewController.showViewController(for: show)
-                tabBarController.pushViewController(showViewController, animated: false)
+                let pageViewController = PageViewController(id: .show(show))
+                tabBarController.pushViewController(pageViewController, animated: false)
                 window.play_dismissAllViewControllers(animated: true, completion: nil)
             }
         )

--- a/Application/Sources/RadioChannels/RadioChannelsViewController.m
+++ b/Application/Sources/RadioChannels/RadioChannelsViewController.m
@@ -25,9 +25,9 @@
     
     NSMutableArray<UIViewController *> *viewControllers = [NSMutableArray array];
     for (RadioChannel *radioChannel in radioChannels) {
-        UIViewController *viewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
-        viewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:radioChannel.name image:RadioChannelLogoImage(radioChannel) tag:0];
-        [viewControllers addObject:viewController];
+        UIViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
+        pageViewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:radioChannel.name image:RadioChannelLogoImage(radioChannel) tag:0];
+        [viewControllers addObject:pageViewController];
     }
     
     NSUInteger initialPage = [radioChannels indexOfObject:ApplicationSettingLastOpenedRadioChannel()];

--- a/Application/Sources/RadioChannels/RadioChannelsViewController.m
+++ b/Application/Sources/RadioChannels/RadioChannelsViewController.m
@@ -25,7 +25,7 @@
     
     NSMutableArray<UIViewController *> *viewControllers = [NSMutableArray array];
     for (RadioChannel *radioChannel in radioChannels) {
-        UIViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
+        PageViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
         pageViewController.tabBarItem = [[UITabBarItem alloc] initWithTitle:radioChannel.name image:RadioChannelLogoImage(radioChannel) tag:0];
         [viewControllers addObject:pageViewController];
     }

--- a/Application/Sources/Search/SearchViewController.swift
+++ b/Application/Sources/Search/SearchViewController.swift
@@ -432,16 +432,16 @@ extension SearchViewController: UICollectionViewDelegate {
             play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
         case let .show(show):
             guard let navigationController else { return }
-            let showViewController = PageViewController.showViewController(for: show)
-            navigationController.pushViewController(showViewController, animated: true)
+            let pageViewController = PageViewController(id: .show(show))
+            navigationController.pushViewController(pageViewController, animated: true)
             
             SRGDataProvider.current!.increaseSearchResultsViewCount(for: show)
                 .sink { _ in } receiveValue: { _ in }
                 .store(in: &cancellables)
         case let .topic(topic):
             guard let navigationController else { return }
-            let topicViewController = PageViewController.topicViewController(for: topic)
-            navigationController.pushViewController(topicViewController, animated: true)
+            let pageViewController = PageViewController(id: .topic(topic))
+            navigationController.pushViewController(pageViewController, animated: true)
         case .loading:
             break
         }

--- a/Application/Sources/Search/SearchViewController.swift
+++ b/Application/Sources/Search/SearchViewController.swift
@@ -432,7 +432,7 @@ extension SearchViewController: UICollectionViewDelegate {
             play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
         case let .show(show):
             guard let navigationController else { return }
-            let showViewController = SectionViewController.showViewController(for: show)
+            let showViewController = PageViewController.showViewController(for: show)
             navigationController.pushViewController(showViewController, animated: true)
             
             SRGDataProvider.current!.increaseSearchResultsViewCount(for: show)

--- a/Application/Sources/UI/Controllers/TabBarController.m
+++ b/Application/Sources/UI/Controllers/TabBarController.m
@@ -272,7 +272,7 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
                                                                      tag:TabBarItemIdentifierVideos];
     videosTabBarItem.accessibilityIdentifier = [AccessibilityIdentifierObjC identifier:AccessibilityIdentifierVideosTabBarItem].value;
  
-    UIViewController *pageViewController = [PageViewController videosViewController];
+    PageViewController *pageViewController = [PageViewController videosViewController];
     NavigationController *videosNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
     videosNavigationController.tabBarItem = videosTabBarItem;
     return videosNavigationController;
@@ -300,7 +300,7 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
     }
     else if (radioChannels.count == 1) {
         RadioChannel *radioChannel = radioChannels.firstObject;
-        UIViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
+        PageViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
         NavigationController *audiosNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
         audiosNavigationController.tabBarItem = [self audiosTabBarItem];
         [audiosNavigationController updateWithRadioChannel:radioChannel animated:NO];
@@ -322,7 +322,7 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
                                                                        tag:TabBarItemIdentifierLivestreams];
         liveTabBarItem.accessibilityIdentifier = [AccessibilityIdentifierObjC identifier:AccessibilityIdentifierLivestreamsTabBarItem].value;
         
-        UIViewController *pageViewController = [PageViewController liveViewController];
+        PageViewController *pageViewController = [PageViewController liveViewController];
         NavigationController *liveNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
         liveNavigationController.tabBarItem = liveTabBarItem;
         return liveNavigationController;

--- a/Application/Sources/UI/Controllers/TabBarController.m
+++ b/Application/Sources/UI/Controllers/TabBarController.m
@@ -272,8 +272,8 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
                                                                      tag:TabBarItemIdentifierVideos];
     videosTabBarItem.accessibilityIdentifier = [AccessibilityIdentifierObjC identifier:AccessibilityIdentifierVideosTabBarItem].value;
  
-    UIViewController *videosViewController = [PageViewController videosViewController];
-    NavigationController *videosNavigationController = [[NavigationController alloc] initWithRootViewController:videosViewController];
+    UIViewController *pageViewController = [PageViewController videosViewController];
+    NavigationController *videosNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
     videosNavigationController.tabBarItem = videosTabBarItem;
     return videosNavigationController;
 }
@@ -300,8 +300,8 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
     }
     else if (radioChannels.count == 1) {
         RadioChannel *radioChannel = radioChannels.firstObject;
-        UIViewController *audiosViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
-        NavigationController *audiosNavigationController = [[NavigationController alloc] initWithRootViewController:audiosViewController];
+        UIViewController *pageViewController = [PageViewController audiosViewControllerForRadioChannel:radioChannel];
+        NavigationController *audiosNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
         audiosNavigationController.tabBarItem = [self audiosTabBarItem];
         [audiosNavigationController updateWithRadioChannel:radioChannel animated:NO];
         return audiosNavigationController;
@@ -322,8 +322,8 @@ static const CGFloat MiniPlayerDefaultOffset = 5.f;
                                                                        tag:TabBarItemIdentifierLivestreams];
         liveTabBarItem.accessibilityIdentifier = [AccessibilityIdentifierObjC identifier:AccessibilityIdentifierLivestreamsTabBarItem].value;
         
-        UIViewController *liveViewController = [PageViewController liveViewController];
-        NavigationController *liveNavigationController = [[NavigationController alloc] initWithRootViewController:liveViewController];
+        UIViewController *pageViewController = [PageViewController liveViewController];
+        NavigationController *liveNavigationController = [[NavigationController alloc] initWithRootViewController:pageViewController];
         liveNavigationController.tabBarItem = liveTabBarItem;
         return liveNavigationController;
     }

--- a/Application/Sources/UI/Helpers/ContextMenu.swift
+++ b/Application/Sources/UI/Helpers/ContextMenu.swift
@@ -223,7 +223,7 @@ extension ContextMenu {
         }
         return UIAction(title: NSLocalizedString("More episodes", comment: "Context menu action to open more episodes associated with a media"),
                         image: UIImage(resource: .episodes)) { _ in
-            let showViewController = SectionViewController.showViewController(for: show)
+            let showViewController = PageViewController.showViewController(for: show)
             navigationController.pushViewController(showViewController, animated: true)
         }
     }
@@ -234,7 +234,7 @@ extension ContextMenu {
 extension ContextMenu {
     static func configuration(for show: SRGShow, identifier: NSCopying?, in viewController: UIViewController) -> UIContextMenuConfiguration? {
         return UIContextMenuConfiguration(identifier: identifier) {
-            return SectionViewController.showViewController(for: show)
+            return PageViewController.showViewController(for: show)
         } actionProvider: { _ in
             return menu(for: show, in: viewController)
         }

--- a/Application/Sources/UI/Helpers/ContextMenu.swift
+++ b/Application/Sources/UI/Helpers/ContextMenu.swift
@@ -223,8 +223,8 @@ extension ContextMenu {
         }
         return UIAction(title: NSLocalizedString("More episodes", comment: "Context menu action to open more episodes associated with a media"),
                         image: UIImage(resource: .episodes)) { _ in
-            let showViewController = PageViewController.showViewController(for: show)
-            navigationController.pushViewController(showViewController, animated: true)
+            let pageViewController = PageViewController(id: .show(show))
+            navigationController.pushViewController(pageViewController, animated: true)
         }
     }
 }
@@ -234,7 +234,7 @@ extension ContextMenu {
 extension ContextMenu {
     static func configuration(for show: SRGShow, identifier: NSCopying?, in viewController: UIViewController) -> UIContextMenuConfiguration? {
         return UIContextMenuConfiguration(identifier: identifier) {
-            return PageViewController.showViewController(for: show)
+            return PageViewController(id: .show(show))
         } actionProvider: { _ in
             return menu(for: show, in: viewController)
         }

--- a/Application/Sources/UI/Helpers/ContextMenu.swift
+++ b/Application/Sources/UI/Helpers/ContextMenu.swift
@@ -217,8 +217,8 @@ extension ContextMenu {
         guard !ApplicationConfiguration.shared.areShowsUnavailable,
               let show = media.show,
               let navigationController = viewController.navigationController else { return nil }
-        if let sectionViewController = viewController as? SectionViewController,
-           let displayedShow = sectionViewController.model.configuration.properties.displayedShow {
+        if let pageViewController = viewController as? PageViewController,
+           let displayedShow = pageViewController.id.displayedShow {
             guard !show.isEqual(displayedShow) else { return nil }
         }
         return UIAction(title: NSLocalizedString("More episodes", comment: "Context menu action to open more episodes associated with a media"),

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19306,8 +19306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 18.0.0;
+				branch = "feature/content-show-page";
+				kind = branch;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19259,7 +19259,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srganalytics-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.1;
+				minimumVersion = 9.0.2;
 			};
 		};
 		6F3AED322614C5B6007D591F /* XCRemoteSwiftPackageReference "srgappearance-apple" */ = {
@@ -19306,8 +19306,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 18.1.0;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19306,7 +19306,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = "feature/content-show-page";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "branch" : "feature/content-show-page",
-        "revision" : "7a92ee7bf751876773d060f3727941ae7680088e"
+        "branch" : "develop",
+        "revision" : "0f1aacc7508f896b564a0f4b25d97373ba48648e"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -303,7 +303,7 @@
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
         "branch" : "feature/content-show-page",
-        "revision" : "51adab868ef12ee0a25fb8426e73322887f95c01"
+        "revision" : "cfe26d70ada19d97a358ec9ac1c14b30276dc296"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -303,7 +303,7 @@
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
         "branch" : "feature/content-show-page",
-        "revision" : "cfe26d70ada19d97a358ec9ac1c14b30276dc296"
+        "revision" : "7a92ee7bf751876773d060f3727941ae7680088e"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -275,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srganalytics-apple.git",
       "state" : {
-        "revision" : "5fbe14159af7f61c86b8e02470cea97a133040f4",
-        "version" : "9.0.1"
+        "revision" : "45343b66e5bc2626197d314dfff88d50f9a96388",
+        "version" : "9.0.2"
       }
     },
     {
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "branch" : "develop",
-        "revision" : "0f1aacc7508f896b564a0f4b25d97373ba48648e"
+        "revision" : "a7380a80cab17b9c3f84e1b32d6c403b0bedc2be",
+        "version" : "18.1.0"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -303,7 +303,7 @@
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
         "branch" : "feature/content-show-page",
-        "revision" : "472e9d6f8416b619aaf9e5712200b2cb59b65c54"
+        "revision" : "51adab868ef12ee0a25fb8426e73322887f95c01"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -302,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "93a46a26d9ea068e3d812755e5a44c7402b2ad04",
-        "version" : "18.0.0"
+        "branch" : "feature/content-show-page",
+        "revision" : "472e9d6f8416b619aaf9e5712200b2cb59b65c54"
       }
     },
     {

--- a/TV Application/Sources/SceneDelegate.swift
+++ b/TV Application/Sources/SceneDelegate.swift
@@ -54,7 +54,7 @@ final class SceneDelegate: UIResponder {
     private static func applicationRootViewController() -> UIViewController {
         var viewControllers = [UIViewController]()
         
-        let videosViewController = PageViewController(id: .video)
+        let videosViewController = PageViewController.videosViewController()
         videosViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Home", comment: "Home tab title"), image: nil, tag: 0)
         videosViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.videosTabBarItem.value
         viewControllers.append(videosViewController)
@@ -63,7 +63,7 @@ final class SceneDelegate: UIResponder {
         
 #if DEBUG
         if let firstChannel = configuration.radioHomepageChannels.first {
-            let audiosViewController = PageViewController(id: .audio(channel: firstChannel))
+            let audiosViewController = PageViewController.audiosViewController(forRadioChannel: firstChannel)
             audiosViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Audios", comment: "Audios tab title"), image: nil, tag: 1)
             audiosViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.audiosTabBarItem.value
             viewControllers.append(audiosViewController)
@@ -71,7 +71,7 @@ final class SceneDelegate: UIResponder {
 #endif
         
         if !configuration.liveHomeSections.isEmpty {
-            let liveViewController = PageViewController(id: .live)
+            let liveViewController = PageViewController.liveViewController()
             liveViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Livestreams", comment: "Livestreams tab title"), image: nil, tag: 2)
             liveViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.livestreamsTabBarItem.value
             viewControllers.append(liveViewController)

--- a/TV Application/Sources/SceneDelegate.swift
+++ b/TV Application/Sources/SceneDelegate.swift
@@ -54,27 +54,27 @@ final class SceneDelegate: UIResponder {
     private static func applicationRootViewController() -> UIViewController {
         var viewControllers = [UIViewController]()
         
-        let videosViewController = PageViewController.videosViewController()
-        videosViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Home", comment: "Home tab title"), image: nil, tag: 0)
-        videosViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.videosTabBarItem.value
-        viewControllers.append(videosViewController)
+        let pageViewController = PageViewController(id: .video)
+        pageViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Home", comment: "Home tab title"), image: nil, tag: 0)
+        pageViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.videosTabBarItem.value
+        viewControllers.append(pageViewController)
         
         let configuration = ApplicationConfiguration.shared
         
 #if DEBUG
         if let firstChannel = configuration.radioHomepageChannels.first {
-            let audiosViewController = PageViewController.audiosViewController(forRadioChannel: firstChannel)
-            audiosViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Audios", comment: "Audios tab title"), image: nil, tag: 1)
-            audiosViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.audiosTabBarItem.value
-            viewControllers.append(audiosViewController)
+            let pageViewController = PageViewController(id: .audio(channel: firstChannel))
+            pageViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Audios", comment: "Audios tab title"), image: nil, tag: 1)
+            pageViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.audiosTabBarItem.value
+            viewControllers.append(pageViewController)
         }
 #endif
         
         if !configuration.liveHomeSections.isEmpty {
-            let liveViewController = PageViewController.liveViewController()
-            liveViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Livestreams", comment: "Livestreams tab title"), image: nil, tag: 2)
-            liveViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.livestreamsTabBarItem.value
-            viewControllers.append(liveViewController)
+            let pageViewController = PageViewController(id: .live)
+            pageViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Livestreams", comment: "Livestreams tab title"), image: nil, tag: 2)
+            pageViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.livestreamsTabBarItem.value
+            viewControllers.append(pageViewController)
         }
         
         if !configuration.isTvGuideUnavailable {

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -74,7 +74,7 @@ The radio channel JSON dictionaries have one more key:
 
 ## Shows
 
-* `legacyShowPagePreferred` (optional, boolean): Set to `true` iff show pages need to be displayed with the legacy layout (ie: only one predefined section with available episodes). If omitted, `false`.
+* `predefinedShowPagePreferred` (optional, boolean): Set to `true` iff show pages need to be displayed with the predefined layout (ie: only one predefined section with available episodes). If omitted, `false`.
 * `showLeadPreferred` (optional, boolean): Set to `true` iff show pages and show elements should display lead instead of description. If omitted, `false`.
 
 ## Audio homepage

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -74,6 +74,7 @@ The radio channel JSON dictionaries have one more key:
 
 ## Shows
 
+* `legacyShowPagePreferred` (optional, boolean): Set to `true` iff show pages need to be displayed with the legacy layout (ie: only one predefined section with available episodes). If omitted, `false`.
 * `showLeadPreferred` (optional, boolean): Set to `true` iff show pages and show elements should display lead instead of description. If omitted, `false`.
 
 ## Audio homepage


### PR DESCRIPTION
### Motivation and Context

Content available on TV (video) show page can be editorialized using the PAC (Play Application Configuration) tool.

### Description

- Update DataProvider with content show page additional endpoints: https://github.com/SRGSSR/srgdataprovider-apple/pull/52
- Show pages are from `PageViewController`, no more from `SectionViewController`.
  - Same show header.
  - Same share button.
  - Same UserActivity intent.
  - Same page view analytics.
  - Same default available episodes media list layout on iOS and iPad OS, media list grid layout on tvOS.
- TV show pages request PAC sections from IL PAC page endpoint.
- TV show pages for Play SWI (only accessible from media detail page) use a predefined section, "available episodes".
- Radio show pages use a predefined section, "available episodes". Same layout as before.
- Show header is now with a nullable show and still resizable for large or compact width.
- `PageViewController` needs to update layout configuration to update Show header layout, regarding horizontal size class.
- `SectionViewController` can now display a detail section page for "available episodes" from PAC predefined section and configured section, with the media list layout on iOS and iPad OS, the grid layout on tvOS.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
