### PR TITLE
Move # section to end of AZ list (PLAYRTS-5499)

### DIFF
--- a/Application/Sources/Helpers/Extensions.swift
+++ b/Application/Sources/Helpers/Extensions.swift
@@ -193,7 +193,11 @@ extension Collection {
                 return "#"
             }
         }
-        return dictionary.sorted { $0.key < $1.key }
+        let hashGroup = dictionary["#"]
+        return dictionary
+            .filter { $0.key != "#" }
+            .sorted { $0.key < $1.key }
+            .appending(contentsOf: hashGroup.map { [(Character("#"), $0)] } ?? [])
     }
 }
 


### PR DESCRIPTION
### Motivation and Context

> It looked like a mistake if the navigation starts with `#0-9` in the "A to Z" view. Also if a user navigates with a screen reader (like VoiceOver), it's easier to understand at the end of the navigation.

The show list should start with “A” section. And “#“ should be at the end of the list.

### Description

- Move "#" section to the end of the AZ list (in Videos and Audios).

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
