### PR TITLE
Deployment status updated after PR closure

### DIFF
--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -23,8 +23,8 @@ jobs:
         run: |
           AUTHORIZATION="Authorization: token $GITHUB_TOKEN"
           ACCEPT="Accept: application/vnd.github.ant-man-preview+json"
-          PR_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_PR_NUMBER}"
-          DEPLOYMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
+          PR_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$GITHUB_PR_NUMBER"
+          DEPLOYMENTS_URL="https://api.github.com/repos/$GITHUB_REPOSITORY/deployments"
 
           echo "Working with PR URL: $PR_URL"
 

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -1,5 +1,5 @@
 ---
-name: Update deployment status after PR closure
+name: Deployment status after PR closure
 
 on:
   pull_request:

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -26,6 +26,8 @@ jobs:
           PR_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_PR_NUMBER}"
           DEPLOYMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
 
+          echo "Working with PR URL: $PR_URL"
+
           # Get the pull request head branch
           HEAD_BRANCH=$(curl -s -H "$AUTHORIZATION" "$PR_URL" | jq -r '.head.ref')
 
@@ -48,6 +50,9 @@ jobs:
           IOS_ENVIRONMENT=$(echo "playsrg-ios-nightly+$BUILD_NAME" | jq -R -r @uri)
           TVOS_ENVIRONMENT=$(echo "playsrg-tvos-nightly+$BUILD_NAME" | jq -R -r @uri)
 
+          echo "Working with iOS environment: $IOS_ENVIRONMENT"
+          echo "Working with tvOS environment: $TVOS_ENVIRONMENT"
+
           # Get the latest active deployment for iOS
           IOS_DEPLOYMENT=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_URL?environment=$IOS_ENVIRONMENT" | jq '.[0]')
 
@@ -67,6 +72,9 @@ jobs:
           if [ "$IOS_DEPLOYMENT" != "null" ]; then
             DEPLOYMENT_ID=$(echo "$IOS_DEPLOYMENT" | jq -r '.id')
             STATUSES_URL=$(echo "$IOS_DEPLOYMENT" | jq -r '.statuses_url')
+
+            echo "Working with iOS deployment ID: $DEPLOYMENT_ID"
+
             URLS=$(fetch_status_urls "$STATUSES_URL")
             IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
 
@@ -81,15 +89,18 @@ jobs:
             RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
 
             # Output the information
-            echo "Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
+            echo "-> Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
           else
             IOS_ENVIRONMENT=$(printf '%b' "${IOS_ENVIRONMENT//%/\\x}")
-            echo "No deployment for $IOS_ENVIRONMENT environment. No update."
+            echo "-> No deployment for $IOS_ENVIRONMENT environment. No update."
           fi
 
           if [ "$TVOS_DEPLOYMENT" != "null" ]; then
             DEPLOYMENT_ID=$(echo "$TVOS_DEPLOYMENT" | jq -r '.id')
             STATUSES_URL=$(echo "$TVOS_DEPLOYMENT" | jq -r '.statuses_url')
+
+            echo "Working with tvOS deployment ID: $DEPLOYMENT_ID"
+
             URLS=$(fetch_status_urls "$STATUSES_URL")
             IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
 
@@ -104,8 +115,8 @@ jobs:
             RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
 
             # Output the information
-            echo "Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
+            echo "-> Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
           else
             TVOS_ENVIRONMENT=$(printf '%b' "${TVOS_ENVIRONMENT//%/\\x}")
-            echo "No deployment for $TVOS_ENVIRONMENT environment. No update."
+            echo "-> No deployment for $TVOS_ENVIRONMENT environment. No update."
           fi

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -1,5 +1,5 @@
 ---
-name: Deployment status after PR closure
+name: Deployments after PR closure
 
 on:
   pull_request:
@@ -12,7 +12,7 @@ jobs:
       deployments: write
 
     steps:
