### PR TITLE
Enable search subtitles available option for Play RTS iOS

### DIFF
--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -29,7 +29,6 @@
   "continuousPlaybackBackgroundTransitionDuration": 0,
   "endToleranceRatio": 0.02,
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
-  "searchSettingSubtitledHidden": true,
   "showLeadPreferred": true,
   "tvGuideOtherBouquets": "srf,rsi",
   "userConsentDefaultLanguage": "fr"


### PR DESCRIPTION
### Motivation and Context

Play web has in in search options, "subtitles available" for Play RTS:
https://www.rts.ch/play/recherche?query=&showAll=true&properties=subtitlesAvailable

Missing in Play RTS iOS.

### Description

- Update the remote and local configuration for Play RTS.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
