### PR TITLE
Fix documentation

### DIFF
--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -139,7 +139,7 @@ Feeds
 * `tvGuideUnavailable` (optional, boolean): If set to `true`, TV guide access is removed and replaced with the legacy _by date_ access.
 * `tvGuideOtherBouquets` (optional, string, multiple): TV guide other bouquets to display below the main vendor bouquet. Available values:
 	* `thirdparty`: Third party bouquet delivered for the vendor.
-	* `	rsi`: RSI vendor bouquet.
+	* `rsi`: RSI vendor bouquet.
 	* `rts`: RT vendor bouquet.
 	* `srf`: SR vendor bouquet.
 


### PR DESCRIPTION
### Motivation and Context

#389 added a new remote configuration property. One of the value described in the documentation file has a not expected space character.

### Description

- Remove the not expected character.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
