### PR TITLE
Remove unexpected playback stops 

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -161,19 +161,19 @@ name: PLCrashReporter, nameSpecified: PLCrashReporter, owner: microsoft, version
 
 name: promises, nameSpecified: Promises, owner: google, version: 2.3.1, source: https://github.com/google/promises
 
-name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.0.2, source: https://github.com/SRGSSR/srganalytics-apple
+name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.1.0, source: https://github.com/SRGSSR/srganalytics-apple
 
 name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version: 5.2.1, source: https://github.com/SRGSSR/srgappearance-apple
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 18.1.0, source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 19.0.0, source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 
 name: srgidentity-apple, nameSpecified: SRGIdentity, owner: SRGSSR, version: 3.3.0, source: https://github.com/SRGSSR/srgidentity-apple
 
-name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9.2.1, source: https://github.com/SRGSSR/srgletterbox-apple
+name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9.3.0, source: https://github.com/SRGSSR/srgletterbox-apple
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -278,7 +278,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srganalytics-apple</string>
 			<key>Title</key>
-			<string>SRGAnalytics (9.0.2)</string>
+			<string>SRGAnalytics (9.1.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>
@@ -302,7 +302,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>SRGDataProvider (18.1.0)</string>
+			<string>SRGDataProvider (19.0.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>
@@ -326,7 +326,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgletterbox-apple</string>
 			<key>Title</key>
-			<string>SRGLetterbox (9.2.1)</string>
+			<string>SRGLetterbox (9.3.0)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -231,8 +231,6 @@ static void *s_kvoContext = &s_kvoContext;
 
 - (void)setupAnalytics
 {
-    [SRGAnalyticsTracker applySetupAnalyticsWorkaround];
-    
     ApplicationConfiguration *applicationConfiguration = ApplicationConfiguration.sharedApplicationConfiguration;
     SRGAnalyticsConfiguration *configuration = [[SRGAnalyticsConfiguration alloc] initWithBusinessUnitIdentifier:applicationConfiguration.analyticsBusinessUnitIdentifier
                                                                                                        sourceKey:applicationConfiguration.analyticsSourceKey

--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -9,7 +9,6 @@ import Foundation
 import SRGAppearanceSwift
 import SRGDataProviderCombine
 import SwiftUI
-import TCServerSide_noIDFA
 
 func constant<T>(iOS: T, tvOS: T) -> T {
 #if os(tvOS)
@@ -578,19 +577,5 @@ extension SRGAnalyticsLabels {
         
         analyticsLabels.customInfo = customInfo
         return analyticsLabels
-    }
-}
-
-extension SRGAnalyticsTracker {
-    @objc class func applySetupAnalyticsWorkaround() {
-        // Workaround for Commanders Act migration from v4 to v5
-        
-        // 1. Use the TC unique id value for new `device.sdk_id` property.
-        if let tcUniqueID = TCPredefinedVariables.sharedInstance().uniqueIdentifier(), !tcUniqueID.isEmpty {
-            TCDevice.sharedInstance().sdkID = tcUniqueID
-        }
-        
-        // 2. Use the TC unique id value for the new `user.consistent_anonymous_id` property.
-        TCPredefinedVariables.sharedInstance().useLegacyUniqueIDForAnonymousID()
     }
 }

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -19283,7 +19283,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srgletterbox-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.2.1;
+				minimumVersion = 9.3.0;
 			};
 		};
 		6F6DD3A924E449D7003F9437 /* XCRemoteSwiftPackageReference "srgdataprovider-apple" */ = {
@@ -19291,7 +19291,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 18.1.0;
+				minimumVersion = 19.0.0;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -284,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srganalytics-apple.git",
       "state" : {
-        "revision" : "45343b66e5bc2626197d314dfff88d50f9a96388",
-        "version" : "9.0.2"
+        "revision" : "0e48e8e36951bc474ef80f29192759ea93d8009d",
+        "version" : "9.1.0"
       }
     },
     {
@@ -311,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "a7380a80cab17b9c3f84e1b32d6c403b0bedc2be",
-        "version" : "18.1.0"
+        "revision" : "ae92436f7861651e66de5d33d2c0d1cf7d73345e",
+        "version" : "19.0.0"
       }
     },
     {
@@ -338,8 +338,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgletterbox-apple.git",
       "state" : {
-        "revision" : "6fd631014a39074d4fec1dce00804fa468d833fd",
-        "version" : "9.2.1"
+        "revision" : "4b9cf8f31eeccfa583aaf895f5307c9fe471b326",
+        "version" : "9.3.0"
       }
     },
     {

--- a/TV Application/Sources/AppDelegate.swift
+++ b/TV Application/Sources/AppDelegate.swift
@@ -88,8 +88,6 @@ extension AppDelegate: UIApplicationDelegate {
         
         UserConsentHelper.setup()
         
-        SRGAnalyticsTracker.applySetupAnalyticsWorkaround()
-        
         let analyticsConfiguration = SRGAnalyticsConfiguration(
             businessUnitIdentifier: configuration.analyticsBusinessUnitIdentifier,
             sourceKey: configuration.analyticsSourceKey,


### PR DESCRIPTION
### Motivation and Context

A player feature named "kill switch" was introduced [in 2017](https://github.com/SRGSSR/srgletterbox-apple/commit/c9a2910d21fcb4ce364813e9a741bf93a00fc286) for legal reason. https://github.com/SRGSSR/srgletterbox-apple/releases/tag/1.6
Since few months, users reported unexpected stops during video on demand playbacks.
Player team investigated is because of this player feature: https://github.com/SRGSSR/pillarbox-documentation/issues/51

A new player release removes this feature, thanks to our users.

### Description

- Update `SRGLetterbox` to version [9.3.0](https://github.com/SRGSSR/srgletterbox-apple/releases/tag/9.3.0).
- Update `SRGAnalytics` to version [9.1.0](https://github.com/SRGSSR/srganalytics-apple/releases/tag/9.1.0).
- Remove #388 .

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
