### PR TITLE
Add desktop type for feedback form

### DIFF
--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -50,7 +50,15 @@ extension ApplicationConfiguration {
     }
     
     private static var type: String {
-        return UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "phone"
+        if ProcessInfo.processInfo.isMacCatalystApp || ProcessInfo.processInfo.isiOSAppOnMac {
+            return "desktop"
+        }
+        else if UIDevice.current.userInterfaceIdiom == .pad {
+            return "tablet"
+        }
+        else {
+            return "phone"
+        }
     }
     
     private static var identifier: String? {


### PR DESCRIPTION
### Motivation and Context

The application can run on a Mac with an Apple chipset.
The platform could be `desktop` instead of `tablet` for the feedback form.

Inspired by https://github.com/SRGSSR/srganalytics-apple/pull/83 and https://github.com/SRGSSR/pillarbox-apple/pull/364.

### Description

- Update feedback type implementation with `ProcessInfo` to set `desktop` value.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
