### PR TITLE
Use object vendor for requests

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -393,15 +393,14 @@ private extension Content {
         
         func publisher(pageSize: UInt, paginatedBy paginator: Trigger.Signal?, filter: SectionFiltering?) -> AnyPublisher<[Content.Item], Error> {
             let dataProvider = SRGDataProvider.current!
-            let vendor = ApplicationConfiguration.shared.vendor
             
             switch contentSection.type {
             case .medias:
-                return dataProvider.medias(for: vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
+                return dataProvider.medias(for: contentSection.vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
                     .map { self.filterItems($0).map { .media($0) } }
                     .eraseToAnyPublisher()
             case .showAndMedias:
-                return dataProvider.showAndMedias(for: vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
+                return dataProvider.showAndMedias(for: contentSection.vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
                     .map {
                         var items = [Content.Item]()
                         if let show = $0.show {
@@ -412,7 +411,7 @@ private extension Content {
                     }
                     .eraseToAnyPublisher()
             case .shows:
-                return dataProvider.shows(for: vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
+                return dataProvider.shows(for: contentSection.vendor, contentSectionUid: contentSection.uid, pageSize: pageSize, paginatedBy: paginator)
                     .map { self.filterItems($0).map { .show($0) } }
                     .eraseToAnyPublisher()
             case .predefined:
@@ -428,11 +427,11 @@ private extension Content {
                         .map { $0.map { .media($0) } }
                         .eraseToAnyPublisher()
                 case .livestreams:
-                    return dataProvider.tvLivestreams(for: vendor)
+                    return dataProvider.tvLivestreams(for: contentSection.vendor)
                         .map { $0.map { .media($0) } }
                         .eraseToAnyPublisher()
                 case .topicSelector:
-                    return dataProvider.tvTopics(for: vendor)
+                    return dataProvider.tvTopics(for: contentSection.vendor)
                         .map { $0.map { .topic($0) } }
                         .eraseToAnyPublisher()
                 case .continueWatching:

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -492,12 +492,12 @@ private extension PageViewModel {
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .topic(topic):
-            return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, topicWithUrn: topic.urn)
+            return SRGDataProvider.current!.contentPage(for: topic.vendor, topicWithUrn: topic.urn)
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .show(show):
             if show.transmission == .TV && !ApplicationConfiguration.shared.isPredefinedShowPagePreferred {
-                return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
+                return SRGDataProvider.current!.contentPage(for: show.vendor, product: show.transmission == .radio ? .playAudio : .playVideo, showWithUrn: show.urn)
                     .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0, show: show), index: $1) }) }
                     .eraseToAnyPublisher()
             }
@@ -507,7 +507,7 @@ private extension PageViewModel {
                     .eraseToAnyPublisher()
             }
         case let .page(page):
-            return SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, uid: page.uid)
+            return SRGDataProvider.current!.contentPage(for: page.vendor, uid: page.uid)
                 .map { Page(uid: $0.uid, sections: $0.sections.enumeratedMap { Section(.content($0), index: $1) }) }
                 .eraseToAnyPublisher()
         case let .audio(channel: channel):


### PR DESCRIPTION
### Motivation and Context

Testing #431 across BU builds, the page can be load, but not the content.
Like Play web and Play Android, use the object vendor when available instead of the application configured vendor.

### Description

For requests, if available:
- Use content vendor (page and section).
- Use show vendor.
- Use topic vendor.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
