### PR TITLE
Don't display show title on show page everywhere

### DIFF
--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -797,9 +797,7 @@ private extension PageViewController {
         }
         
         private func haveSameShow(media: SRGMedia?, in section: PageViewModel.Section) -> Bool {
-            guard let displayedShow = section.properties.displayedShow,
-                  let mediaShow = media?.show
-            else { return false }
+            guard let displayedShow = section.properties.displayedShow, let mediaShow = media?.show else { return false }
             
             return displayedShow.isEqual(mediaShow)
         }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -782,21 +782,21 @@ private extension PageViewController {
             case .heroStage:
                 HeroMediaCell(media: media, label: section.properties.label)
             case .headline:
-                FeaturedContentCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .headline)
+                FeaturedContentCell(media: media, style: haveSameShow(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .headline)
             case .element, .elementSwimlane:
-                FeaturedContentCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .element)
+                FeaturedContentCell(media: media, style: haveSameShow(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .element)
             case .liveMediaSwimlane, .liveMediaGrid:
                 LiveMediaCell(media: media)
             case .mediaGrid:
-                PlaySRG.MediaCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show)
+                PlaySRG.MediaCell(media: media, style: haveSameShow(media: media, in: section) ? .date : .show)
             case .mediaList:
                 PlaySRG.MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
             default:
-                PlaySRG.MediaCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, layout: .vertical)
+                PlaySRG.MediaCell(media: media, style: haveSameShow(media: media, in: section) ? .date : .show, layout: .vertical)
             }
         }
         
-        private func areRedundant(media: SRGMedia?, in section: PageViewModel.Section) -> Bool {
+        private func haveSameShow(media: SRGMedia?, in section: PageViewModel.Section) -> Bool {
             guard let displayedShow = section.properties.displayedShow,
                   let mediaShow = media?.show
             else { return false }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -782,18 +782,26 @@ private extension PageViewController {
             case .heroStage:
                 HeroMediaCell(media: media, label: section.properties.label)
             case .headline:
-                FeaturedContentCell(media: media, label: section.properties.label, layout: .headline)
+                FeaturedContentCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .headline)
             case .element, .elementSwimlane:
-                FeaturedContentCell(media: media, label: section.properties.label, layout: .element)
+                FeaturedContentCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, label: section.properties.label, layout: .element)
             case .liveMediaSwimlane, .liveMediaGrid:
                 LiveMediaCell(media: media)
             case .mediaGrid:
-                PlaySRG.MediaCell(media: media, style: section.properties.displayedShow != nil ? .date : .show)
+                PlaySRG.MediaCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show)
             case .mediaList:
                 PlaySRG.MediaCell(media: media, style: .dateAndSummary, layout: .horizontal)
             default:
-                PlaySRG.MediaCell(media: media, style: section.properties.displayedShow != nil ? .date : .show, layout: .vertical)
+                PlaySRG.MediaCell(media: media, style: areRedundant(media: media, in: section) ? .date : .show, layout: .vertical)
             }
