### PR TITLE
Update badge concepts

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Salta";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "Presto";
-
 /* Search setting */
 "Sort by" = "Ordinare per";
 

--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Pertinenza";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Replay";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Immagine: %@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "In advance";
+
 /* Information section header */
 "Information" = "Informazioni";
 

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Finir";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "Proximamain";
-
 /* Search setting */
 "Sort by" = "Sortar tenor";
 

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Maletg:%@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "In advance";
+
 /* Information section header */
 "Information" = "Infurmaziun";
 

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Relevanza";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Replay";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -31,6 +31,5 @@
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
   "showLeadPreferred": true,
   "tvGuideOtherBouquets": "srf,rsi",
-  "userConsentDefaultLanguage": "fr",
-  "webFirstBadgeEnabled": true
+  "userConsentDefaultLanguage": "fr"
 }

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -31,5 +31,6 @@
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
   "showLeadPreferred": true,
   "tvGuideOtherBouquets": "srf,rsi",
-  "userConsentDefaultLanguage": "fr"
+  "userConsentDefaultLanguage": "fr",
+  "webFirstBadgeEnabled": true
 }

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Ignorer";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "Prochainement";
-
 /* Search setting */
 "Sort by" = "Trier par";
 

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -849,7 +849,7 @@
 "Watch later" = "Regarder plus tard";
 
 /* Short label identifying a web first content. */
-"Web first" = "Exclu";
+"Web first" = "Avant-première";
 
 /* Label of the button to display what's new information
    Title displayed at the top of the What's new view */

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Crédit image : %@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "Avant-première";
+
 /* Information section header */
 "Information" = "Information";
 

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -852,7 +852,7 @@
 "Watch later" = "Regarder plus tard";
 
 /* Short label identifying a web first content. */
-"Web first" = "Nouveau";
+"Web first" = "Exclu";
 
 /* Label of the button to display what's new information
    Title displayed at the top of the What's new view */

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -849,7 +849,7 @@
 "Watch later" = "Regarder plus tard";
 
 /* Short label identifying a web first content. */
-"Web first" = "Avant-première";
+"Web first" = "Nouveau";
 
 /* Label of the button to display what's new information
    Title displayed at the top of the What's new view */

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Pertinence";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Rediffusion";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -28,5 +28,6 @@
   "audioDescriptionAvailabilityHidden": true,
   "posterImagesEnabled": true,
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
-  "userConsentDefaultLanguage": "de"
+  "userConsentDefaultLanguage": "de",
+  "webFirstBadgeHidden": true
 }

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -28,6 +28,5 @@
   "audioDescriptionAvailabilityHidden": true,
   "posterImagesEnabled": true,
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
-  "userConsentDefaultLanguage": "de",
-  "webFirstBadgeHidden": true
+  "userConsentDefaultLanguage": "de"
 }

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Abbrechen";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "In Kürze";
-
 /* Search setting */
 "Sort by" = "Sortieren nach";
 

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Bild: %@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "Vorab";
+
 /* Information section header */
 "Information" = "Informationen";
 

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Relevanz";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Replay";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Image credit: %@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "In advance";
+
 /* Information section header */
 "Information" = "Information";
 

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Relevance";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Replay";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Skip";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "Soon";
-
 /* Search setting */
 "Sort by" = "Sort by";
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -61,6 +61,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, readonly, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
+@property (nonatomic, readonly, getter=isWebFirstBadgeHidden) BOOL webFirstBadgeHidden;
 
 @property (nonatomic, readonly, copy, nullable) NSString *discoverySubtitleOptionLanguage;
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -61,7 +61,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, readonly, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
-@property (nonatomic, readonly, getter=isWebFirstBadgeHidden) BOOL webFirstBadgeHidden;
+@property (nonatomic, readonly, getter=isWebFirstBadgeEnabled) BOOL webFirstBadgeEnabled;
 
 @property (nonatomic, readonly, copy, nullable) NSString *discoverySubtitleOptionLanguage;
 

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -146,6 +146,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
+@property (nonatomic, getter=isWebFirstBadgeHidden) BOOL webFirstBadgeHidden;
 
 @property (nonatomic, copy) NSString *discoverySubtitleOptionLanguage;
 
@@ -439,6 +440,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     
     self.subtitleAvailabilityHidden = [firebaseConfiguration boolForKey:@"subtitleAvailabilityHidden"];
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];
+    self.webFirstBadgeHidden = [firebaseConfiguration boolForKey:@"webFirstBadgeHidden"];
     
     self.discoverySubtitleOptionLanguage = [firebaseConfiguration stringForKey:@"discoverySubtitleOptionLanguage"];
     

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -146,7 +146,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic, getter=isSubtitleAvailabilityHidden) BOOL subtitleAvailabilityHidden;
 @property (nonatomic, getter=isAudioDescriptionAvailabilityHidden) BOOL audioDescriptionAvailabilityHidden;
-@property (nonatomic, getter=isWebFirstBadgeHidden) BOOL webFirstBadgeHidden;
+@property (nonatomic, getter=isWebFirstBadgeEnabled) BOOL webFirstBadgeEnabled;
 
 @property (nonatomic, copy) NSString *discoverySubtitleOptionLanguage;
 
@@ -440,7 +440,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     
     self.subtitleAvailabilityHidden = [firebaseConfiguration boolForKey:@"subtitleAvailabilityHidden"];
     self.audioDescriptionAvailabilityHidden = [firebaseConfiguration boolForKey:@"audioDescriptionAvailabilityHidden"];
-    self.webFirstBadgeHidden = [firebaseConfiguration boolForKey:@"webFirstBadgeHidden"];
+    self.webFirstBadgeEnabled = [firebaseConfiguration boolForKey:@"webFirstBadgeEnabled"];
     
     self.discoverySubtitleOptionLanguage = [firebaseConfiguration stringForKey:@"discoverySubtitleOptionLanguage"];
     

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
@@ -12,14 +12,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UILabel (PlaySRG)
 
 /**
- *  Use this method to display the correct date label for some media metadata.
+ *  Use this method to display the correct date label for some media.
  */
-- (void)play_displayDateLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata;
+- (void)play_displayDateLabelForMedia:(SRGMedia *)media;
 
 /**
- *  Use this method to display the correct availability label for some media metadata.
+ *  Use this method to display the correct availability label for some media.
  */
-- (void)play_displayAvailabilityBadgeForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata;
+- (void)play_displayAvailabilityBadgeForMedia:(SRGMedia *)media;
 
 /**
  *  Call to display the standard "web first" badge.

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
@@ -12,11 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UILabel (PlaySRG)
 
 /**
- *  Use this method to display the correct duration label for some media metadata.
- */
-- (void)play_displayDurationLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata;
-
-/**
  *  Use this method to display the correct date label for some media metadata.
  */
 - (void)play_displayDateLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.h
@@ -12,11 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UILabel (PlaySRG)
 
 /**
- *  Use this method to display the correct date label for some media.
- */
-- (void)play_displayDateLabelForMedia:(SRGMedia *)media;
-
-/**
  *  Use this method to display the correct availability label for some media.
  */
 - (void)play_displayAvailabilityBadgeForMedia:(SRGMedia *)media;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -39,7 +39,10 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSDate *nowDate = NSDate.date;
     SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
     
