### PR TITLE
Fix song list layout (PLAYRTS-5494)

### DIFF
--- a/Application/Sources/Player/SongTableViewCell.h
+++ b/Application/Sources/Player/SongTableViewCell.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, getter=isPlayable) BOOL playable;
 
-- (void)setSong:(nullable SRGSong *)song playing:(BOOL)playing;
+- (void)setSong:(nullable SRGSong *)song playing:(BOOL)playing withCellWidth:(CGFloat)width;
 - (void)updateProgressForDateInterval:(nullable NSDateInterval *)dateInterval;
 
 @end

--- a/Application/Sources/Player/SongTableViewCell.m
+++ b/Application/Sources/Player/SongTableViewCell.m
@@ -62,10 +62,16 @@ static const CGFloat SongTableViewWaveformViewTrailing = 22.f;
 {
     // Add variable contribution depending on the number of lines required to properly display a song title
     // (maximum of 2 lines)
-    // Remark: We take the waveform into account. We namely do not want to change the height of the cell whether or not
-    //         the waveform is displayed. We therefore calculate the layout in the nominal case, i.e. without waveform.
+    // Remark: We namely do not want to change the height of the cell whether or not the waveform is displayed. We
+    //         therefore calculate the layout in the nominal case, i.e. without waveform.
+    return [self heightForSong:song withCellWidth:width waveformDisplayed:NO];
+}
+
++ (CGFloat)heightForSong:(SRGSong *)song withCellWidth:(CGFloat)width waveformDisplayed:(BOOL)waveformDisplayed
+{
     UIFont *font = [self titleLabelFont];
-    CGFloat textWidth = fmaxf(width - SongTableViewMargin - SongTableViewWaveformViewLeading - SongTableViewWaveformViewWidth - SongTableViewWaveformViewTrailing, 0.f);
+    CGFloat textMargins = waveformDisplayed ? SongTableViewMargin + SongTableViewWaveformViewLeading + SongTableViewWaveformViewWidth + SongTableViewWaveformViewTrailing : 2 * SongTableViewMargin;
+    CGFloat textWidth = fmaxf(width - textMargins, 0.f);
     CGRect boundingRect = [song.title boundingRectWithSize:CGSizeMake(textWidth, CGFLOAT_MAX)
                                                    options:NSStringDrawingUsesLineFragmentOrigin
                                                 attributes:@{ NSFontAttributeName : font }
@@ -77,6 +83,11 @@ static const CGFloat SongTableViewWaveformViewTrailing = 22.f;
     
     // Time and artist fields are mandatory, a contribution is therefore added for each
     return [self timeLabelFont].lineHeight + [self artistLabelFont].lineHeight + titleHeight;
+}
+
++ (NSInteger)titleNumberOfLinesForSong:(SRGSong *)song withCellWidth:(CGFloat)width
+{
+    return [self heightForSong:song withCellWidth:width waveformDisplayed:NO] == [self heightForSong:song withCellWidth:width waveformDisplayed:YES] ? 2 : 1;
 }
 
 #pragma mark Overrides
@@ -117,7 +128,7 @@ static const CGFloat SongTableViewWaveformViewTrailing = 22.f;
 
 #pragma mark Attached data
 
-- (void)setSong:(SRGSong *)song playing:(BOOL)playing
+- (void)setSong:(SRGSong *)song playing:(BOOL)playing withCellWidth:(CGFloat)width
 {
     self.song = song;
     self.playing = playing;
@@ -125,6 +136,7 @@ static const CGFloat SongTableViewWaveformViewTrailing = 22.f;
     self.timeLabel.text = [NSDateFormatter.play_time stringFromDate:song.date];
     self.timeLabel.font = [SongTableViewCell timeLabelFont];
     
+    self.titleLabel.numberOfLines = [SongTableViewCell titleNumberOfLinesForSong:song withCellWidth:width];
     self.titleLabel.text = song.title;
     self.titleLabel.font = [SongTableViewCell titleLabelFont];
     

--- a/Application/Sources/Player/SongTableViewCell.m
+++ b/Application/Sources/Player/SongTableViewCell.m
@@ -13,6 +13,9 @@
 @import SRGAppearance;
 
 static const CGFloat SongTableViewMargin = 42.f;
+static const CGFloat SongTableViewWaveformViewWidth = 34.f;
+static const CGFloat SongTableViewWaveformViewLeading = 8.f;
+static const CGFloat SongTableViewWaveformViewTrailing = 22.f;
 
 @interface SongTableViewCell ()
 
@@ -29,6 +32,10 @@ static const CGFloat SongTableViewMargin = 42.f;
 @property (nonatomic, weak) IBOutlet UIView *waveformView;
 
 @property (nonatomic) IBOutletCollection(NSLayoutConstraint) NSArray<NSLayoutConstraint *> *marginWidthConstraints;
+
+@property (nonatomic) IBOutlet NSLayoutConstraint *waveformViewWidthConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *waveformViewLeadingConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *waveformViewTrailingConstraint;
 
 @end
 
@@ -55,11 +62,10 @@ static const CGFloat SongTableViewMargin = 42.f;
 {
     // Add variable contribution depending on the number of lines required to properly display a song title
     // (maximum of 2 lines)
-    // Remark: We do not take the waveform into account. We namely do not want to change the height of the
-    //         cell whether or not the waveform is displayed. We therefore calculate the layout in the nominal
-    //         case, i.e. without waveform.
+    // Remark: We take the waveform into account. We namely do not want to change the height of the cell whether or not
+    //         the waveform is displayed. We therefore calculate the layout in the nominal case, i.e. without waveform.
     UIFont *font = [self titleLabelFont];
-    CGFloat textWidth = fmaxf(width - 2 * SongTableViewMargin, 0.f);
+    CGFloat textWidth = fmaxf(width - SongTableViewMargin - SongTableViewWaveformViewLeading - SongTableViewWaveformViewWidth - SongTableViewWaveformViewTrailing, 0.f);
     CGRect boundingRect = [song.title boundingRectWithSize:CGSizeMake(textWidth, CGFLOAT_MAX)
                                                    options:NSStringDrawingUsesLineFragmentOrigin
                                                 attributes:@{ NSFontAttributeName : font }
@@ -85,6 +91,10 @@ static const CGFloat SongTableViewMargin = 42.f;
     [self.marginWidthConstraints enumerateObjectsUsingBlock:^(NSLayoutConstraint * _Nonnull constraint, NSUInteger idx, BOOL * _Nonnull stop) {
         constraint.constant = SongTableViewMargin;
     }];
+    
+    self.waveformViewWidthConstraint.constant = SongTableViewWaveformViewWidth;
+    self.waveformViewLeadingConstraint.constant = SongTableViewWaveformViewLeading;
+    self.waveformViewTrailingConstraint.constant = SongTableViewWaveformViewTrailing;
     
     self.waveformView.hidden = YES;
     self.rightMarginView.hidden = NO;

--- a/Application/Sources/Player/SongTableViewCell.xib
+++ b/Application/Sources/Player/SongTableViewCell.xib
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -57,7 +59,7 @@
                                                 <rect key="frame" x="308" y="0.0" width="64" height="54"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" image="waveform_animation-0" translatesAutoresizingMaskIntoConstraints="NO" id="Msg-dq-g9i">
-                                                        <rect key="frame" x="8" y="-37" width="34" height="128"/>
+                                                        <rect key="frame" x="8" y="10" width="34" height="34"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="34" id="tO5-GP-UH3"/>
@@ -105,6 +107,9 @@
                 <outlet property="titleLabel" destination="9i6-JI-bLq" id="x3p-6c-WAo"/>
                 <outlet property="waveformImageView" destination="Msg-dq-g9i" id="IvZ-9k-vrd"/>
                 <outlet property="waveformView" destination="1rh-f6-w0B" id="Tqz-b6-4i9"/>
+                <outlet property="waveformViewLeadingConstraint" destination="PKd-eI-pPX" id="ZRc-V2-bXi"/>
+                <outlet property="waveformViewTrailingConstraint" destination="6in-QA-oke" id="IYx-TE-4AN"/>
+                <outlet property="waveformViewWidthConstraint" destination="tO5-GP-UH3" id="Jnj-4k-CK9"/>
                 <outletCollection property="marginWidthConstraints" destination="MyP-WU-aUc" id="Igq-wL-KUN"/>
                 <outletCollection property="marginWidthConstraints" destination="y7s-P1-YZs" id="tOb-db-jQg"/>
             </connections>
@@ -112,6 +117,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="waveform_animation-0" width="128" height="128"/>
+        <image name="waveform_animation-0" width="34" height="34"/>
     </resources>
 </document>

--- a/Application/Sources/Player/SongsViewController.m
+++ b/Application/Sources/Player/SongsViewController.m
@@ -263,7 +263,7 @@
 {
     SRGSong *song = self.items[indexPath.row];
     BOOL playing = (self.letterboxController.playbackState == SRGMediaPlayerPlaybackStatePlaying);
-    [cell setSong:song playing:playing];
+    [cell setSong:song playing:playing withCellWidth:CGRectGetWidth(tableView.frame)];
     [cell updateProgressForDateInterval:self.letterboxController.play_dateInterval];
 }
 


### PR DESCRIPTION
### Motivation and Context

A user reported a song title text issue when the song is playing, the artist name could not be readable correctly, when title switch from 1 line to 2 lines on a small-width screen (including an iPad in split view). 

<img src="https://github.com/SRGSSR/playsrg-apple/assets/380522/4d3c37f0-0d53-4dc4-b200-f66c91a3606b" alt="IMG_4168" width="512">

### Description

- Keep the same number of lines for the title, with or without the waveform. No cell height changes when selecting the cell as well. 

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
