### PR TITLE
Update translation pulling script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/xcrun make -f
 
 CONFIGURATION_REPOSITORY_URL=https://github.com/SRGSSR/playsrg-apple-configuration.git
-CONFIGURATION_COMMIT_SHA1=cf878c955afb0fd424cce6678bc7e5c3f7a817a1
+CONFIGURATION_COMMIT_SHA1=4ffd8e0ab0d0b4b1594648a094ddaed943d9d77f
 CONFIGURATION_FOLDER=Configuration
 
 .PHONY: all


### PR DESCRIPTION
### Motivation and Context

The project uses [Crowdin](https://crowdin.com) service for translations.
API need to be updated. Effective from November 30, 2023, the current used API v1 will no longer be supported.

### Description

- Use updated script from private configuration. https://github.com/SRGSSR/playsrg-apple-configuration/pull/3

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
