### PR TITLE
Fix french translation

### DIFF
--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -864,4 +864,4 @@
 "You have been automatically logged out. Login again to keep your data synchronized across devices." = "Vous avez été automatiquement déconnecté. Connectez-vous à nouveau pour conserver vos données synchronisées entre vos appareils.";
 
 /* Add to Calendar alert title */
-"“%@” would like to access to your calendar" = "« %@ » souhaite accéder à vote calendrier.";
+"“%@” would like to access to your calendar" = "« %@ » souhaite accéder à votre calendrier.";


### PR DESCRIPTION
### Motivation and Context

In the TV Guide, the calendar alert has a French translation issue.
Translators fixed it.

### Description

- Update French translations.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