-      - name: Update deployment status to Inactive
+      - name: Update deployment statuses to Inactive
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -12,9 +12,6 @@ jobs:
       deployments: write
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
       - name: Update deployment status to Inactive
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-deployment:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -1,0 +1,109 @@
+---
+name: Update deployment status after PR closure
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  update-deployment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Update deployment status to Inactive
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          AUTHORIZATION="Authorization: token $GITHUB_TOKEN"
+          ACCEPT="Accept: application/vnd.github.ant-man-preview+json"
+          PR_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${GITHUB_PR_NUMBER}"
+          DEPLOYMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
+
+          # Get the pull request head branch
+          HEAD_BRANCH=$(curl -s -H "$AUTHORIZATION" "$PR_URL" | jq -r '.head.ref')
+
+          if [ "$HEAD_BRANCH" == "null" ]; then
+            echo "No PR available, so no founded environments. Exiting..."
+            exit 0
+          fi
+
+          # Get the pull request state
+          PR_STATE=$(curl -s -H "$AUTHORIZATION" "$PR_URL" | jq -r '.state')
+          if [ "$PR_STATE" != "closed" ]; then
+              echo "PR not closed. Exiting..."
+              exit 0
+          fi
+
+          # Remove "feature/" from the head branch
+          BUILD_NAME=$(echo "$HEAD_BRANCH" | sed 's/feature\///g')
+
+          # Define environment names
+          IOS_ENVIRONMENT=$(echo "playsrg-ios-nightly+$BUILD_NAME" | jq -R -r @uri)
+          TVOS_ENVIRONMENT=$(echo "playsrg-tvos-nightly+$BUILD_NAME" | jq -R -r @uri)
+
+          # Get the latest active deployment for iOS
+          IOS_DEPLOYMENT=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_URL?environment=$IOS_ENVIRONMENT" | jq '.[0]')
+
+          # Get the latest active deployment for tvOS
+          TVOS_DEPLOYMENT=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_URL?environment=$TVOS_ENVIRONMENT" | jq '.[0]')
+
+          # Function to fetch log and environment URLs from status URL
+          fetch_status_urls() {
+            STATUS_URL=$1
+            STATUS_RESPONSE=$(curl -s -H "$AUTHORIZATION" "$STATUS_URL")
+            FIRST_STATUS=$(echo "$STATUS_RESPONSE" | jq -r '.[0]')
+            LOG_URL=$(echo "$FIRST_STATUS" | jq -r '.log_url')
+            ENVIRONMENT_URL=$(echo "$FIRST_STATUS" | jq -r '.environment_url')
+            echo "$LOG_URL,$ENVIRONMENT_URL"
+          }
+
+          if [ "$IOS_DEPLOYMENT" != "null" ]; then
+            DEPLOYMENT_ID=$(echo "$IOS_DEPLOYMENT" | jq -r '.id')
+            STATUSES_URL=$(echo "$IOS_DEPLOYMENT" | jq -r '.statuses_url')
+            URLS=$(fetch_status_urls "$STATUSES_URL")
+            IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
+
+            # Mark the latest deployment for iOS nightly as inactive
+            DEPLOYMENT_URL="$DEPLOYMENTS_URL/$DEPLOYMENT_ID/statuses"
+            BODY="{\"state\": \"inactive\", \"description\": \"The PR is closed.\", \
+              \"log_url\": \"$LOG_URL\", \"environment_url\": \"$ENVIRONMENT_URL\"}"
+            RESPONSE=$(curl -s -X POST -H "$AUTHORIZATION" -H "$ACCEPT" "$DEPLOYMENT_URL" -d "$BODY")
+
+            # Extract information from the response
+            RESPONSE_STATE=$(echo "$RESPONSE" | jq -r '.state')
+            RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
+
+            # Output the information
+            echo "Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
+          else
+            IOS_ENVIRONMENT=$(printf '%b' "${IOS_ENVIRONMENT//%/\\x}")
+            echo "No deployment for $IOS_ENVIRONMENT environment. No update."
+          fi
+
+          if [ "$TVOS_DEPLOYMENT" != "null" ]; then
+            DEPLOYMENT_ID=$(echo "$TVOS_DEPLOYMENT" | jq -r '.id')
+            STATUSES_URL=$(echo "$TVOS_DEPLOYMENT" | jq -r '.statuses_url')
+            URLS=$(fetch_status_urls "$STATUSES_URL")
+            IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
+
+            # Mark the latest deployment for tvOS nightly as inactive
+            DEPLOYMENT_URL="$DEPLOYMENTS_URL/$DEPLOYMENT_ID/statuses"
+            BODY="{\"state\": \"inactive\", \"description\": \"The PR is closed.\", \
+              \"log_url\": \"$LOG_URL\", \"environment_url\": \"$ENVIRONMENT_URL\"}"
+            RESPONSE=$(curl -s -X POST -H "$AUTHORIZATION" -H "$ACCEPT" "$DEPLOYMENT_URL" -d "$BODY")
+
+            # Extract information from the response
+            RESPONSE_STATE=$(echo "$RESPONSE" | jq -r '.state')
+            RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
+
+            # Output the information
+            echo "Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
+          else
+            TVOS_ENVIRONMENT=$(printf '%b' "${TVOS_ENVIRONMENT//%/\\x}")
+            echo "No deployment for $TVOS_ENVIRONMENT environment. No update."
+          fi

--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update deployment status to Inactive
         env:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+---
+
+rules:
+  line-length:
+    max: 120


### PR DESCRIPTION
### Motivation and Context

The CI can now shared deployment with #447.
When a PR si closed, the GitHub branch is deleted.
Like [Play web deployments](https://github.com/mmz-srf/play-web/deployments), the PR merge is set inactive the deployment.

### Description

- Add a Github action to fallow PR closure and update the latest deployments for iOS and tvOS nighties.

### No in this PR
- Take care of "playsrg-beta" and "playsrg-testflight" environments. They should not have brand environments.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
