### PR TITLE
Sort user latest episodes by web publication date

### DIFF
--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -33,7 +33,7 @@ extension SRGDataProvider {
             }
             .reduce([]) { $0 + $1 }
             .map { medias in
-                return Array(medias.sorted(by: { $0.date > $1.date }).prefix(Int(pageSize)))
+                return Array(medias.sorted(by: { $0.publicationDate > $1.publicationDate }).prefix(Int(pageSize)))
             }
             .eraseToAnyPublisher()
     }

--- a/Application/Sources/Helpers/Extensions/SRGMedia+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/SRGMedia+PlaySRG.swift
@@ -72,4 +72,8 @@ extension SRGMedia {
     private var play_audioVariants: [SRGVariant] {
         return audioVariants(for: recommendedAudioVariantSource) ?? []
     }
+    
+    var publicationDate: Date {
+        return startDate ?? date
+    }
 }


### PR DESCRIPTION
### Motivation and Context

**As** a user who added shows to my favorites
**I want** to see on homepage latest published episodes from the web publication date, not broadcast date
**so that** I don’t have “web first” episodes days or weeks in first elements displayed in my user media list swimlane.

### Description

- Set a `publicationDate` for media: `media.startDate` if exists, otherwise `media.date`.
- For the “my program” content section, sort episodes with this descending `publicationDate`, instead of the descending `media.date`.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
