### PR TITLE
Connect non-production builds to Play web staging domain

### DIFF
--- a/Xcode/Shared/BUs/RSI.xcconfig
+++ b/Xcode/Shared/BUs/RSI.xcconfig
@@ -7,11 +7,11 @@ BU__BUNDLE_IDENTIFIER_PREFIX[config=Nightly] = ch.srgssr.
 BU__BUNDLE_IDENTIFIER_PREFIX[config=Debug] = ch.srgssr.
 BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rsi.ch
-BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
-BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rsi.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
-BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rsi.test.srf.ch
-BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
+BU__DOMAIN[config=Beta] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Beta_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-staging.herokuapp.com
 BU__IDENTIFIER = rsi
 BU__PRODUCT_NAME = Play RSI
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RSI.xcconfig
+++ b/Xcode/Shared/BUs/RSI.xcconfig
@@ -11,7 +11,7 @@ BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rsi.stage.srf.ch
 BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rsi.test.srf.ch
-BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
 BU__IDENTIFIER = rsi
 BU__PRODUCT_NAME = Play RSI
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RSI.xcconfig
+++ b/Xcode/Shared/BUs/RSI.xcconfig
@@ -9,7 +9,7 @@ BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rsi.ch
 BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rsi.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rsi.test.srf.ch
 BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
 BU__IDENTIFIER = rsi

--- a/Xcode/Shared/BUs/RTR.xcconfig
+++ b/Xcode/Shared/BUs/RTR.xcconfig
@@ -7,11 +7,11 @@ BU__BUNDLE_IDENTIFIER_PREFIX[config=Nightly] = ch.srgssr.
 BU__BUNDLE_IDENTIFIER_PREFIX[config=Debug] = ch.srgssr.
 BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rtr.ch
-BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
-BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rtr.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
-BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rtr.test.srf.ch
-BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
+BU__DOMAIN[config=Beta] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Beta_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-staging.herokuapp.com
 BU__IDENTIFIER = rtr
 BU__PRODUCT_NAME = Play RTR
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RTR.xcconfig
+++ b/Xcode/Shared/BUs/RTR.xcconfig
@@ -9,7 +9,7 @@ BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rtr.ch
 BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rtr.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rtr.test.srf.ch
 BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
 BU__IDENTIFIER = rtr

--- a/Xcode/Shared/BUs/RTR.xcconfig
+++ b/Xcode/Shared/BUs/RTR.xcconfig
@@ -11,7 +11,7 @@ BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rtr.stage.srf.ch
 BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rtr.test.srf.ch
-BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
 BU__IDENTIFIER = rtr
 BU__PRODUCT_NAME = Play RTR
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RTS.xcconfig
+++ b/Xcode/Shared/BUs/RTS.xcconfig
@@ -7,11 +7,11 @@ BU__BUNDLE_IDENTIFIER_PREFIX[config=Nightly] = ch.srgssr.
 BU__BUNDLE_IDENTIFIER_PREFIX[config=Debug] = ch.srgssr.
 BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rts.ch
-BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
-BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rts.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
-BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rts.test.srf.ch
-BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
+BU__DOMAIN[config=Beta] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Beta_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-staging.herokuapp.com
 BU__IDENTIFIER = rts
 BU__PRODUCT_NAME = Play RTS
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RTS.xcconfig
+++ b/Xcode/Shared/BUs/RTS.xcconfig
@@ -11,7 +11,7 @@ BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rts.stage.srf.ch
 BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rts.test.srf.ch
-BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
 BU__IDENTIFIER = rts
 BU__PRODUCT_NAME = Play RTS
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/RTS.xcconfig
+++ b/Xcode/Shared/BUs/RTS.xcconfig
@@ -9,7 +9,7 @@ BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.rts.ch
 BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-rts.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-rts.test.srf.ch
 BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
 BU__IDENTIFIER = rts

--- a/Xcode/Shared/BUs/SRF.xcconfig
+++ b/Xcode/Shared/BUs/SRF.xcconfig
@@ -7,11 +7,11 @@ BU__BUNDLE_IDENTIFIER_PREFIX[config=Nightly] = ch.srgssr.
 BU__BUNDLE_IDENTIFIER_PREFIX[config=Debug] = ch.srgssr.
 BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.srf.ch
-BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
-BU__DOMAIN[config=Beta_AppCenter] = srgplayer-srf.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
-BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-srf.test.srf.ch
-BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
+BU__DOMAIN[config=Beta] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Beta_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-staging.herokuapp.com
 BU__IDENTIFIER = srf
 BU__PRODUCT_NAME = Play SRF
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/SRF.xcconfig
+++ b/Xcode/Shared/BUs/SRF.xcconfig
@@ -9,7 +9,7 @@ BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application.entitlements
 BU__DOMAIN = *.srf.ch
 BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-srf.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-srf.test.srf.ch
 BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
 BU__IDENTIFIER = srf

--- a/Xcode/Shared/BUs/SRF.xcconfig
+++ b/Xcode/Shared/BUs/SRF.xcconfig
@@ -11,7 +11,7 @@ BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-srf.stage.srf.ch
 BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-srf.test.srf.ch
-BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
 BU__IDENTIFIER = srf
 BU__PRODUCT_NAME = Play SRF
 BU__TV_TOP_SHELF_CONTENT_REQUEST = popular_shows

--- a/Xcode/Shared/BUs/SWI.xcconfig
+++ b/Xcode/Shared/BUs/SWI.xcconfig
@@ -7,11 +7,11 @@ BU__BUNDLE_IDENTIFIER_PREFIX[config=Nightly] = ch.srgssr.
 BU__BUNDLE_IDENTIFIER_PREFIX[config=Debug] = ch.srgssr.
 BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application-without-CarPlay.entitlements
 BU__DOMAIN = *.swissinfo.ch
-BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
-BU__DOMAIN[config=Beta_AppCenter] = srgplayer-swi.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
-BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-swi.test.srf.ch
-BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
+BU__DOMAIN[config=Beta] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Beta_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Nightly_AppCenter] = play-web-staging.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-staging.herokuapp.com
 BU__IDENTIFIER = swi
 BU__PRODUCT_NAME = Play SWI
 BU__TV_TOP_SHELF_CONTENT_REQUEST = all_shows

--- a/Xcode/Shared/BUs/SWI.xcconfig
+++ b/Xcode/Shared/BUs/SWI.xcconfig
@@ -11,7 +11,7 @@ BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-swi.stage.srf.ch
 BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-swi.test.srf.ch
-BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Debug] = play-web-pr-1251.herokuapp.com
 BU__IDENTIFIER = swi
 BU__PRODUCT_NAME = Play SWI
 BU__TV_TOP_SHELF_CONTENT_REQUEST = all_shows

--- a/Xcode/Shared/BUs/SWI.xcconfig
+++ b/Xcode/Shared/BUs/SWI.xcconfig
@@ -9,7 +9,7 @@ BU__CODE_SIGN_ENTITLEMENTS_IOS_APP_FILE_NAME = Application-without-CarPlay.entit
 BU__DOMAIN = *.swissinfo.ch
 BU__DOMAIN[config=Beta] = play-mmf.herokuapp.com
 BU__DOMAIN[config=Beta_AppCenter] = srgplayer-swi.stage.srf.ch
-BU__DOMAIN[config=Nightly] = play-mmf.herokuapp.com
+BU__DOMAIN[config=Nightly] = play-web-pr-1251.herokuapp.com
 BU__DOMAIN[config=Nightly_AppCenter] = srgplayer-swi.test.srf.ch
 BU__DOMAIN[config=Debug] = play-mmf.herokuapp.com
 BU__IDENTIFIER = swi


### PR DESCRIPTION
### Motivation and Context

To test Apple universal links, iOS builds needs a domain with can answer to `.well-known/apple-app-site-association`.

For easier tests with web urls, connect `Debug`, `Nightly` and private `Beta` to Play web non production version. Thanks to https://github.com/mmz-srf/play-web/pull/1251.

### Description

- Update `BU__DOMAIN` for `Debug`, `Nightly` and private `Beta` build configurations.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
