### PR TITLE
Support optional media from iOS media player view

### DIFF
--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -72,7 +72,9 @@ import SRGAppearanceSwift
         return media.duration / 1000
     }
     
-    @objc static func availability(for media: SRGMedia) -> String {
+    @objc static func availability(for media: SRGMedia?) -> String? {
+        guard let media else { return nil }
+        
         var values: [String] = []
         
         if let date = formattedDate(for: media, style: .shortDateAndTime) {
@@ -106,7 +108,9 @@ import SRGAppearanceSwift
         }
     }
     
-    @objc static func availabilityAccessibilityLabel(for media: SRGMedia) -> String {
+    @objc static func availabilityAccessibilityLabel(for media: SRGMedia?) -> String? {
+        guard let media else { return nil }
+        
         var values: [String] = []
         
         if let date = formattedDate(for: media, style: .shortDateAndTime, accessibilityLabel: true) {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -72,8 +72,8 @@ import SRGAppearanceSwift
         return media.duration / 1000
     }
     
-    @objc static func availability(for media: SRGMedia?) -> String? {
-        guard let media else { return nil }
+    @objc static func availability(for media: SRGMedia?) -> String {
+        guard let media else { return "" }
         
         var values: [String] = []
         

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -91,7 +91,7 @@ struct MediaDetailView: View {
     private struct AvailabilityView: View {
         @ObservedObject var model: MediaDetailViewModel
         
-        private var availabilityInformation: String? {
+        private var availabilityInformation: String {
             guard let media = model.media else { return .placeholder(length: 15) }
             return MediaDescription.availability(for: media)
         }
@@ -108,7 +108,7 @@ struct MediaDetailView: View {
         
         var body: some View {
             HStack(spacing: 20) {
-                if let availabilityInformation, !availabilityInformation.isEmpty {
+                if !availabilityInformation.isEmpty {
                     Text(availabilityInformation)
                         .srgFont(.subtitle2)
                         .foregroundColor(.white)

--- a/TV Application/Sources/MediaDetailView.swift
+++ b/TV Application/Sources/MediaDetailView.swift
@@ -91,7 +91,7 @@ struct MediaDetailView: View {
     private struct AvailabilityView: View {
         @ObservedObject var model: MediaDetailViewModel
         
-        private var availabilityInformation: String {
+        private var availabilityInformation: String? {
             guard let media = model.media else { return .placeholder(length: 15) }
             return MediaDescription.availability(for: media)
         }
@@ -108,7 +108,7 @@ struct MediaDetailView: View {
         
         var body: some View {
             HStack(spacing: 20) {
-                if !availabilityInformation.isEmpty {
+                if let availabilityInformation, !availabilityInformation.isEmpty {
                     Text(availabilityInformation)
                         .srgFont(.subtitle2)
                         .foregroundColor(.white)


### PR DESCRIPTION
### Motivation and Context

Following Swift conversion #430 , some crashes appeared.
This PR would like to fix #444.

### Description

- Support optional Media parameter on the two `MediaDescription` methods used by the objective-C code.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
