### PR TITLE
Fix rotation crash on iPad

### DIFF
--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -136,7 +136,7 @@ class PageContainerViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
         
         coordinator.animate(alongsideTransition: { _ in
-            // viewWillTransition(to:with:) could be called before controller view is laoded.
+            // viewWillTransition(to:with:) could be called before controller view is loaded.
             if self.tabBar != nil {
                 // Force a refresh of the tab bar so that the alignment is correct after rotation
                 self.tabBar.alignment = .leading

--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -136,9 +136,12 @@ class PageContainerViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
         
         coordinator.animate(alongsideTransition: { _ in
-            // Force a refresh of the tab bar so that the alignment is correct after rotation
-            self.tabBar.alignment = .leading
-            self.tabBar.alignment = .center
+            // viewWillTransition(to:with:) could be called before controller view is laoded.
+            if self.tabBar != nil {
+                // Force a refresh of the tab bar so that the alignment is correct after rotation
+                self.tabBar.alignment = .leading
+                self.tabBar.alignment = .center
+            }
         }, completion: nil)
     }
     


### PR DESCRIPTION
### Motivation and Context

The following last swift conversion #430 introduced `!` on controller view properties.
A rotation on iPad calls `viewWillTransition(to:with:)` even the view is not loaded.

### Description

- Fix with a test condition.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
