### PR TITLE
Update Swift Package Manager to version 3

### DIFF
--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "80cc5a529f66e851ef52b937b7cb21381c7ec29b972f617c0d477118a0ac3311",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -451,5 +452,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
### Motivation and Context

Xcode 15.3 now uses Swift Package Manager version 3 and an `originHash` hash.

### Description

- Update `Package.resolved` file with Xcode 15.3 constraint.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
