### PR TITLE
Reduce display of user consent banner when travelling outside Switzerland

### DIFF
--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -428,8 +428,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk",
       "state" : {
-        "revision" : "a0987154857d372be3e90458296825fa594e1b0c",
-        "version" : "2.11.1"
+        "revision" : "c2b0202dcaaf7e81c32c4fb715f31a4984752c83",
+        "version" : "2.12.0"
       }
     },
     {


### PR DESCRIPTION
### Motivation and Context

The third parts SDK for user consent as been updated and now it saves the user choices per configurations.
Applications have two configurations, CH and WW.

### Description

- Update UserCentrics to version [2.12.0](https://usercentrics.com/docs/apps/releases/).

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
