### PR TITLE
Add make appstore-status and make appstore-testflight-status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,6 @@ clean:
 	@xcodebuild clean
 	@echo "... done.\n"
 
-.PHONY: ruby-setup
-ruby-setup:
-	@echo "Installing needed ruby version if missing..."
-	@Scripts/rbenv-install.sh "./"
-	@echo "Running bundle install..."
-	@bundle install > /dev/null
-	@echo "... done.\n"
-
 .PHONY: check-quality
 check-quality:
 	@echo "Checking quality..."
@@ -65,24 +57,46 @@ spm-outdated:
 	@Scripts/spm-outdated.sh
 	@echo "... done.\n"
 
+.PHONY: ruby-setup
+ruby-setup:
+	@echo "Installing needed ruby version if missing..."
+	@Scripts/rbenv-install.sh "./"
+	@echo "Running bundle install..."
+	@bundle install > /dev/null
+	@echo "... done.\n"
+
+.PHONY: appstore-status
+appstore-status: ruby-setup
+	@echo "Running fastlane ios appStoreAppStatus..."
+	@bundle exec fastlane ios appStoreAppStatus
+	@echo "... done.\n"
+
+.PHONY: appstore-testflight-status
+appstore-testflight-status: ruby-setup
+	@echo "Running fastlane ios appStoreAppStatus..."
+	@bundle exec fastlane ios appStoreTestFlightAppStatus
+	@echo "... done.\n"
+
 .PHONY: help
 help:
 	@echo "The following targets are available:"
 	@echo ""
-	@echo "   all                 Run setup"
-	@echo "   setup               Setup project"
-	@echo "   clean               Clean the project and its dependencies"
+	@echo "   all                        Run setup"
+	@echo "   setup                      Setup project"
+	@echo "   clean                      Clean the project and its dependencies"
 	@echo ""
-	@echo "   ruby-setup          Install needed ruby version with rbenv if missing and run bundle install"
+	@echo "   check-quality              Run quality checks"
+	@echo "   fix-quality                Fix quality automatically (if possible)"
 	@echo ""
-	@echo "   check-quality       Run quality checks"
-	@echo "   fix-quality         Fix quality automatically (if possible)"
+	@echo "   pull-translations          Pull new translations from Crowdin"
 	@echo ""
-	@echo "   pull-translations   Pull new translations from Crowdin"
+	@echo "   git-hook-install           Use hooks located in ./hooks"
+	@echo "   git-hook-uninstall         Use default hooks located in .git/hooks"
 	@echo ""
-	@echo "   git-hook-install    Use hooks located in ./hooks"
-	@echo "   git-hook-uninstall  Use default hooks located in .git/hooks"
+	@echo "   spm-outdated               Run outdated Swift package dependencies check"
 	@echo ""
-	@echo "   spm-outdated        Run outdated Swift package dependencies check"
+	@echo "   ruby-setup                 Install needed ruby version with rbenv if missing and run bundle install"
+	@echo "   appstore-status            Get AppStore review status"
+	@echo "   appstore-testflight-status Get public TestFlight review status"
 	@echo ""
-	@echo "   help                Display this message"
+	@echo "   help                       Display this message"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -69,8 +69,16 @@
 	- Play RTS tvOS: `fastlane ios tvOSrtsScreenshots`
 	- Play SRF tvOS: `fastlane ios tvOSsrfScreenshots` (No upload to ASC, due to some marketing images)
 	- Play SWI tvOS: `fastlane ios tvOSswiScreenshots`
-- Application status (Ready for sale, In review, etc…)
-	- All published apps: `fastlane ios appStoreAppStatus`
+
+# AppStore and TestFlight review status
+
+- Get AppStore review status (Ready for sale, In review, etc…)
+	- `fastlane ios appStoreAppStatus`
+	- or `make appstore-status`
+- Get public TestFlight review status (In beta testing, In review, etc…)
+	- `fastlane ios appStoreTestFlightAppStatus`
+	- or `make appstore-testflight-status`
+
 
 # Release notes on Github pages
 


### PR DESCRIPTION
### Motivation and Context

Following #404 proposition, adding in `make` command the AppStore and TestFlight status could simplify developer checks during an AppStore release.

### Description

- Add `make appstore-status`.
- Add `make appstore-testflight-status`.
- Update Release documentation.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