-    if (mediaMetadata.date && timeAvailability != SRGTimeAvailabilityNotYetAvailable) {
+    if (mediaMetadata.date
+        && timeAvailability != SRGTimeAvailabilityNotYetAvailable
+        && mediaMetadata.contentType != SRGContentTypeLivestream
+        && !(mediaMetadata.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
         NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:mediaMetadata.date].play_localizedUppercaseFirstLetterString;
         NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(mediaMetadata.date);
         
@@ -108,6 +111,12 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
             NSTimeInterval timeIntervalBeforeEnd = [mediaMetadata.endDate timeIntervalSinceDate:nowDate];
             text = [NSString stringWithFormat:NSLocalizedString(@"%@ left", @"Short label displayed on a media expiring soon"), LabelFormattedDuration(timeIntervalBeforeEnd)];
         }
+    }
+    else if (mediaMetadata.contentType == SRGContentTypeLivestream
+             || (mediaMetadata.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
+        self.backgroundColor = UIColor.srg_lightRedColor;
+        
+        text = NSLocalizedString(@"Live", @"Short label identifying a livestream. Display in uppercase.").uppercaseString;
     }
     
     if (text) {

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -7,10 +7,6 @@
 #import "UILabel+PlaySRG.h"
 
 #import "Layout.h"
-#import "NSBundle+PlaySRG.h"
-#import "NSString+PlaySRG.h"
-#import "PlayAccessibilityFormatter.h"
-#import "PlayDurationFormatter.h"
 #import "PlaySRG-Swift.h"
 
 @import SRGAppearance;
@@ -33,51 +29,6 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
 @implementation UILabel (PlaySRG)
 
 #pragma mark Public
-
-- (void)play_displayDateLabelForMedia:(SRGMedia *)media
-{
-    NSDate *nowDate = NSDate.date;
-    SRGTimeAvailability timeAvailability = [media timeAvailabilityAtDate:nowDate];
-    
-    if (media.date
-        && timeAvailability != SRGTimeAvailabilityNotYetAvailable
-        && media.contentType != SRGContentTypeLivestream
-        && !(media.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
-        NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:media.date].play_localizedUppercaseFirstLetterString;
-        NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(media.date);
-        
-        BOOL isWebFirst = [media.date compare:nowDate] == NSOrderedDescending && timeAvailability == SRGTimeAvailabilityAvailable && media.contentType == SRGContentTypeEpisode;
-        
-        if (isWebFirst) {
-            NSString *webFirst = NSLocalizedString(@"In advance", @"Short text replacing date for a web first content.");
-            
-            // Unbreakable spaces before / after the separator
-            text = webFirst;
-            
-            accessibilityLabel = webFirst;
-        }
-        
-        if (timeAvailability == SRGTimeAvailabilityAvailable && media.endDate
-                && media.contentType != SRGContentTypeScheduledLivestream && media.contentType != SRGContentTypeLivestream && media.contentType != SRGContentTypeTrailer) {
-            NSDateComponents *remainingDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:media.endDate options:0];
-            if (remainingDateComponents.day > kDayNearExpirationThreshold) {
-                NSString *expiration = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), [NSDateFormatter.play_shortDate stringFromDate:media.endDate].play_localizedUppercaseFirstLetterString];
-                // Unbreakable spaces before / after the separator
-                text = [text stringByAppendingFormat:@" · %@", expiration];
-                
-                NSString *expirationAccessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), PlayAccessibilityDateFromDate(media.endDate)];
-                accessibilityLabel = [accessibilityLabel stringByAppendingFormat:@", %@", expirationAccessibilityLabel];
-            }
-        }
-        
-        self.text = text;
-        self.accessibilityLabel = accessibilityLabel;
-    }
-    else {
-        self.text = nil;
-        self.accessibilityLabel = nil;
-    }
-}
 
 - (void)play_displayAvailabilityBadgeForMedia:(SRGMedia *)media
 {

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -49,9 +49,9 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
             NSString *webFirst = NSLocalizedString(@"Web first", @"Short label identifying a web first content.");
             
             // Unbreakable spaces before / after the separator
-            text = [webFirst stringByAppendingFormat:@" · %@", text];
+            text = webFirst;
             
-            accessibilityLabel = [webFirst stringByAppendingFormat:@", %@", accessibilityLabel];
+            accessibilityLabel = webFirst;
         }
         
         if (timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.endDate

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -46,7 +46,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:mediaMetadata.date].play_localizedUppercaseFirstLetterString;
         NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(mediaMetadata.date);
         
