### PR TITLE
Release checklist: Add Jira release step

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -30,6 +30,7 @@
 | Finish git-flow release, tags, Bump patch / build version numbers and push (with fastlane\*) ||||||
 | Close milestone and issues on github ||||||
 | Create github release ||||||
+| Add release date on Jira release ||||||
 | Update status page on Confluence (Release date, old versions section) ||||||
 
 ### \*Fastlane on PlayCity CI:


### PR DESCRIPTION
### Motivation and Context

Our team missed the Jira release date, which close the release on Jira.

### Description

- Add the step in the checklist template, which is copied on a spreadsheet  tool internally.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
