### PR TITLE
Add make pull-translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/xcrun make -f
 
 CONFIGURATION_REPOSITORY_URL=https://github.com/SRGSSR/playsrg-apple-configuration.git
-CONFIGURATION_COMMIT_SHA1=d2e0ec3f4b0d0c126e5fc2da5bc428a063fd8c84
+CONFIGURATION_COMMIT_SHA1=ca02311d62e5896b485d02e4c1ee8fb8392a40a6
 CONFIGURATION_FOLDER=Configuration
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/xcrun make -f
 
 CONFIGURATION_REPOSITORY_URL=https://github.com/SRGSSR/playsrg-apple-configuration.git
-CONFIGURATION_COMMIT_SHA1=994c5847cdf722a76ccfb4f241982b75798072d4
+CONFIGURATION_COMMIT_SHA1=cd072b8c387a39ba89f9c5125bf766bc5a2d54be
 CONFIGURATION_FOLDER=Configuration
 
 .PHONY: all
@@ -41,6 +41,12 @@ fix-quality:
 	@Scripts/fix-quality.sh
 	@echo "... done.\n"
 
+.PHONY: pull-translations
+pull-translations:
+	@echo "Pulling translations..."
+	@Scripts/pullCrowdin.sh
+	@echo "... done.\n"
+
 .PHONY: git-hook-install
 git-hook-install:
 	@echo "Installing git hooks..."
@@ -71,6 +77,8 @@ help:
 	@echo ""
 	@echo "   check-quality       Run quality checks"
 	@echo "   fix-quality         Fix quality automatically (if possible)"
+	@echo ""
+	@echo "   pull-translations   Pull new translations from Crowdin"
 	@echo ""
 	@echo "   git-hook-install    Use hooks located in ./hooks"
 	@echo "   git-hook-uninstall  Use default hooks located in .git/hooks"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/xcrun make -f
 
 CONFIGURATION_REPOSITORY_URL=https://github.com/SRGSSR/playsrg-apple-configuration.git
-CONFIGURATION_COMMIT_SHA1=cd072b8c387a39ba89f9c5125bf766bc5a2d54be
+CONFIGURATION_COMMIT_SHA1=d2e0ec3f4b0d0c126e5fc2da5bc428a063fd8c84
 CONFIGURATION_FOLDER=Configuration
 
 .PHONY: all

--- a/Scripts/pullCrowdin.sh
+++ b/Scripts/pullCrowdin.sh
@@ -15,8 +15,8 @@ if [ -f "$ENV_FILE" ]; then
 	. "$ENV_FILE"
 fi
 
-if [ -z "$CROWDIN_API_KEY" ]; then
-	echo "CROWDIN_API_KEY environment variable is not set. Skipping Crowdin pulling."
+if [ -z "$CROWDIN_API_TOKEN" ]; then
+	echo "CROWDIN_API_TOKEN environment variable is not set. Skipping Crowdin pulling."
 	exit 0
 fi
 
@@ -28,11 +28,11 @@ CROWDIN_CONFIG_FILE="$script_dir/../crowdin.yml"
 
 # crowdin CLI needs sources in the current directory to get translations.
 echo "Downloading sources from Crowdin..."
-crowdin pull sources -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_KEY" --no-progress
+crowdin pull sources -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_TOKEN" --no-progress
 
 # crowdin CLI builds ZIP archive with the latest translations automatically.
 echo "Downloading the latest translations..."
-crowdin pull -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_KEY" --no-progress
+crowdin pull -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_TOKEN" --no-progress
 
 for i in "$@"
 do