-        BOOL isWebFirst = mediaMetadata.date > nowDate && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
+        BOOL isWebFirst = [mediaMetadata.date compare:nowDate] == NSOrderedDescending && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
         
         if (isWebFirst) {
             NSString *webFirst = NSLocalizedString(@"In advance", @"Short text identifying a web first content.");

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -48,7 +48,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         
         BOOL isWebFirst = mediaMetadata.date > nowDate && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
         
-        if (isWebFirst && [ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeHidden) {
+        if (isWebFirst && ![ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeEnabled) {
             NSString *webFirst = NSLocalizedString(@"Web first", @"Short label identifying a web first content.");
             
             // Unbreakable spaces before / after the separator

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -49,7 +49,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         BOOL isWebFirst = [mediaMetadata.date compare:nowDate] == NSOrderedDescending && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
         
         if (isWebFirst) {
-            NSString *webFirst = NSLocalizedString(@"In advance", @"Short text identifying a web first content.");
+            NSString *webFirst = NSLocalizedString(@"In advance", @"Short text replacing date for a web first content.");
             
             // Unbreakable spaces before / after the separator
             text = webFirst;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -42,6 +42,18 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         
         NSDate *nowDate = NSDate.date;
         SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
+        
+        BOOL isWebFirst = mediaMetadata.date > nowDate && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
+        
+        if (isWebFirst && [ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeHidden) {
+            NSString *webFirst = NSLocalizedString(@"Web first", @"Short label identifying a web first content.");
+            
+            // Unbreakable spaces before / after the separator
+            text = [webFirst stringByAppendingFormat:@" · %@", text];
+            
+            accessibilityLabel = [webFirst stringByAppendingFormat:@", %@", accessibilityLabel];
+        }
+        
         if (timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.endDate
                 && mediaMetadata.contentType != SRGContentTypeScheduledLivestream && mediaMetadata.contentType != SRGContentTypeLivestream && mediaMetadata.contentType != SRGContentTypeTrailer) {
             NSDateComponents *remainingDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:mediaMetadata.endDate options:0];

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -48,8 +48,8 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         
         BOOL isWebFirst = mediaMetadata.date > nowDate && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
         
-        if (isWebFirst && ![ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeEnabled) {
-            NSString *webFirst = NSLocalizedString(@"Web first", @"Short label identifying a web first content.");
+        if (isWebFirst) {
+            NSString *webFirst = NSLocalizedString(@"In advance", @"Short text identifying a web first content.");
             
             // Unbreakable spaces before / after the separator
             text = webFirst;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -92,7 +92,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSDate *nowDate = NSDate.date;
     SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
-        self.backgroundColor = UIColor.srg_darkRedColor;
+        self.backgroundColor = UIColor.play_black80a;
         
         NSDate *startDate = mediaMetadata.startDate != nil ? mediaMetadata.startDate : mediaMetadata.date;
         text = [[NSDateFormatter play_relativeShortDateAndTime] stringFromDate:startDate].play_localizedUppercaseFirstLetterString;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -34,15 +34,6 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
 
 #pragma mark Public
 
-- (void)play_displayDurationLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata
-{
-    BOOL isLivestreamOrScheduledLivestream = (mediaMetadata.contentType == SRGContentTypeLivestream || mediaMetadata.contentType == SRGContentTypeScheduledLivestream);
-    [self play_displayDurationLabelWithTimeAvailability:[mediaMetadata timeAvailabilityAtDate:NSDate.date]
-                                               duration:mediaMetadata.duration
-                      isLivestreamOrScheduledLivestream:isLivestreamOrScheduledLivestream
-                                            isLiveEvent:[SRGMedia PlayIsSwissTXTURN:mediaMetadata.URN]];
-}
-
 - (void)play_displayDateLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata
 {
     if (mediaMetadata.date) {
@@ -125,48 +116,6 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     self.text = [NSString stringWithFormat:@"%@    ", NSLocalizedString(@"Web first", @"Short label identifying a web first content.")].uppercaseString;
     self.textAlignment = NSTextAlignmentCenter;
     self.textColor = UIColor.whiteColor;
-}
-
-#pragma mark Private
-
-- (void)play_displayDurationLabelWithTimeAvailability:(SRGTimeAvailability)timeAvailability duration:(NSTimeInterval)duration isLivestreamOrScheduledLivestream:(BOOL)isLivestreamOrScheduledLivestream isLiveEvent:(BOOL)isLiveEvent
-{
-    self.font = [SRGFont fontWithStyle:SRGFontStyleCaption];
-    
-    if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
-        [self play_displayDurationLabelWithName:NSLocalizedString(@"Soon", @"Short label identifying content which will be available soon.") isLive:NO];
-    }
-    else if (timeAvailability == SRGTimeAvailabilityNotAvailableAnymore) {
-        [self play_displayDurationLabelWithName:NSLocalizedString(@"Expired", @"Short label identifying content which has expired.") isLive:NO];
-    }
-    else if (isLivestreamOrScheduledLivestream) {
-        [self play_displayDurationLabelWithName:NSLocalizedString(@"Live", @"Short label identifying a livestream. Display in uppercase.") isLive:YES];
-    }
-    else if (isLiveEvent) {
-        [self play_displayDurationLabelWithName:NSLocalizedString(@"Replay", @"Short label identifying a replay sport event. Display in uppercase.") isLive:NO];
-    }
-    else if (duration != 0.) {
-        NSString *durationString = PlayFormattedDuration(duration / 1000.);
-        [self play_displayDurationLabelWithName:durationString isLive:NO];
-    }
-    else {
-        self.text = nil;
-        self.hidden = YES;
-    }
-}
-
-- (void)play_displayDurationLabelWithName:(NSString *)name isLive:(BOOL)isLive
-{
-    self.backgroundColor = isLive ? UIColor.srg_lightRedColor : UIColor.play_blackDurationLabelBackground;
-    self.layer.cornerRadius = LayoutStandardLabelCornerRadius;
-    self.layer.masksToBounds = YES;
-    
-    NSString *labelString = isLive ? name.uppercaseString : name;
-    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"  %@  ", labelString]
-                                                                                       attributes:@{ NSFontAttributeName : [SRGFont fontWithStyle:SRGFontStyleCaption],
-                                                                                                     NSForegroundColorAttributeName : UIColor.whiteColor }];
-    self.attributedText = attributedText.copy;
-    self.hidden = NO;
 }
 
 @end

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -113,7 +113,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     self.layer.cornerRadius = LayoutStandardLabelCornerRadius;
     self.layer.masksToBounds = YES;
     self.font = [SRGFont fontWithStyle:SRGFontStyleCaption];
-    self.text = [NSString stringWithFormat:@"%@    ", NSLocalizedString(@"Web first", @"Short label identifying a web first content.")].uppercaseString;
+    self.text = [NSString stringWithFormat:@"%@    ", NSLocalizedString(@"Web first", @"Short label identifying a web first content.")];
     self.textAlignment = NSTextAlignmentCenter;
     self.textColor = UIColor.whiteColor;
 }

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -77,7 +77,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSDate *nowDate = NSDate.date;
     SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
-        self.backgroundColor = UIColor.play_black80a;
+        self.backgroundColor = UIColor.srg_darkRedColor;
         
         text = NSLocalizedString(@"Soon", @"Short label identifying content which will be available soon.");
     }
@@ -98,7 +98,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     }
     
     if (text) {
-        self.text = [NSString stringWithFormat:@"%@    ", text].uppercaseString;
+        self.text = [NSString stringWithFormat:@"%@    ", text];
         self.hidden = NO;
     }
     else {

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -34,19 +34,19 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
 
 #pragma mark Public
 
-- (void)play_displayDateLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata
+- (void)play_displayDateLabelForMedia:(SRGMedia *)media
 {
     NSDate *nowDate = NSDate.date;
-    SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
+    SRGTimeAvailability timeAvailability = [media timeAvailabilityAtDate:nowDate];
     
-    if (mediaMetadata.date
+    if (media.date
         && timeAvailability != SRGTimeAvailabilityNotYetAvailable
-        && mediaMetadata.contentType != SRGContentTypeLivestream
-        && !(mediaMetadata.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
-        NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:mediaMetadata.date].play_localizedUppercaseFirstLetterString;
-        NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(mediaMetadata.date);
+        && media.contentType != SRGContentTypeLivestream
+        && !(media.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
+        NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:media.date].play_localizedUppercaseFirstLetterString;
+        NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(media.date);
         
-        BOOL isWebFirst = [mediaMetadata.date compare:nowDate] == NSOrderedDescending && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
+        BOOL isWebFirst = [media.date compare:nowDate] == NSOrderedDescending && timeAvailability == SRGTimeAvailabilityAvailable && media.contentType == SRGContentTypeEpisode;
         
         if (isWebFirst) {
             NSString *webFirst = NSLocalizedString(@"In advance", @"Short text replacing date for a web first content.");
@@ -57,15 +57,15 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
             accessibilityLabel = webFirst;
         }
         
-        if (timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.endDate
-                && mediaMetadata.contentType != SRGContentTypeScheduledLivestream && mediaMetadata.contentType != SRGContentTypeLivestream && mediaMetadata.contentType != SRGContentTypeTrailer) {
-            NSDateComponents *remainingDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:mediaMetadata.endDate options:0];
+        if (timeAvailability == SRGTimeAvailabilityAvailable && media.endDate
+                && media.contentType != SRGContentTypeScheduledLivestream && media.contentType != SRGContentTypeLivestream && media.contentType != SRGContentTypeTrailer) {
+            NSDateComponents *remainingDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:media.endDate options:0];
             if (remainingDateComponents.day > kDayNearExpirationThreshold) {
-                NSString *expiration = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), [NSDateFormatter.play_shortDate stringFromDate:mediaMetadata.endDate].play_localizedUppercaseFirstLetterString];
+                NSString *expiration = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), [NSDateFormatter.play_shortDate stringFromDate:media.endDate].play_localizedUppercaseFirstLetterString];
                 // Unbreakable spaces before / after the separator
                 text = [text stringByAppendingFormat:@" · %@", expiration];
                 
-                NSString *expirationAccessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), PlayAccessibilityDateFromDate(mediaMetadata.endDate)];
+                NSString *expirationAccessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Available until %@", @"Availability until date, specified as parameter"), PlayAccessibilityDateFromDate(media.endDate)];
                 accessibilityLabel = [accessibilityLabel stringByAppendingFormat:@", %@", expirationAccessibilityLabel];
             }
         }
@@ -79,7 +79,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     }
 }
 
-- (void)play_displayAvailabilityBadgeForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata
+- (void)play_displayAvailabilityBadgeForMedia:(SRGMedia *)media
 {
     self.layer.cornerRadius = LayoutStandardLabelCornerRadius;
     self.layer.masksToBounds = YES;
@@ -90,11 +90,11 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSString *text = nil;
     
     NSDate *nowDate = NSDate.date;
-    SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
+    SRGTimeAvailability timeAvailability = [media timeAvailabilityAtDate:nowDate];
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
         self.backgroundColor = UIColor.play_black80a;
         
-        NSDate *startDate = mediaMetadata.startDate != nil ? mediaMetadata.startDate : mediaMetadata.date;
+        NSDate *startDate = media.startDate != nil ? media.startDate : media.date;
         text = [[NSDateFormatter play_relativeShortDateAndTime] stringFromDate:startDate].play_localizedUppercaseFirstLetterString;
     }
     else if (timeAvailability == SRGTimeAvailabilityNotAvailableAnymore) {
@@ -102,18 +102,18 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
         
         text = NSLocalizedString(@"Expired", @"Short label identifying content which has expired.");
     }
-    else if (timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.endDate
-             && (mediaMetadata.contentType == SRGContentTypeEpisode || mediaMetadata.contentType == SRGContentTypeClip)) {
+    else if (timeAvailability == SRGTimeAvailabilityAvailable && media.endDate
+             && (media.contentType == SRGContentTypeEpisode || media.contentType == SRGContentTypeClip)) {
         self.backgroundColor = UIColor.play_orange;
         
-        NSDateComponents *monthsDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:mediaMetadata.endDate options:0];
+        NSDateComponents *monthsDateComponents = [NSCalendar.srg_defaultCalendar components:NSCalendarUnitDay fromDate:nowDate toDate:media.endDate options:0];
         if (monthsDateComponents.day <= kDayNearExpirationThreshold) {
-            NSTimeInterval timeIntervalBeforeEnd = [mediaMetadata.endDate timeIntervalSinceDate:nowDate];
+            NSTimeInterval timeIntervalBeforeEnd = [media.endDate timeIntervalSinceDate:nowDate];
             text = [NSString stringWithFormat:NSLocalizedString(@"%@ left", @"Short label displayed on a media expiring soon"), LabelFormattedDuration(timeIntervalBeforeEnd)];
         }
     }
