### PR TITLE
Crash when opening audio channel view from media player view

### DIFF
--- a/Application/Sources/RadioChannels/RadioChannelsViewController.swift
+++ b/Application/Sources/RadioChannels/RadioChannelsViewController.swift
@@ -73,8 +73,8 @@ extension RadioChannelsViewController: PlayApplicationNavigation {
     func open(_ applicationSectionInfo: ApplicationSectionInfo) -> Bool {
         guard let radioChannel = applicationSectionInfo.radioChannel else { return false }
         
-        if let radioChannelViewController = viewControllers.first(where: { ($0 as? PageViewController)?.radioChannel == radioChannel }) as? UIViewController & PlayApplicationNavigation {
-            let pageIndex = viewControllers.firstIndex(of: radioChannelViewController)!
+        if let radioChannelViewController = viewControllers.first(where: { ($0 as? PageViewController)?.radioChannel == radioChannel }) as? UIViewController & PlayApplicationNavigation,
+           let pageIndex = viewControllers.firstIndex(of: radioChannelViewController) {
             _ = self.switchToIndex(pageIndex, animated: false)
             
             return radioChannelViewController.open(applicationSectionInfo)

--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -177,7 +177,7 @@ class PageContainerViewController: UIViewController {
         }
     }
     
-    func displayPage(at index: Int, animated: Bool) -> Bool {
+    private func displayPage(at index: Int, animated: Bool) -> Bool {
         guard index < viewControllers.count else { return false }
         
         if self.isViewLoaded {
@@ -200,7 +200,7 @@ class PageContainerViewController: UIViewController {
         }
     }
     
-    func updateFonts() {
+    private func updateFonts() {
         let tabBarFont = SRGFont.font(.body) as UIFont
         tabBar.unselectedItemTitleFont = tabBarFont
         tabBar.selectedItemTitleFont = tabBarFont

--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -9,7 +9,8 @@ import SRGAppearance
 
 class PageContainerViewController: UIViewController {
     let viewControllers: [UIViewController]
-    let initialPage: Int
+    
+    private(set) var initialPage: Int
     
     private var pageViewController: UIPageViewController
     
@@ -137,7 +138,7 @@ class PageContainerViewController: UIViewController {
         
         coordinator.animate(alongsideTransition: { _ in
             // viewWillTransition(to:with:) could be called before controller view is loaded.
-            if self.tabBar != nil {
+            if self.isViewLoaded {
                 // Force a refresh of the tab bar so that the alignment is correct after rotation
                 self.tabBar.alignment = .leading
                 self.tabBar.alignment = .center
@@ -162,25 +163,41 @@ class PageContainerViewController: UIViewController {
     }
     
     func switchToIndex(_ index: Int, animated: Bool) -> Bool {
-        guard displayPage(at: index, animated: animated) else { return false }
+        guard index < viewControllers.count else { return false }
         
-        tabBar.setSelectedItem(tabBar.items[index], animated: animated)
-        return true
+        if self.isViewLoaded {
+            guard displayPage(at: index, animated: animated) else { return false }
+            
+            tabBar.setSelectedItem(tabBar.items[index], animated: animated)
+            return true
+        }
+        else {
+            initialPage = index
+            return true
+        }
     }
     
     func displayPage(at index: Int, animated: Bool) -> Bool {
         guard index < viewControllers.count else { return false }
         
-        let currentViewController = pageViewController.viewControllers!.first!
-        let currentIndex = viewControllers.firstIndex(of: currentViewController)!
-        let direction: UIPageViewController.NavigationDirection = index > currentIndex ? .forward : .reverse
-        
-        let newViewController = viewControllers[index]
-        pageViewController.setViewControllers([newViewController], direction: direction, animated: animated)
-        self.play_setNeedsScrollableViewUpdate()
-        
-        didDisplayViewController(newViewController, animated: animated)
-        return true
+        if self.isViewLoaded {
+            var direction: UIPageViewController.NavigationDirection = .forward
+            if let currentViewController = pageViewController.viewControllers?.first {
+                let currentIndex = viewControllers.firstIndex(of: currentViewController)!
+                direction = index > currentIndex ? .forward : .reverse
+            }
+            
+            let newViewController = viewControllers[index]
+            pageViewController.setViewControllers([newViewController], direction: direction, animated: animated)
+            self.play_setNeedsScrollableViewUpdate()
+            
+            didDisplayViewController(newViewController, animated: animated)
+            return true
+        }
+        else {
+            initialPage = index
+            return true
+        }
     }
     
     func updateFonts() {


### PR DESCRIPTION
### Motivation and Context

Following Swift conversion #430 , some crashes appeared.
This PR would like to fix #440.

### Description

- Remove forced unwrap values.
- Check that the `pageViewController` view is loaded, otherwise, update the `initialPage` index. 

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
