### PR TITLE
Remove unreachable page view analytics event

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -312,8 +312,6 @@ private extension Content {
                     return AnalyticsPageTitle.watchLater.rawValue
                 case .topicSelector:
                     return AnalyticsPageTitle.topics.rawValue
-                case .availableEpisodes:
-                    return AnalyticsPageTitle.availableEpisodes.rawValue
                 default:
                     return nil
                 }
@@ -336,12 +334,7 @@ private extension Content {
             case .medias, .showAndMedias, .shows:
                 return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, AnalyticsPageLevel.section.rawValue]
             case .predefined:
-                switch presentation.type {
-                case .availableEpisodes:
-                    return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue, show?.title ?? ""]
-                default:
-                    return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
-                }
+                return [AnalyticsPageLevel.play.rawValue, AnalyticsPageLevel.video.rawValue]
             case .none:
                 return nil
             }
@@ -690,8 +683,6 @@ private extension Content {
         
         var analyticsTitle: String? {
             switch configuredSection {
-            case .availableEpisodes:
-                return AnalyticsPageTitle.availableEpisodes.rawValue
             case .history:
                 return AnalyticsPageTitle.history.rawValue
             case .radioAllShows, .tvAllShows:
@@ -738,9 +729,6 @@ private extension Content {
         
         var analyticsLevels: [String]? {
             switch configuredSection {
-            case let .availableEpisodes(show):
-                let level1 = show.transmission == .radio ? AnalyticsPageLevel.audio.rawValue : AnalyticsPageLevel.video.rawValue
-                return [AnalyticsPageLevel.play.rawValue, level1, show.title]
             case let .radioAllShows(channelUid),
                 let .radioFavoriteShows(channelUid: channelUid),
                 let .radioLatest(channelUid: channelUid),

--- a/Application/Sources/Helpers/AnalyticsConstants.h
+++ b/Application/Sources/Helpers/AnalyticsConstants.h
@@ -37,7 +37,6 @@ OBJC_EXPORT AnalyticsPageLevel const AnalyticsPageLevelVideo;
  */
 typedef NSString * AnalyticsPageTitle NS_STRING_ENUM;
 
-OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleAvailableEpisodes;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleDevices;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleDownloads;
 OBJC_EXPORT AnalyticsPageTitle const AnalyticsPageTitleFavorites;

--- a/Application/Sources/Helpers/AnalyticsConstants.m
+++ b/Application/Sources/Helpers/AnalyticsConstants.m
@@ -27,7 +27,6 @@ AnalyticsPageLevel const AnalyticsPageLevelTopic = @"topic";
 AnalyticsPageLevel const AnalyticsPageLevelUser = @"user";
 AnalyticsPageLevel const AnalyticsPageLevelVideo = @"video";
 
-AnalyticsPageTitle const AnalyticsPageTitleAvailableEpisodes = @"available episodes";
 AnalyticsPageTitle const AnalyticsPageTitleDevices = @"devices";
 AnalyticsPageTitle const AnalyticsPageTitleDownloads = @"downloads";
 AnalyticsPageTitle const AnalyticsPageTitleFavorites = @"favorites";


### PR DESCRIPTION
### Motivation and Context

Introduced by #390 proposition, the "available episodes" sections are predefined or configured. It means, no titles are provided by PAC and the codebase has no titles for those sections.
The page view added in code (titles, levels, type) was only with title added in the code and the advanced feature "Section wide support".

Proposition is to remove it.

### Description

- Remove code for `availableEpisodes` section detail page view event.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
