### PR TITLE
No placeholders if section errors

### DIFF
--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -29,7 +29,7 @@ final class PageViewModel: Identifiable, ObservableObject {
                                                      pageSize: Self.pageSize(for: section, in: page.sections),
                                                      paginatedBy: self?.trigger.signal(activatedBy: TriggerId.loadMore(section: section))
                             )
-                            .replaceError(with: Self.placeholderRow(for: section, state: self?.state))
+                            .replaceError(with: Self.fallbackRow(for: section, state: self?.state))
                             .prepend(Self.placeholderRow(for: section, state: self?.state))
                         }
                     })
@@ -124,6 +124,15 @@ final class PageViewModel: Identifiable, ObservableObject {
         }
         else {
             return Row(section: section, items: Self.placeholderRowItems(for: section))
+        }
+    }
+    
+    private static func fallbackRow(for section: Section, state: State?) -> Row {
+        if let row = state?.rows.first(where: { $0.section == section }) {
+            return row
+        }
+        else {
+            return Row(section: section, items: [])
         }
     }
     


### PR DESCRIPTION
### Motivation and Context

On content pages, if a section request returns an error, the placeholders items stay.
It's create a stream UI and not understable.

Like Play web and recent Play Android fix, remove placeholders items if request failed.

Current example: La chronique scientifique - https://www.rts.ch/play/radio/quicklink/9929109

### Description

- Error on a section request returns the cached responses, or empty row, not more placeholders.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
