### PR TITLE
Improve TV guide shared url in calendar event

### DIFF
--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -360,11 +360,11 @@ final class ProgramViewModel: ObservableObject {
         if let media = self.media {
             return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
         }
+        else if let media = self.livestreamMedia, program?.timeAvailability(at: Date()) == .notYetAvailable {
+            return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
+        }
         else if let show {
             return ApplicationConfiguration.shared.sharingURL(for: show)
-        }
-        else if let media = self.livestreamMedia {
-            return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
         }
         else {
             return ApplicationConfiguration.shared.playURL(for: self.channel?.vendor ?? ApplicationConfiguration.shared.vendor)

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -367,7 +367,7 @@ final class ProgramViewModel: ObservableObject {
             return ApplicationConfiguration.shared.sharingURL(for: show)
         }
         else {
-            return ApplicationConfiguration.shared.playURL(for: ApplicationConfiguration.shared.vendor)
+            return ApplicationConfiguration.shared.playURL(for: self.channel?.vendor ?? ApplicationConfiguration.shared.vendor)
         }
     }
     

--- a/Application/Sources/ProgramGuide/ProgramViewModel.swift
+++ b/Application/Sources/ProgramGuide/ProgramViewModel.swift
@@ -360,11 +360,11 @@ final class ProgramViewModel: ObservableObject {
         if let media = self.media {
             return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
         }
-        else if let media = self.livestreamMedia, program?.timeAvailability(at: Date()) == .notYetAvailable {
-            return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
-        }
         else if let show {
             return ApplicationConfiguration.shared.sharingURL(for: show)
+        }
+        else if let media = self.livestreamMedia {
+            return ApplicationConfiguration.shared.sharingURL(for: media, at: .zero)
         }
         else {
             return ApplicationConfiguration.shared.playURL(for: self.channel?.vendor ?? ApplicationConfiguration.shared.vendor)


### PR DESCRIPTION
### Motivation and Context

Following the multi BU channels in TV guide #389 , the default sharing url using not the best vendor shared url.
Also, on a livestream event, the default Play home url was not interesting. Try to share the livestream url wherever the program is available.

### Description

- Share the default Play url, regarding the channel vendor, not the application vendor. 
- ~Share the livestream url wherever the program is available.~

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
