### PR TITLE
Use date style on swimlane media cells for show page

### DIFF
--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -792,7 +792,7 @@ private extension PageViewController {
             case .mediaList:
                 PlaySRG.MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
             default:
-                PlaySRG.MediaCell(media: media, style: .show, layout: .vertical)
+                PlaySRG.MediaCell(media: media, style: section.properties.displayedShow != nil ? .date : .show, layout: .vertical)
             }
         }
     }


### PR DESCRIPTION
### Motivation and Context

On a show page, media cells don't need to display the show title again, as it's displayed in the show header and navigation bar.

#390 introduced content swimlane sections, like on homepages and topic pages but does not respect the show page rule.

### Description

- Don't display show title in subtitle label on media cells in show pages.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