-    else if (mediaMetadata.contentType == SRGContentTypeLivestream
-             || (mediaMetadata.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
+    else if (media.contentType == SRGContentTypeLivestream
+             || (media.contentType == SRGContentTypeScheduledLivestream && timeAvailability == SRGTimeAvailabilityAvailable)) {
         self.backgroundColor = UIColor.srg_lightRedColor;
         
         text = NSLocalizedString(@"Live", @"Short label identifying a livestream. Display in uppercase.").uppercaseString;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -161,7 +161,8 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     self.layer.cornerRadius = LayoutStandardLabelCornerRadius;
     self.layer.masksToBounds = YES;
     
-    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"  %@  ", name].uppercaseString
+    NSString *labelString = isLive ? name.uppercaseString : name;
+    NSMutableAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"  %@  ", labelString]
                                                                                        attributes:@{ NSFontAttributeName : [SRGFont fontWithStyle:SRGFontStyleCaption],
                                                                                                      NSForegroundColorAttributeName : UIColor.whiteColor }];
     self.attributedText = attributedText.copy;

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -36,12 +36,12 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
 
 - (void)play_displayDateLabelForMediaMetadata:(id<SRGMediaMetadata>)mediaMetadata
 {
-    if (mediaMetadata.date) {
+    NSDate *nowDate = NSDate.date;
+    SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
+    
+    if (mediaMetadata.date && timeAvailability != SRGTimeAvailabilityNotYetAvailable) {
         NSString *text = [NSDateFormatter.play_shortDateAndTime stringFromDate:mediaMetadata.date].play_localizedUppercaseFirstLetterString;
         NSString *accessibilityLabel = PlayAccessibilityDateAndTimeFromDate(mediaMetadata.date);
-        
-        NSDate *nowDate = NSDate.date;
-        SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
         
         BOOL isWebFirst = mediaMetadata.date > nowDate && timeAvailability == SRGTimeAvailabilityAvailable && mediaMetadata.contentType == SRGContentTypeEpisode;
         

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -86,7 +86,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSDate *nowDate = NSDate.date;
     SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
-        self.backgroundColor = UIColor.play_green;
+        self.backgroundColor = [UIColor.blackColor colorWithAlphaComponent:.8];
         
         text = NSLocalizedString(@"Soon", @"Short label identifying content which will be available soon.");
     }
@@ -118,7 +118,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
 
 - (void)play_setWebFirstBadge
 {
-    self.backgroundColor = UIColor.srg_blueColor;
+    self.backgroundColor = UIColor.srg_darkRedColor;
     self.layer.cornerRadius = LayoutStandardLabelCornerRadius;
     self.layer.masksToBounds = YES;
     self.font = [SRGFont fontWithStyle:SRGFontStyleCaption];

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -86,7 +86,7 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     NSDate *nowDate = NSDate.date;
     SRGTimeAvailability timeAvailability = [mediaMetadata timeAvailabilityAtDate:nowDate];
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
-        self.backgroundColor = [UIColor.blackColor colorWithAlphaComponent:.8];
+        self.backgroundColor = UIColor.play_black80a;
         
         text = NSLocalizedString(@"Soon", @"Short label identifying content which will be available soon.");
     }

--- a/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
+++ b/Application/Sources/Helpers/Categories/UILabel+PlaySRG.m
@@ -91,7 +91,8 @@ static NSString *LabelFormattedDuration(NSTimeInterval duration)
     if (timeAvailability == SRGTimeAvailabilityNotYetAvailable) {
         self.backgroundColor = UIColor.srg_darkRedColor;
         
-        text = NSLocalizedString(@"Soon", @"Short label identifying content which will be available soon.");
+        NSDate *startDate = mediaMetadata.startDate != nil ? mediaMetadata.startDate : mediaMetadata.date;
+        text = [[NSDateFormatter play_relativeShortDateAndTime] stringFromDate:startDate].play_localizedUppercaseFirstLetterString;
     }
     else if (timeAvailability == SRGTimeAvailabilityNotAvailableAnymore) {
         self.backgroundColor = UIColor.srg_gray96Color;

--- a/Application/Sources/Helpers/Extensions/DateFormatter+playSRG.swift
+++ b/Application/Sources/Helpers/Extensions/DateFormatter+playSRG.swift
@@ -111,7 +111,7 @@ extension DateFormatter {
      *
      *  @discussion Use `PlayAccessibilityRelativeDateFromDate` for accessibility-oriented formatting.
      */
-    static var play_relativeShortDateAndTime: DateFormatter = {
+    @objc static var play_relativeShortDateAndTime: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone.srgTimeZone
         dateFormatter.dateStyle = .short

--- a/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
@@ -11,10 +11,6 @@ extension UIColor {
         return play_hexadecimal("#ed3323")
     }
     
-    @objc static var play_green: UIColor {
-        return play_hexadecimal("#347368")
-    }
-    
     @objc static var play_orange: UIColor {
         return play_hexadecimal("#df5200")
     }

--- a/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
@@ -7,6 +7,10 @@
 import SRGAppearance
 
 extension UIColor {
+    @objc static var play_black80a: UIColor {
+        return .black.withAlphaComponent(0.8)
+    }
+    
     @objc static var play_notificationRed: UIColor {
         return play_hexadecimal("#ed3323")
     }

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -53,7 +53,7 @@ struct FeaturedMediaContent: FeaturedContent {
     
     var accessibilityLabel: String? {
         guard let media else { return nil }
-        return MediaDescription.accessibilityLabel(for: media)
+        return MediaDescription.cellAccessibilityLabel(for: media)
     }
     
     var accessibilityHint: String? {

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -109,7 +109,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
 
 @property (nonatomic, weak) IBOutlet UIScrollView *scrollView;
 
-@property (nonatomic, weak) IBOutlet UILabel *dateLabel;
+@property (nonatomic, weak) IBOutlet UIStackView *dateStackView;
+@property (nonatomic, strong) IBOutlet UILabel *dateLabel;
 @property (nonatomic, weak) IBOutlet UILabel *titleLabel;
 @property (nonatomic, weak) IBOutlet UILabel *availabilityLabel;
 @property (nonatomic, weak) IBOutlet UIStackView *viewCountStackView;
@@ -815,6 +816,13 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         
         self.dateLabel.font = [SRGFont fontWithStyle:SRGFontStyleCaption];
         [self.dateLabel play_displayDateLabelForMediaMetadata:media];
+        
+        if (self.dateLabel.text.length == 0) {
+            [self.dateLabel removeFromSuperview];
+        }
+        else if (self.dateLabel.superview == nil) {
+            [self.dateStackView insertSubview:self.dateLabel atIndex:1];
+        }
         
         [self removeSongPanel];
         

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -856,7 +856,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         self.summaryLabel.text = media.play_fullSummary;
         
         BOOL downloaded = (mainChapterMedia != nil) ? [Download downloadForMedia:mainChapterMedia].state == DownloadStateDownloaded : NO;
-        BOOL isWebFirst = mainChapterMedia.play_isWebFirst;
+        BOOL isWebFirst = mainChapterMedia.play_isWebFirst && ![ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeHidden;
         BOOL hasSubtitles = resource.play_subtitlesAvailable && ! downloaded;
         BOOL hasAudioDescription = resource.play_audioDescriptionAvailable && ! downloaded;
         BOOL hasMultiAudio = resource.play_multiAudioAvailable && ! downloaded;

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -864,7 +864,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         self.summaryLabel.text = media.play_fullSummary;
         
         BOOL downloaded = (mainChapterMedia != nil) ? [Download downloadForMedia:mainChapterMedia].state == DownloadStateDownloaded : NO;
-        BOOL isWebFirst = mainChapterMedia.play_isWebFirst && ![ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeHidden;
+        BOOL isWebFirst = mainChapterMedia.play_isWebFirst && [ApplicationConfiguration sharedApplicationConfiguration].isWebFirstBadgeEnabled;
         BOOL hasSubtitles = resource.play_subtitlesAvailable && ! downloaded;
         BOOL hasAudioDescription = resource.play_audioDescriptionAvailable && ! downloaded;
         BOOL hasMultiAudio = resource.play_multiAudioAvailable && ! downloaded;

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -809,13 +809,13 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         self.scrollView.hidden = NO;
         self.channelView.hidden = YES;
         
-        [self.availabilityLabel play_displayAvailabilityBadgeForMediaMetadata:mainChapterMedia];
+        [self.availabilityLabel play_displayAvailabilityBadgeForMedia:mainChapterMedia];
         
         self.titleLabel.font = [SRGFont fontWithStyle:SRGFontStyleH2];
         self.titleLabel.text = media.title;
         
         self.dateLabel.font = [SRGFont fontWithStyle:SRGFontStyleCaption];
-        [self.dateLabel play_displayDateLabelForMediaMetadata:media];
+        [self.dateLabel play_displayDateLabelForMedia:media];
         
         if (self.dateLabel.text.length == 0) {
             [self.dateLabel removeFromSuperview];

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -20,7 +20,6 @@
 #import "ModalTransition.h"
 #import "NSBundle+PlaySRG.h"
 #import "PlayApplication.h"
-#import "PlayDurationFormatter.h"
 #import "PlayErrors.h"
 #import "Playlist.h"
 #import "PlaySRG-Swift.h"
@@ -815,7 +814,8 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
         self.titleLabel.text = media.title;
         
         self.dateLabel.font = [SRGFont fontWithStyle:SRGFontStyleCaption];
-        [self.dateLabel play_displayDateLabelForMedia:media];
+        self.dateLabel.text = [MediaDescription availabilityFor:media];
+        self.dateLabel.accessibilityLabel = [MediaDescription availabilityAccessibilityLabelFor:media];
         
         if (self.dateLabel.text.length == 0) {
             [self.dateLabel removeFromSuperview];

--- a/Application/Sources/Player/MediaPlayerViewController.storyboard
+++ b/Application/Sources/Player/MediaPlayerViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HgT-ei-KY5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HgT-ei-KY5">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -662,6 +662,7 @@
                         <outlet property="currentProgramTitleLabel" destination="G8U-yX-Q0a" id="kSk-dP-6ET"/>
                         <outlet property="currentProgramView" destination="jXJ-O2-0II" id="9EU-sl-htH"/>
                         <outlet property="dateLabel" destination="eaZ-CL-kRu" id="akM-kX-bBk"/>
+                        <outlet property="dateStackView" destination="p9y-d4-l6T" id="nj2-g8-2ld"/>
                         <outlet property="detailsButton" destination="PuO-1V-zBs" id="0Ac-AM-WVb"/>
                         <outlet property="detailsGestureRecognizer" destination="mqd-VT-g2Z" id="sbb-Cs-wWm"/>
                         <outlet property="downloadButton" destination="nnp-1j-BhQ" id="H26-HB-WST"/>

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -40,7 +40,7 @@ enum MediaDescription {
     
     private static func formattedDate(for media: SRGMedia) -> String? {
         if media.play_isWebFirst {
-            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
+            return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
             return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
@@ -52,7 +52,7 @@ enum MediaDescription {
     
     private static func formattedShortDate(for media: SRGMedia) -> String? {
         if media.play_isWebFirst {
-            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
+            return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
             return DateFormatter.play_relativeShortDate.string(from: media.date)
@@ -64,7 +64,7 @@ enum MediaDescription {
     
     private static func formattedShortDateAndTime(for media: SRGMedia) -> String? {
         if media.play_isWebFirst {
-            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
+            return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
             return DateFormatter.play_shortDateAndTime.string(from: media.date)

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -181,7 +181,7 @@ enum MediaDescription {
             case .notYetAvailable:
                 if allowsDateDisplay, let startDate = media.startDate {
                     return BadgeProperties(
-                        text: DateFormatter.play_relativeShortDateAndTime.string(from: startDate),
+                    text: DateFormatter.play_relativeShortDateAndTime.string(from: startDate).capitalizedFirstLetter,
                         color: .play_black80a
                     )
                 }

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -156,10 +156,7 @@ import SRGAppearanceSwift
                 )
             case .available:
                 if media.contentType == .scheduledLivestream {
-                    return BadgeProperties(
-                        text: NSLocalizedString("Live", comment: "Short label identifying a livestream. Display in uppercase.").uppercased(),
-                        color: .srgLightRed
-                    )
+                    return liveBadgeProperties()
                 }
                 else if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
                     return BadgeProperties(

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -145,7 +145,7 @@ enum MediaDescription {
     
     static func liveBadgeProperties() -> BadgeProperties {
         return BadgeProperties(
-            text: NSLocalizedString("Live", comment: "Short label identifying a livestream. Display in uppercase."),
+            text: NSLocalizedString("Live", comment: "Short label identifying a livestream. Display in uppercase.").uppercased(),
             color: .srgLightRed
         )
     }
@@ -179,7 +179,7 @@ enum MediaDescription {
             case .available:
                 if media.contentType == .scheduledLivestream {
                     return BadgeProperties(
-                        text: NSLocalizedString("Live", comment: "Short label identifying a livestream. Display in uppercase."),
+                        text: NSLocalizedString("Live", comment: "Short label identifying a livestream. Display in uppercase.").uppercased(),
                         color: .srgLightRed
                     )
                 }

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -158,7 +158,7 @@ enum MediaDescription {
         }
         
         // Unbreakable spaces before / after the separator
-        return values.joined(separator: " - ")
+        return values.joined(separator: " · ")
     }
     
     static func accessibilityLabel(for media: SRGMedia) -> String? {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -89,7 +89,7 @@ import SRGAppearanceSwift
     
     // MARK: - Accessibility
     
-    static func accessibilityLabel(for media: SRGMedia) -> String? {
+    static func cellAccessibilityLabel(for media: SRGMedia) -> String? {
         let accessibilityLabel: String
         if let show = media.show, !areRedundant(media: media, show: show) {
             accessibilityLabel = show.title.appending(", \(media.title)")

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -39,8 +39,8 @@ enum MediaDescription {
     }
     
     private static func formattedDate(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
-            return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
+        if media.play_isWebFirst {
+            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
             return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
@@ -51,11 +51,23 @@ enum MediaDescription {
     }
     
     private static func formattedShortDate(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
-            return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
+        if media.play_isWebFirst {
+            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
             return DateFormatter.play_relativeShortDate.string(from: media.date)
+        }
+        else {
+            return nil
+        }
+    }
+    
+    private static func formattedShortDateAndTime(for media: SRGMedia) -> String? {
+        if media.play_isWebFirst {
+            return NSLocalizedString("In advance", comment: "Short text identifying a web first content.")
+        }
+        else if shouldDisplayPublication(for: media) {
+            return DateFormatter.play_shortDateAndTime.string(from: media.date)
         }
         else {
             return nil
@@ -136,8 +148,8 @@ enum MediaDescription {
         && !(media.contentType == .scheduledLivestream && media.timeAvailability(at: now) == .available)
     }
     
-    private static func publication(for media: SRGMedia) -> String {
-        return DateFormatter.play_shortDateAndTime.string(from: media.date)
+    private static func publication(for media: SRGMedia) -> String? {
+        return formattedShortDateAndTime(for: media)
     }
     
     private static func expiration(for media: SRGMedia) -> String? {
@@ -148,11 +160,8 @@ enum MediaDescription {
     static func availability(for media: SRGMedia) -> String {
         var values: [String] = []
         
-        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
-            values.append(NSLocalizedString("Web first", comment: "Short label identifying a web first content."))
-        }
-        else if shouldDisplayPublication(for: media) {
-            values.append(publication(for: media))
+        if let publication = publication(for: media) {
+            values.append(publication)
         }
         
         if shouldDisplayExpiration(for: media), let expiration = expiration(for: media) {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -170,7 +170,7 @@ enum MediaDescription {
         )
     }
     
-    static func availabilityBadgeProperties(for media: SRGMedia, allowsDateDisplay: Bool = true) -> BadgeProperties? {
+    static func availabilityBadgeProperties(for media: SRGMedia) -> BadgeProperties? {
         if media.contentType == .livestream {
             return liveBadgeProperties()
         }
@@ -179,18 +179,11 @@ enum MediaDescription {
             let availability = media.timeAvailability(at: now)
             switch availability {
             case .notYetAvailable:
-                if allowsDateDisplay, let startDate = media.startDate {
+                let startDate = media.startDate ?? media.date
                     return BadgeProperties(
                     text: DateFormatter.play_relativeShortDateAndTime.string(from: startDate).capitalizedFirstLetter,
                         color: .play_black80a
                     )
-                }
-                else {
-                    return BadgeProperties(
-                        text: NSLocalizedString("Soon", comment: "Short label identifying content which will be available soon."),
-                        color: .srgDarkRed
-                    )
-                }
             case .notAvailableAnymore:
                 return BadgeProperties(
                     text: NSLocalizedString("Expired", comment: "Short label identifying content which has expired."),

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -162,13 +162,13 @@ enum MediaDescription {
                 if allowsDateDisplay, let startDate = media.startDate {
                     return BadgeProperties(
                         text: DateFormatter.play_relativeShortDateAndTime.string(from: startDate),
-                        color: .play_green
+                        color: .black.withAlphaComponent(0.8)
                     )
                 }
                 else {
                     return BadgeProperties(
                         text: NSLocalizedString("Soon", comment: "Short label identifying content which will be available soon."),
-                        color: .play_green
+                        color: .black.withAlphaComponent(0.8)
                     )
                 }
             case .notAvailableAnymore:
@@ -186,7 +186,7 @@ enum MediaDescription {
                 else if media.play_isWebFirst {
                     return BadgeProperties(
                         text: NSLocalizedString("Web first", comment: "Short label identifying a web first content."),
-                        color: .srgBlue
+                        color: .srgDarkRed
                     )
                 }
                 else if let endDate = media.endDate, media.contentType == .episode || media.contentType == .clip,

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -45,9 +45,9 @@ import SRGAppearanceSwift
                 if areRedundant(media: media, show: show) {
                     return show.title
                 }
-                else if let publicationDate = formattedDate(for: media, style: .shortDate) {
+                else if let formattedDate = formattedDate(for: media, style: .shortDate) {
                     // Unbreakable spaces before / after the separator
-                    return "\(show.title) · \(publicationDate)"
+                    return "\(show.title) · \(formattedDate)"
                 }
                 else {
                     return show.title

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -162,13 +162,13 @@ enum MediaDescription {
                 if allowsDateDisplay, let startDate = media.startDate {
                     return BadgeProperties(
                         text: DateFormatter.play_relativeShortDateAndTime.string(from: startDate),
-                        color: .black.withAlphaComponent(0.8)
+                        color: .play_black80a
                     )
                 }
                 else {
                     return BadgeProperties(
                         text: NSLocalizedString("Soon", comment: "Short label identifying content which will be available soon."),
-                        color: .black.withAlphaComponent(0.8)
+                        color: .play_black80a
                     )
                 }
             case .notAvailableAnymore:

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -48,7 +48,7 @@ enum MediaDescription {
         if media.play_isWebFirst {
             return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
-        else if shouldDisplayPublication(for: media) {
+        else if shouldDisplayDate(for: media) {
             switch style {
             case .date:
                 return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
@@ -121,7 +121,7 @@ enum MediaDescription {
         return media.duration / 1000
     }
     
-    private static func shouldDisplayExpiration(for media: SRGMedia) -> Bool {
+    private static func shouldDisplayExpirationDate(for media: SRGMedia) -> Bool {
         let now = Date()
         guard media.timeAvailability(at: now) == .available,
               media.contentType != .scheduledLivestream, media.contentType != .trailer,
@@ -130,31 +130,27 @@ enum MediaDescription {
         return remainingDateComponents.day! > 3
     }
     
-    private static func shouldDisplayPublication(for media: SRGMedia) -> Bool {
+    private static func shouldDisplayDate(for media: SRGMedia) -> Bool {
         let now = Date()
         return media.timeAvailability(at: now) != .notYetAvailable
         && media.contentType != .livestream
         && !(media.contentType == .scheduledLivestream && media.timeAvailability(at: now) == .available)
     }
     
-    private static func publication(for media: SRGMedia) -> String? {
-        return formattedDate(for: media, style: .shortDateAndTime)
-    }
-    
-    private static func expiration(for media: SRGMedia) -> String? {
-        guard let endDate = media.endDate else { return nil }
+    private static func expirationDate(for media: SRGMedia) -> String? {
+        guard let endDate = media.endDate, shouldDisplayExpirationDate(for: media) else { return nil }
         return String(format: NSLocalizedString("Available until %@", comment: "Availability until date, specified as parameter"), DateFormatter.play_shortDate.string(from: endDate))
     }
     
     static func availability(for media: SRGMedia) -> String {
         var values: [String] = []
         
-        if let publication = publication(for: media) {
-            values.append(publication)
+        if let date = formattedDate(for: media, style: .shortDateAndTime) {
+            values.append(date)
         }
         
-        if shouldDisplayExpiration(for: media), let expiration = expiration(for: media) {
-            values.append(expiration)
+        if let expirationDate = expirationDate(for: media) {
+            values.append(expirationDate)
         }
         
         // Unbreakable spaces before / after the separator

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -39,7 +39,21 @@ enum MediaDescription {
     }
     
     private static func formattedDate(for media: SRGMedia) -> String {
-        return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
+        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+            return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
+        }
+        else {
+            return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
+        }
+    }
+    
+    private static func formattedShortDate(for media: SRGMedia) -> String {
+        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+            return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
+        }
+        else {
+            return DateFormatter.play_relativeShortDate.string(from: media.date)
+        }
     }
     
     private static func formattedTime(for media: SRGMedia) -> String {
@@ -75,7 +89,7 @@ enum MediaDescription {
                 }
                 else {
                     // Unbreakable spaces before / after the separator
-                    return "\(show.title) · \(DateFormatter.play_relativeShortDate.string(from: media.date))"
+                    return "\(show.title) · \(formattedShortDate(for: media))"
                 }
             }
             else {
@@ -116,14 +130,20 @@ enum MediaDescription {
     }
     
     static func availability(for media: SRGMedia) -> String {
-        let publication = publication(for: media)
+        var values: [String] = []
+        
+        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+            values.append(NSLocalizedString("Web first", comment: "Short label identifying a web first content."))
+        }
+        
+        values.append(publication(for: media))
+        
         if shouldDisplayExpiration(for: media), let expiration = expiration(for: media) {
-            // Unbreakable spaces before / after the separator
-            return "\(publication) - \(expiration)"
+            values.append(expiration)
         }
-        else {
-            return publication
-        }
+        
+        // Unbreakable spaces before / after the separator
+        return values.joined(separator: " - ")
     }
     
     static func accessibilityLabel(for media: SRGMedia) -> String? {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -149,8 +149,7 @@ enum MediaDescription {
         if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
             values.append(NSLocalizedString("Web first", comment: "Short label identifying a web first content."))
         }
-        
-        if shouldDisplayPublication(for: media) {
+        else if shouldDisplayPublication(for: media) {
             values.append(publication(for: media))
         }
         

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -132,6 +132,8 @@ enum MediaDescription {
     private static func shouldDisplayPublication(for media: SRGMedia) -> Bool {
         let now = Date()
         return media.timeAvailability(at: now) != .notYetAvailable
+        && media.contentType != .livestream
+        && !(media.contentType == .scheduledLivestream && media.timeAvailability(at: now) == .available)
     }
     
     private static func publication(for media: SRGMedia) -> String {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -6,8 +6,7 @@
 
 import SRGAppearanceSwift
 
-@objcMembers
-class MediaDescription: NSObject {
+@objc class MediaDescription: NSObject {
     override init() {
         fatalError("init() is not available")
     }
@@ -73,7 +72,7 @@ class MediaDescription: NSObject {
         return media.duration / 1000
     }
     
-    static func availability(for media: SRGMedia) -> String {
+    @objc static func availability(for media: SRGMedia) -> String {
         var values: [String] = []
         
         if let date = formattedDate(for: media, style: .shortDateAndTime) {
@@ -107,7 +106,7 @@ class MediaDescription: NSObject {
         }
     }
     
-    static func availabilityAccessibilityLabel(for media: SRGMedia) -> String {
+    @objc static func availabilityAccessibilityLabel(for media: SRGMedia) -> String {
         var values: [String] = []
         
         if let date = formattedDate(for: media, style: .shortDateAndTime, accessiblityLabel: true) {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -38,36 +38,25 @@ enum MediaDescription {
         }
     }
     
-    private static func formattedDate(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst {
-            return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
-        }
-        else if shouldDisplayPublication(for: media) {
-            return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
-        }
-        else {
-            return nil
-        }
+    private enum DateStyle {
+        case date
+        case shortDate
+        case shortDateAndTime
     }
     
-    private static func formattedShortDate(for media: SRGMedia) -> String? {
+    private static func formattedDate(for media: SRGMedia, style: DateStyle = .date) -> String? {
         if media.play_isWebFirst {
             return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
-            return DateFormatter.play_relativeShortDate.string(from: media.date)
-        }
-        else {
-            return nil
-        }
-    }
-    
-    private static func formattedShortDateAndTime(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst {
-            return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
-        }
-        else if shouldDisplayPublication(for: media) {
-            return DateFormatter.play_shortDateAndTime.string(from: media.date)
+            switch style {
+            case .date:
+                return DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
+            case .shortDate:
+                return DateFormatter.play_relativeShortDate.string(from: media.date)
+            case .shortDateAndTime:
+                return DateFormatter.play_shortDateAndTime.string(from: media.date)
+            }
         }
         else {
             return nil
@@ -105,7 +94,7 @@ enum MediaDescription {
                 if areRedundant(media: media, show: show) {
                     return show.title
                 }
-                else if let publicationDate = formattedShortDate(for: media) {
+                else if let publicationDate = formattedDate(for: media, style: .shortDate) {
                     // Unbreakable spaces before / after the separator
                     return "\(show.title) · \(publicationDate)"
                 }
@@ -149,7 +138,7 @@ enum MediaDescription {
     }
     
     private static func publication(for media: SRGMedia) -> String? {
-        return formattedShortDateAndTime(for: media)
+        return formattedDate(for: media, style: .shortDateAndTime)
     }
     
     private static func expiration(for media: SRGMedia) -> String? {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -183,7 +183,7 @@ enum MediaDescription {
                         color: .srgLightRed
                     )
                 }
-                else if media.play_isWebFirst {
+                else if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeHidden {
                     return BadgeProperties(
                         text: NSLocalizedString("Web first", comment: "Short label identifying a web first content."),
                         color: .srgDarkRed

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -109,11 +109,11 @@ import SRGAppearanceSwift
     @objc static func availabilityAccessibilityLabel(for media: SRGMedia) -> String {
         var values: [String] = []
         
-        if let date = formattedDate(for: media, style: .shortDateAndTime, accessiblityLabel: true) {
+        if let date = formattedDate(for: media, style: .shortDateAndTime, accessibilityLabel: true) {
             values.append(date)
         }
         
-        if let expirationDate = formattedExpirationDate(for: media, accessiblityLabel: true) {
+        if let expirationDate = formattedExpirationDate(for: media, accessibilityLabel: true) {
             values.append(expirationDate)
         }
         
@@ -208,22 +208,22 @@ import SRGAppearanceSwift
         case shortDateAndTime
     }
     
-    private static func formattedDate(for media: SRGMedia, style: DateStyle = .date, accessiblityLabel: Bool = false) -> String? {
+    private static func formattedDate(for media: SRGMedia, style: DateStyle = .date, accessibilityLabel: Bool = false) -> String? {
         if media.play_isWebFirst {
             return NSLocalizedString("In advance", comment: "Short text replacing date for a web first content.")
         }
         else if shouldDisplayDate(for: media) {
             switch style {
             case .date:
-                return accessiblityLabel
+                return accessibilityLabel
                 ? PlayAccessibilityRelativeDateFromDate(media.date)
                 : DateFormatter.play_relativeDate.string(from: media.date).capitalizedFirstLetter
             case .shortDate:
-                return accessiblityLabel
+                return accessibilityLabel
                 ? PlayAccessibilityRelativeDateFromDate(media.date)
                 : DateFormatter.play_relativeShortDate.string(from: media.date)
             case .shortDateAndTime:
-                return accessiblityLabel
+                return accessibilityLabel
                 ? PlayAccessibilityDateAndTimeFromDate(media.date)
                 : DateFormatter.play_shortDateAndTime.string(from: media.date)
             }
@@ -233,9 +233,9 @@ import SRGAppearanceSwift
         }
     }
     
-    private static func formattedExpirationDate(for media: SRGMedia, accessiblityLabel: Bool = false) -> String? {
+    private static func formattedExpirationDate(for media: SRGMedia, accessibilityLabel: Bool = false) -> String? {
         guard let endDate = media.endDate, shouldDisplayExpirationDate(for: media) else { return nil }
-        let dateString = accessiblityLabel
+        let dateString = accessibilityLabel
         ? PlayAccessibilityDateFromDate(endDate)
         : DateFormatter.play_shortDate.string(from: endDate)
         return String(format: NSLocalizedString("Available until %@", comment: "Availability until date, specified as parameter"), dateString)

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -39,7 +39,7 @@ enum MediaDescription {
     }
     
     private static func formattedDate(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
             return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
@@ -51,7 +51,7 @@ enum MediaDescription {
     }
     
     private static func formattedShortDate(for media: SRGMedia) -> String? {
-        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
             return NSLocalizedString("Web first", comment: "Short label identifying a web first content.")
         }
         else if shouldDisplayPublication(for: media) {
@@ -148,7 +148,7 @@ enum MediaDescription {
     static func availability(for media: SRGMedia) -> String {
         var values: [String] = []
         
-        if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+        if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
             values.append(NSLocalizedString("Web first", comment: "Short label identifying a web first content."))
         }
         else if shouldDisplayPublication(for: media) {
@@ -213,7 +213,7 @@ enum MediaDescription {
                         color: .srgLightRed
                     )
                 }
-                else if media.play_isWebFirst && !ApplicationConfiguration.shared.isWebFirstBadgeHidden {
+                else if media.play_isWebFirst && ApplicationConfiguration.shared.isWebFirstBadgeEnabled {
                     return BadgeProperties(
                         text: NSLocalizedString("Web first", comment: "Short label identifying a web first content."),
                         color: .srgDarkRed

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -168,7 +168,7 @@ enum MediaDescription {
                 else {
                     return BadgeProperties(
                         text: NSLocalizedString("Soon", comment: "Short label identifying content which will be available soon."),
-                        color: .play_black80a
+                        color: .srgDarkRed
                     )
                 }
             case .notAvailableAnymore:

--- a/Application/Sources/UI/Views/Badges.swift
+++ b/Application/Sources/UI/Views/Badges.swift
@@ -27,7 +27,6 @@ struct Badge: View {
     var body: some View {
         Text(text)
             .srgFont(.label)
-            .textCase(.uppercase)
             .lineLimit(1)
             .truncationMode(.head)
             .foregroundColor(textColor)

--- a/Application/Sources/UI/Views/DownloadCell.swift
+++ b/Application/Sources/UI/Views/DownloadCell.swift
@@ -163,7 +163,7 @@ private extension DownloadCell {
     var accessibilityLabel: String? {
         guard let download else { return nil }
         if let media = download.media {
-            return MediaDescription.accessibilityLabel(for: media)
+            return MediaDescription.cellAccessibilityLabel(for: media)
         }
         else {
             return download.title

--- a/Application/Sources/UI/Views/FeaturedDescriptionView.swift
+++ b/Application/Sources/UI/Views/FeaturedDescriptionView.swift
@@ -43,7 +43,7 @@ struct FeaturedDescriptionView<Content: FeaturedContent>: View {
         VStack(alignment: stackAlignment, spacing: 6) {
             HStack(spacing: constant(iOS: 8, tvOS: 12)) {
                 if let label = content.label {
-                    Badge(text: label, color: Color(.play_green))
+                    Badge(text: label, color: Color(.srgDarkRed))
                 }
                 if let introduction = content.introduction {
                     Text(introduction)

--- a/Application/Sources/UI/Views/HeroMediaCell.swift
+++ b/Application/Sources/UI/Views/HeroMediaCell.swift
@@ -96,7 +96,7 @@ struct HeroMediaCell: View {
             VStack {
                 HStack(spacing: constant(iOS: 8, tvOS: 12)) {
                     if let label {
-                        Badge(text: label, color: Color(.play_green))
+                        Badge(text: label, color: Color(.srgDarkRed))
                     }
                     if let subtitle {
                         Text(subtitle)

--- a/Application/Sources/UI/Views/HeroMediaCell.swift
+++ b/Application/Sources/UI/Views/HeroMediaCell.swift
@@ -124,7 +124,7 @@ struct HeroMediaCell: View {
 private extension HeroMediaCell {
     var accessibilityLabel: String? {
         guard let media else { return nil }
-        return MediaDescription.accessibilityLabel(for: media)
+        return MediaDescription.cellAccessibilityLabel(for: media)
     }
     
     var accessibilityHint: String? {

--- a/Application/Sources/UI/Views/LiveMediaCellViewModel.swift
+++ b/Application/Sources/UI/Views/LiveMediaCellViewModel.swift
@@ -118,7 +118,7 @@ extension LiveMediaCellViewModel {
             return label
         }
         else if let media {
-            return MediaDescription.accessibilityLabel(for: media)
+            return MediaDescription.cellAccessibilityLabel(for: media)
         }
         else {
             return nil

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -181,7 +181,7 @@ struct MediaCell: View {
         }
         
         private var bottomPadding: CGFloat {
-            // Allow 3 lines for titles, with a badge and no subtitles
+            // Allow 3 lines for title, with a badge and no subtitles
             return embeddedDirection == .horizontal ? -2 : 0
         }
         

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -181,7 +181,7 @@ struct MediaCell: View {
         }
         
         private var bottomPadding: CGFloat {
-            // Allow 3 lines for titles, badges and no subtitles
+            // Allow 3 lines for titles, with a badge and no subtitles
             return embeddedDirection == .horizontal ? -2 : 0
         }
         

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -180,6 +180,11 @@ struct MediaCell: View {
             }
         }
         
+        private var bottomPadding: CGFloat {
+            // Allow 3 lines for titles, badges and no subtitles
+            return embeddedDirection == .horizontal ? -2 : 0
+        }
+        
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
                 if embeddedDirection == .horizontal, let properties = availabilityBadgeProperties {
@@ -207,6 +212,7 @@ struct MediaCell: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.bottom, bottomPadding)
         }
     }
 }

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -232,7 +232,7 @@ extension MediaCell {
 private extension MediaCell {
     var accessibilityLabel: String? {
         guard let media else { return nil }
-        return MediaDescription.accessibilityLabel(for: media)
+        return MediaDescription.cellAccessibilityLabel(for: media)
     }
     
     var accessibilityHint: String? {

--- a/Application/Sources/UI/Views/MediaCell.swift
+++ b/Application/Sources/UI/Views/MediaCell.swift
@@ -148,7 +148,7 @@ struct MediaCell: View {
             return MediaDescription.subtitle(for: media, style: mediaDescriptionStyle)
         }
         
-        private var title: String {
+        private var title: String? {
             guard let media else { return .placeholder(length: 8) }
             return MediaDescription.title(for: media, style: mediaDescriptionStyle)
         }
@@ -192,11 +192,13 @@ struct MediaCell: View {
                         .lineLimit(2)
                         .foregroundColor(.srgGray96)
                 }
-                Text(title)
-                    .srgFont(.H4)
-                    .lineLimit(titleLineLimit)
-                    .foregroundColor(.srgGrayC7)
-                    .layoutPriority(1)
+                if let title {
+                    Text(title)
+                        .srgFont(.H4)
+                        .lineLimit(titleLineLimit)
+                        .foregroundColor(.srgGrayC7)
+                        .layoutPriority(1)
+                }
                 if let summary {
                     Text(summary)
                         .srgFont(.body)

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -98,7 +98,7 @@ struct MediaDetailView: View {
         
         private var availabilityBadgeProperties: MediaDescription.BadgeProperties? {
             guard let media = model.media else { return nil }
-            return MediaDescription.availabilityBadgeProperties(for: media, allowsDateDisplay: false)
+            return MediaDescription.availabilityBadgeProperties(for: media)
         }
         
         var body: some View {

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -96,6 +96,11 @@ struct MediaDetailView: View {
             return MediaDescription.availability(for: media)
         }
         
+        private var availabilityInformationAccessibilityLabel: String? {
+            guard let media = model.media else { return nil }
+            return MediaDescription.availabilityAccessibilityLabel(for: media)
+        }
+        
         private var availabilityBadgeProperties: MediaDescription.BadgeProperties? {
             guard let media = model.media else { return nil }
             return MediaDescription.availabilityBadgeProperties(for: media)
@@ -108,6 +113,7 @@ struct MediaDetailView: View {
                         .srgFont(.subtitle2)
                         .foregroundColor(.white)
                         .padding(.vertical, 5)
+                        .accessibilityElement(label: availabilityInformationAccessibilityLabel)
                 }
                 if let properties = availabilityBadgeProperties {
                     Badge(text: properties.text, color: Color(properties.color))

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -103,10 +103,12 @@ struct MediaDetailView: View {
         
         var body: some View {
             HStack(spacing: 20) {
-                Text(availabilityInformation)
-                    .srgFont(.subtitle2)
-                    .foregroundColor(.white)
-                    .padding(.vertical, 5)
+                if !availabilityInformation.isEmpty {
+                    Text(availabilityInformation)
+                        .srgFont(.subtitle2)
+                        .foregroundColor(.white)
+                        .padding(.vertical, 5)
+                }
                 if let properties = availabilityBadgeProperties {
                     Badge(text: properties.text, color: Color(properties.color))
                 }

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -308,6 +308,9 @@
 /* Image copyright introductory label */
 "Image credit: %@" = "Image credit: %@";
 
+/* Short text replacing date for a web first content. */
+"In advance" = "In advance";
+
 /* Information section header */
 "Information" = "Information";
 

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -568,9 +568,6 @@
 /* Search setting */
 "Relevance" = "Relevance";
 
-/* Short label identifying a replay sport event. Display in uppercase. */
-"Replay" = "Replay";
-
 /* Label of the button to present technical issue report instructions
    Label to present technical issue report instructions
    Subject of the technical issue mail */

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -651,9 +651,6 @@
 /* Title of the button to skip updating the application */
 "Skip" = "Skip";
 
-/* Short label identifying content which will be available soon. */
-"Soon" = "Soon";
-
 /* Search setting */
 "Sort by" = "Sort by";
 

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -156,4 +156,4 @@ Feeds
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
 * `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
-* `webFirstBadgeHidden` (optional, boolean): Set to `true` to hide the web first badge on media. Only display the label as a text.
+* `webFirstBadgeEnabled` (optional, boolean): Set to `true` to display the web first badge on media. Only display the label as a text.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -156,3 +156,4 @@ Feeds
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
 * `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
+* `webFirstBadgeHidden` (optional, boolean): Set to `true` to hide the web first badge on media. Only display the label as a text.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -156,4 +156,4 @@ Feeds
 * `showsUnavailable` (optional, boolean): If set to `true`, all features related to shows are removed.
 * `subtitleAvailabilityHidden` (optional, boolean): Set to `true` to hide the subtitle availability setting.
 * `discoverySubtitleOptionLanguage` (optional, string): Set system subtitle language to this value once and at the beginning to help user discover that content is subtitled in that language.
-* `webFirstBadgeEnabled` (optional, boolean): Set to `true` to display the web first badge on media. Only display the label as a text.
+* `webFirstBadgeEnabled` (optional, boolean): Set to `true` to display the web first badge on media.


### PR DESCRIPTION
### Motivation and Context

After user tests, update badges color.
Align with the Play SRG web version. 

### Description

- Update badges colors:
  - Update web first badge color to dark red.
  - Update upcoming badge color to black.
  - Update featured badge color to dark red.
- Change badge font to lowercase.
- Remove "soon" badge in media detail pages.
- [Transition] Add remote configuration `webFirstBadgeEnabled` property to display the web first badges on media items.
- Around badges:
  - Remove duplicate date and time when upcoming badge is displayed (media items, media detail pages). ie like upcoming livestream events.
  - Replace web first future date with "in advance" text.
  - In vertical list, media item can display 3 lines for titles, with a badge and no subtitles.
 - Cleanup `MediaDescription` and expose it to Objective-C code so that duplicate logics can be removed on metadata information.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