--- a/Scripts/pullCrowdin.sh
+++ b/Scripts/pullCrowdin.sh
@@ -1,0 +1,188 @@
+#! /bin/sh
+
+if ! command -v crowdin > /dev/null; then
+    echo "crowdin CLI is not available. Please install it. https://crowdin.github.io/crowdin-cli/installation"
+    exit 0
+fi
+
+# Get the directory of the script
+script_dir="$(dirname "$(readlink -f "$0")")"
+
+# Load the repository .env file
+ENV_FILE="$script_dir/../.env"
+if [ -f "$ENV_FILE" ]; then
+# shellcheck source=/dev/null
+	. "$ENV_FILE"
+fi
+
+if [ -z "$CROWDIN_API_KEY" ]; then
+	echo "CROWDIN_API_KEY environment variable is not set. Skipping Crowdin pulling."
+	exit 0
+fi
+
+rm -rf /tmp/playsrg-crowdin
+mkdir /tmp/playsrg-crowdin
+
+# Use the repository configuration file
+CROWDIN_CONFIG_FILE="$script_dir/../crowdin.yml"
+
+# crowdin CLI needs sources in the current directory to get translations.
+echo "Downloading sources from Crowdin..."
+crowdin pull sources -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_KEY" --no-progress
+
+# crowdin CLI builds ZIP archive with the latest translations automatically.
+echo "Downloading the latest translations..."
+crowdin pull -c "$CROWDIN_CONFIG_FILE" --token "$CROWDIN_API_KEY" --no-progress
+
+for i in "$@"
+do
+	if [ "$i" = "--skip-copies" ]; then
+        exit 0
+	fi
+done
+
+if [ -z "$CROWDIN_PLAY_PATH" ]; then
+	CROWDIN_PLAY_PATH="."
+	echo "Use default CROWDIN_PLAY_PATH variable: \".\""
+fi
+
+if [ -z "$CROWDIN_MEDIA_PLAYER_PATH" ]; then
+	CROWDIN_MEDIA_PLAYER_PATH="../srgmediaplayer-apple"
+	echo "Use default CROWDIN_MEDIA_PLAYER_PATH variable: \"$CROWDIN_MEDIA_PLAYER_PATH\""
+fi
+
+if [ -z "$CROWDIN_NETWORK_PATH" ]; then
+	CROWDIN_NETWORK_PATH="../srgnetwork-apple"
+	echo "Use default CROWDIN_NETWORK_PATH variable: \"$CROWDIN_NETWORK_PATH\""
+fi
+
+if [ -z "$CROWDIN_IDENTITY_PATH" ]; then
+	CROWDIN_IDENTITY_PATH="../srgidentity-apple"
+	echo "Use default CROWDIN_IDENTITY_PATH variable: \"$CROWDIN_IDENTITY_PATH\""
+fi
+
+if [ -z "$CROWDIN_CONTENT_PROTECTION_PATH" ]; then
+	CROWDIN_CONTENT_PROTECTION_PATH="../srgcontentprotection-apple"
+	echo "Use default CROWDIN_CONTENT_PROTECTION_PATH variable: \"$CROWDIN_CONTENT_PROTECTION_PATH\""
+fi
+
+if [ -z "$CROWDIN_DATA_PROVIDER_PATH" ]; then
+	CROWDIN_DATA_PROVIDER_PATH="../srgdataprovider-apple"
+	echo "Use default CROWDIN_DATA_PROVIDER_PATH variable: \"$CROWDIN_DATA_PROVIDER_PATH\""
+fi
+
+if [ -z "$CROWDIN_LETTERBOX_PATH" ]; then
+	CROWDIN_LETTERBOX_PATH="../srgletterbox-apple"
+	echo "Use default CROWDIN_LETTERBOX_PATH variable: \"$CROWDIN_LETTERBOX_PATH\""
+fi
+
+if [ -z "$CROWDIN_USER_DATA_PATH" ]; then
+	CROWDIN_USER_DATA_PATH="../srguserdata-apple"
+	echo "Use default CROWDIN_USER_DATA_PATH variable: \"$CROWDIN_USER_DATA_PATH\""
+fi
+
+# Play applications
+echo "Update Play SRG translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/Play App/Localizable.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SRF/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/Play App/Localizable.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTS/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/Play App/Localizable.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RSI/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/Play App/Localizable.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTR/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/Play App/Localizable.strings"    "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SWI/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/Play App/Accessibility.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SRF/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/Play App/Accessibility.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTS/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/Play App/Accessibility.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RSI/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/Play App/Accessibility.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTR/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/Play App/Accessibility.strings"    "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SWI/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/Play App/Onboarding.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SRF/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/Play App/Onboarding.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTS/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/Play App/Onboarding.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RSI/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/Play App/Onboarding.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTR/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/Play App/Onboarding.strings"    "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SWI/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/Play App/InfoPlist.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SRF/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/Play App/InfoPlist.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTS/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/Play App/InfoPlist.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RSI/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/Play App/InfoPlist.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play RTR/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/Play App/InfoPlist.strings"    "$CROWDIN_PLAY_PATH/Application/Resources/Apps/Play SWI/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/Play App/Settings.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Settings.bundle/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/Play App/Settings.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Settings.bundle/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/Play App/Settings.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Settings.bundle/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/Play App/Settings.strings" "$CROWDIN_PLAY_PATH/Application/Resources/Settings.bundle/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/Play App/Settings.strings"    "$CROWDIN_PLAY_PATH/Application/Resources/Settings.bundle/en.lproj/"
+
+# SRG Media Player library
+Echo "Update SRG Media Player translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGMediaPlayer Library/Localizable.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGMediaPlayer Library/Localizable.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGMediaPlayer Library/Localizable.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGMediaPlayer Library/Localizable.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGMediaPlayer Library/Localizable.strings"    "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGMediaPlayer Library/Accessibility.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGMediaPlayer Library/Accessibility.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGMediaPlayer Library/Accessibility.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGMediaPlayer Library/Accessibility.strings" "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGMediaPlayer Library/Accessibility.strings"    "$CROWDIN_MEDIA_PLAYER_PATH/Sources/SRGMediaPlayer/Resources/en.lproj/"
+
+# SRG Network library
+echo "Update SRG Network translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGNetwork Library/Localizable.strings" "$CROWDIN_NETWORK_PATH/Sources/SRGNetwork/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGNetwork Library/Localizable.strings" "$CROWDIN_NETWORK_PATH/Sources/SRGNetwork/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGNetwork Library/Localizable.strings" "$CROWDIN_NETWORK_PATH/Sources/SRGNetwork/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGNetwork Library/Localizable.strings" "$CROWDIN_NETWORK_PATH/Sources/SRGNetwork/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGNetwork Library/Localizable.strings"    "$CROWDIN_NETWORK_PATH/Sources/SRGNetwork/Resources/en.lproj/"
+
+# SRG Identity library
+echo "Update SRG Identity translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGIdentity Library/Localizable.strings" "$CROWDIN_IDENTITY_PATH/Sources/SRGIdentity/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGIdentity Library/Localizable.strings" "$CROWDIN_IDENTITY_PATH/Sources/SRGIdentity/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGIdentity Library/Localizable.strings" "$CROWDIN_IDENTITY_PATH/Sources/SRGIdentity/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGIdentity Library/Localizable.strings" "$CROWDIN_IDENTITY_PATH/Sources/SRGIdentity/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGIdentity Library/Localizable.strings"    "$CROWDIN_IDENTITY_PATH/Sources/SRGIdentity/Resources/en.lproj/"
+
+# SRG Content Protection library
+echo "Update SRG Content Protection translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGContentProtection Library/Localizable.strings" "$CROWDIN_CONTENT_PROTECTION_PATH/Sources/SRGContentProtection/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGContentProtection Library/Localizable.strings" "$CROWDIN_CONTENT_PROTECTION_PATH/Sources/SRGContentProtection/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGContentProtection Library/Localizable.strings" "$CROWDIN_CONTENT_PROTECTION_PATH/Sources/SRGContentProtection/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGContentProtection Library/Localizable.strings" "$CROWDIN_CONTENT_PROTECTION_PATH/Sources/SRGContentProtection/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGContentProtection Library/Localizable.strings"    "$CROWDIN_CONTENT_PROTECTION_PATH/Sources/SRGContentProtection/Resources/en.lproj/"
+
+# SRG Data Provider library
+echo "Update SRG Data Provider translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGDataprovider Library/Localizable.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGDataprovider Library/Localizable.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGDataprovider Library/Localizable.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGDataprovider Library/Localizable.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGDataprovider Library/Localizable.strings"    "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGDataprovider Library/Accessibility.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGDataprovider Library/Accessibility.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGDataprovider Library/Accessibility.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGDataprovider Library/Accessibility.strings" "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGDataprovider Library/Accessibility.strings"    "$CROWDIN_DATA_PROVIDER_PATH/Sources/SRGDataProviderModel/Resources/en.lproj/"
+
+# SRG Letterbox library
+Echo "Update SRG Letterbox translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGLetterbox Library/Localizable.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGLetterbox Library/Localizable.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGLetterbox Library/Localizable.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGLetterbox Library/Localizable.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGLetterbox Library/Localizable.strings"    "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/en.lproj/"
+
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGLetterbox Library/Accessibility.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGLetterbox Library/Accessibility.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGLetterbox Library/Accessibility.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGLetterbox Library/Accessibility.strings" "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGLetterbox Library/Accessibility.strings"    "$CROWDIN_LETTERBOX_PATH/Sources/SRGLetterbox/Resources/en.lproj/"
+
+# SRG User Data library
+echo "Update SRG User Data translations files."
+cp -f "/tmp/playsrg-crowdin/de-CH/Apple/SRGUserData Library/Localizable.strings" "$CROWDIN_USER_DATA_PATH/Sources/SRGUserData/Resources/de.lproj/"
+cp -f "/tmp/playsrg-crowdin/fr-CH/Apple/SRGUserData Library/Localizable.strings" "$CROWDIN_USER_DATA_PATH/Sources/SRGUserData/Resources/fr.lproj/"
+cp -f "/tmp/playsrg-crowdin/it-CH/Apple/SRGUserData Library/Localizable.strings" "$CROWDIN_USER_DATA_PATH/Sources/SRGUserData/Resources/it.lproj/"
+cp -f "/tmp/playsrg-crowdin/rm-CH/Apple/SRGUserData Library/Localizable.strings" "$CROWDIN_USER_DATA_PATH/Sources/SRGUserData/Resources/rm.lproj/"
+cp -f "/tmp/playsrg-crowdin/en/Apple/SRGUserData Library/Localizable.strings"    "$CROWDIN_USER_DATA_PATH/Sources/SRGUserData/Resources/en.lproj/"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,47 @@
+#
+# Crowdin configuration (PlaySRG project)
+#
+"project_id": "126201"
+# "api_token": "" # use --token option instead so that it is work on all computers.
+"base_path": "/tmp/playsrg-crowdin"
+"base_url": "https://api.crowdin.com"
+
+"preserve_hierarchy": true
+files: [
+  {
+    "source": "/Apple/Play App/*.strings",
+    "translation": "/%locale%/Apple/Play App/%original_file_name%"
+  },
+  {
+    "source": "/Apple/Play App/*.csv",
+    "translation": "/%locale%/Apple/Play App/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGContentProtection Library/*.strings",
+    "translation": "/%locale%/Apple/SRGContentProtection Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGDataprovider Library/*.strings",
+    "translation": "/%locale%/Apple/SRGDataprovider Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGIdentity Library/*.strings",
+    "translation": "/%locale%/Apple/SRGIdentity Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGLetterbox Library/*.strings",
+    "translation": "/%locale%/Apple/SRGLetterbox Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGMediaPlayer Library/*.strings",
+    "translation": "/%locale%/Apple/SRGMediaPlayer Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGNetwork Library/*.strings",
+    "translation": "/%locale%/Apple/SRGNetwork Library/%original_file_name%"
+  },
+  {
+    "source": "/Apple/SRGUserData Library/*.strings",
+    "translation": "/%locale%/Apple/SRGUserData Library/%original_file_name%"
+  }
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,18 @@ The project can be built without private settings but some features might not be
 
 Simply open the project with Xcode and wait until all dependencies have been retrieved. Then build and run the project.
 
+## Translations
+
+Pushing new translations needs to upload source files on [crowdin.com](https://crowdin.com/project/play-srg/sources/files).
+
+Pulling new translations:
+
+```
+make pull-translations
+```
+
+The script needs [Crowdin CLI](https://crowdin.github.io/crowdin-cli/).
+
 ## Releasing binaries
 
 The proprietary project uses [fastlane](https://fastlane.tools/) to [release binaries](RELEASE_CHECKLIST.md), either for internal purposes or for the AppStore.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -4,7 +4,7 @@
 |:--:|:--:|:--:|:--:|:--:|:--:|
 | Edit SPM / Podfile dependencies to point at tagged versions ||||||
 | Verify that Package.resolved / Podfile.lock only contain tagged versions ||||||
-| Update application translations (with pullCrowdin .sh) ||||||
+| Update application translations (with make pull-translations) ||||||
 | Perform global diff with last release ||||||
 | Submit what's new for translation ||||||
 | Start git-flow release branch for new version ||||||

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1832,7 +1832,7 @@ def skip_pull_translations
 end
 
 def pull_translations
-  Dir.chdir('..') { sh 'Configuration/Scripts/pullCrowdin.sh --skip-copies' }
+  Dir.chdir('..') { sh 'Scripts/pullCrowdin.sh --skip-copies' }
   ENV['CROWDIN_TRANSLATIONS_PULLLED'] = '1'
 end
 


### PR DESCRIPTION
### Motivation and Context

Pulling translations script is in the private repository since a long time.
Moving it to the public repository and hide the api token only in this private repository.

Help developers with a `Makefile` command.

This PR follows #395 and #397.

### Description

- Add `Scripts/pullCrowdin.sh` which pull PlaySRG and SRGLibraries translations from crowdin.com
- Update fastlane script. Translations used for publication on AppStore and What's new notes on the GitHub page.
- Simplify with `make pull-translations` command line.
- Update configuration to have crowdin api token. https://github.com/SRGSSR/playsrg-apple-configuration/pull/5

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