+        }
+        
+        private func areRedundant(media: SRGMedia?, in section: PageViewModel.Section) -> Bool {
+            guard let displayedShow = section.properties.displayedShow,
+                  let mediaShow = media?.show
+            else { return false }
+            
+            return displayedShow.isEqual(mediaShow)
         }
     }
     

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -29,7 +29,7 @@ protocol FeaturedContent {
 
 struct FeaturedMediaContent: FeaturedContent {
     let media: SRGMedia?
-    let style: MediaDescription.Style
+    let style: FeaturedContentCell<Self>.Style
     let label: String?
     
     var isPlaceholder: Bool {
@@ -38,12 +38,12 @@ struct FeaturedMediaContent: FeaturedContent {
     
     var introduction: String? {
         guard let media else { return nil }
-        return MediaDescription.subtitle(for: media, style: style)
+        return MediaDescription.subtitle(for: media, style: mediaDescriptionStyle)
     }
     
     var title: String? {
         guard let media else { return nil }
-        return MediaDescription.title(for: media, style: style)
+        return MediaDescription.title(for: media, style: mediaDescriptionStyle)
     }
     
     var summary: String? {
@@ -58,6 +58,15 @@ struct FeaturedMediaContent: FeaturedContent {
     
     var accessibilityHint: String? {
         return PlaySRGAccessibilityLocalizedString("Plays the content.", comment: "Featured media hint")
+    }
+    
+    private var mediaDescriptionStyle: MediaDescription.Style {
+        switch style {
+        case .show:
+            return .show
+        case .date:
+            return .date
+        }
     }
     
     func visualView() -> some View {

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -29,6 +29,7 @@ protocol FeaturedContent {
 
 struct FeaturedMediaContent: FeaturedContent {
     let media: SRGMedia?
+    let style: MediaDescription.Style
     let label: String?
     
     var isPlaceholder: Bool {
@@ -37,12 +38,12 @@ struct FeaturedMediaContent: FeaturedContent {
     
     var introduction: String? {
         guard let media else { return nil }
-        return MediaDescription.subtitle(for: media, style: .show)
+        return MediaDescription.subtitle(for: media, style: style)
     }
     
     var title: String? {
         guard let media else { return nil }
-        return MediaDescription.title(for: media, style: .show)
+        return MediaDescription.title(for: media, style: style)
     }
     
     var summary: String? {

--- a/Application/Sources/UI/Views/FeaturedContentCell.swift
+++ b/Application/Sources/UI/Views/FeaturedContentCell.swift
@@ -17,6 +17,7 @@ enum FeaturedContentLayout {
 struct FeaturedContentCell<Content: FeaturedContent>: View {
     let content: Content
     let layout: FeaturedContentLayout
+    let style: MediaDescription.Style
     
     @Environment(\.isSelected) private var isSelected
     @Environment(\.uiHorizontalSizeClass) private var horizontalSizeClass
@@ -86,14 +87,14 @@ struct FeaturedContentCell<Content: FeaturedContent>: View {
 // MARK: Initializers
 
 extension FeaturedContentCell where Content == FeaturedMediaContent {
-    init(media: SRGMedia?, label: String? = nil, layout: FeaturedContentLayout) {
-        self.init(content: FeaturedMediaContent(media: media, label: label), layout: layout)
+    init(media: SRGMedia?, style: MediaDescription.Style, label: String? = nil, layout: FeaturedContentLayout) {
+        self.init(content: FeaturedMediaContent(media: media, style: style, label: label), layout: layout, style: style)
     }
 }
 
 extension FeaturedContentCell where Content == FeaturedShowContent {
     init(show: SRGShow?, label: String? = nil, layout: FeaturedContentLayout) {
-        self.init(content: FeaturedShowContent(show: show, label: label), layout: layout)
+        self.init(content: FeaturedShowContent(show: show, label: label), layout: layout, style: .show)
     }
 }
 
@@ -156,25 +157,25 @@ struct FeaturedContentCell_Previews: PreviewProvider {
     
     static var previews: some View {
 #if os(tvOS)
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .headline)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .headline)
             .previewLayout(for: .headline, layoutWidth: 1800, horizontalSizeClass: .regular)
         
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .element)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .element)
             .previewLayout(for: .headline, layoutWidth: 1800, horizontalSizeClass: .regular)
 #else
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .headline)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .headline)
             .previewLayout(for: .headline, layoutWidth: 1200, horizontalSizeClass: .regular)
             .environment(\.horizontalSizeClass, .regular)
         
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .headline)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .headline)
             .previewLayout(for: .headline, layoutWidth: 800, horizontalSizeClass: .compact)
             .environment(\.horizontalSizeClass, .compact)
         
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .element)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .element)
             .previewLayout(for: .element, layoutWidth: 1200, horizontalSizeClass: .regular)
             .environment(\.horizontalSizeClass, .regular)
         
-        FeaturedContentCell(media: Mock.media(kind), label: label, layout: .element)
+        FeaturedContentCell(media: Mock.media(kind), style: .show, label: label, layout: .element)
             .previewLayout(for: .element, layoutWidth: 800, horizontalSizeClass: .compact)
             .environment(\.horizontalSizeClass, .compact)
         #endif

--- a/Application/Sources/UI/Views/FeaturedContentCell.swift
+++ b/Application/Sources/UI/Views/FeaturedContentCell.swift
@@ -9,15 +9,22 @@ import SwiftUI
 
 // MARK: View
 
-enum FeaturedContentLayout {
-    case headline
-    case element
-}
-
 struct FeaturedContentCell<Content: FeaturedContent>: View {
+    public enum Layout {
+        case headline
+        case element
+    }
+    
+    enum Style {
+        /// Show information emphasis
+        case show
+        /// Date information emphasis
+        case date
+    }
+    
     let content: Content
-    let layout: FeaturedContentLayout
-    let style: MediaDescription.Style
+    let layout: Layout
+    let style: Style
     
     @Environment(\.isSelected) private var isSelected
     @Environment(\.uiHorizontalSizeClass) private var horizontalSizeClass
@@ -87,13 +94,13 @@ struct FeaturedContentCell<Content: FeaturedContent>: View {
 // MARK: Initializers
 
 extension FeaturedContentCell where Content == FeaturedMediaContent {
-    init(media: SRGMedia?, style: MediaDescription.Style, label: String? = nil, layout: FeaturedContentLayout) {
+    init(media: SRGMedia?, style: Style, label: String? = nil, layout: Layout) {
         self.init(content: FeaturedMediaContent(media: media, style: style, label: label), layout: layout, style: style)
     }
 }
 
 extension FeaturedContentCell where Content == FeaturedShowContent {
-    init(show: SRGShow?, label: String? = nil, layout: FeaturedContentLayout) {
+    init(show: SRGShow?, label: String? = nil, layout: Layout) {
         self.init(content: FeaturedShowContent(show: show, label: label), layout: layout, style: .show)
     }
 }
@@ -137,7 +144,7 @@ enum FeaturedContentCellSize {
 // MARK: Preview
 
 private extension View {
-    func previewLayout(for layout: FeaturedContentLayout, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> some View {
+    func previewLayout(for layout: FeaturedContentCell<FeaturedMediaContent>.Layout, layoutWidth: CGFloat, horizontalSizeClass: UIUserInterfaceSizeClass) -> some View {
         let size: CGSize = {
             if layout == .headline {
                 return FeaturedContentCellSize.headline(layoutWidth: layoutWidth, horizontalSizeClass: horizontalSizeClass).previewSize

--- a/Application/Sources/UI/Views/FeaturedDescriptionView.swift
+++ b/Application/Sources/UI/Views/FeaturedDescriptionView.swift
@@ -74,8 +74,8 @@ struct FeaturedDescriptionView<Content: FeaturedContent>: View {
 // MARK: Initializers
 
 extension FeaturedDescriptionView where Content == FeaturedMediaContent {
-    init(media: SRGMedia?, label: String? = nil, alignment: Alignment, detailed: Bool) {
-        self.init(content: FeaturedMediaContent(media: media, label: label), alignment: alignment, detailed: detailed)
+    init(media: SRGMedia?, style: MediaDescription.Style, label: String? = nil, alignment: Alignment, detailed: Bool) {
+        self.init(content: FeaturedMediaContent(media: media, style: style, label: label), alignment: alignment, detailed: detailed)
     }
 }
 
@@ -99,9 +99,9 @@ struct FeaturedDescriptionView_Previews: PreviewProvider {
         .previewLayout(.fixed(width: 800, height: 300))
         
         Group {
-            FeaturedDescriptionView(media: Mock.media(), label: label, alignment: .leading, detailed: true)
-            FeaturedDescriptionView(media: Mock.media(), label: label, alignment: .topLeading, detailed: true)
-            FeaturedDescriptionView(media: Mock.media(), label: label, alignment: .center, detailed: true)
+            FeaturedDescriptionView(media: Mock.media(), style: .show, label: label, alignment: .leading, detailed: true)
+            FeaturedDescriptionView(media: Mock.media(), style: .show, label: label, alignment: .topLeading, detailed: true)
+            FeaturedDescriptionView(media: Mock.media(), style: .show, label: label, alignment: .center, detailed: true)
         }
         .previewLayout(.fixed(width: 800, height: 300))
     }

--- a/Application/Sources/UI/Views/FeaturedDescriptionView.swift
+++ b/Application/Sources/UI/Views/FeaturedDescriptionView.swift
@@ -74,7 +74,7 @@ struct FeaturedDescriptionView<Content: FeaturedContent>: View {
 // MARK: Initializers
 
 extension FeaturedDescriptionView where Content == FeaturedMediaContent {
-    init(media: SRGMedia?, style: MediaDescription.Style, label: String? = nil, alignment: Alignment, detailed: Bool) {
+    init(media: SRGMedia?, style: FeaturedContentCell<FeaturedMediaContent>.Style, label: String? = nil, alignment: Alignment, detailed: Bool) {
         self.init(content: FeaturedMediaContent(media: media, style: style, label: label), alignment: alignment, detailed: detailed)
     }
 }


### PR DESCRIPTION
### Motivation and Context

Following "Use date style on swimlane media cells for show page" #412, this PR missed media element.

### Description

- Remove show title everywhere on a show page when media is from the same show.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
