### PR TITLE
Request radio livestreams with channel vendor

### DIFF
--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -1324,7 +1324,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     
     if (! self.livestreamMediasRequest) {
         ApplicationConfiguration *applicationConfiguration = ApplicationConfiguration.sharedApplicationConfiguration;
-        SRGRequest *request = [SRGDataProvider.currentDataProvider radioLivestreamsForVendor:applicationConfiguration.vendor channelUid:media.channel.uid withCompletionBlock:^(NSArray<SRGMedia *> * _Nullable medias, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
+        SRGRequest *request = [SRGDataProvider.currentDataProvider radioLivestreamsForVendor:media.channel.vendor channelUid:media.channel.uid withCompletionBlock:^(NSArray<SRGMedia *> * _Nullable medias, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
             self.livestreamMedias = medias;
             self.livestreamView.hidden = [self isLivestreamButtonHidden];
         }];


### PR DESCRIPTION
### Motivation and Context

The updated TV program guide displays now all SRG TV channels, thanks to #389 proposition. For consistency in the code, check that media detail view support other channel vendor.

### Description

- Request radio livestreams is updated to use channel vendor instead of application vendor.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
