### PR TITLE
Mitigate CI stop or ending with an error

### DIFF
--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -3,11 +3,15 @@ deployments:
     testing:
       - "playsrg-ios-nightly*"
       - "playsrg-tvos-nightly*"
+      - "playsrg-ios-beta+*"
+      - "playsrg-tvos-beta+*"
+      - "playsrg-ios-testflight+*"
+      - "playsrg-tvos-testflight+*"
     staging:
-      - "playsrg-ios-beta*"
-      - "playsrg-tvos-beta*"
-      - "playsrg-ios-testflight*"
-      - "playsrg-tvos-testflight*"
+      - "playsrg-ios-beta"
+      - "playsrg-tvos-beta"
+      - "playsrg-ios-testflight"
+      - "playsrg-tvos-testflight"
     production:
       - "playsrg-ios"
       - "playsrg-tvos"

--- a/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
@@ -15,15 +15,29 @@ When building binaries with the [fastlane lanes](RELEASE_CHECKLIST.md#fastlane-o
 
 ## Deployments
 
+### Creation
+
 When one of the listed fastlane lane above is executed, a new deployment is created:
 
 - The reference (`ref`) is the git branch name, only if the deployment `sha` is same as the last commit hash on the branch, to be sure that it's link to the correct commit. If it's not the case, the deployment is deleted and a new deployment is created with the last commit hash as the reference.
 - No `auto_merge` option.
 - No `required_contexts` option.
 
+
+### Update state
+
 During a fastlane lane execution:
 
-- the script can update the current Github deployment state to `in_progess`, `success` or `error`.
+- the script can update the current Github deployment state to `in_progress`, `success` or `error`.
 -  if the `BUILD_URL` environment variable is set, it's added to Github deployment information as `log_url`.
 - if the deployment state switched to `success`, an help page url is added to Github deployment information as `environment_url`. The help page url for builds is like:
   - `https://srgssr.github.io/playsrg-apple/deployments/build.html?configuration=[nightly|beta|testflight|appstore]&platform=[ios|tvos]&version=[version_friendly_name]`.
+
+### Unfinished issue
+
+If the fastlane execution finished with an error, the Github deployment state should be set to `error`. But if the fastlane execution is killed with an exit signal, no state is applied and the Github deployment could stay in `in_progress` state.
+
+An independant fastlane lane can help to **stop all unfinished** deployments for a lane which have a Github environement, applying the `error` state.
+
+- `fastlane ios stopUnfinishedGithubDeployments lane:[LANE_NAME]`
+

--- a/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
@@ -37,7 +37,12 @@ During a fastlane lane execution:
 
 If the fastlane execution finished with an error, the Github deployment state should be set to `error`. But if the fastlane execution is killed with an exit signal, no state is applied and the Github deployment could stay in `in_progress` state.
 
-An independant fastlane lane can help to **stop all unfinished** deployments for a lane which have a Github environement, applying the `error` state.
+An independant fastlane lane can help to **stop all unfinished** deployments for a lane which have a Github environement. It's applying the `error` state.
 
 - `fastlane ios stopUnfinishedGithubDeployments lane:[LANE_NAME]`
+
+### Inactive state
+
+- [By default](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#inactive-deployments), the non-transient, non-production environment deployments created by fastlane scripts have `auto_inactive` = `true`. So that a new `success` deployment sets all previous `success` deployments to `inactive` state.
+- When closing a PR, a [Github action](https://github.com/SRGSSR/playsrg-apple/actions) (pr-closure.yml) is updating state to `inactive` to lastest `success` deployment for nighty branch environnements.
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -266,7 +266,7 @@ platform :ios do
     UI.message 'Github environment is deducted from the lane name and the current git branch name.' unless lane_name
     lane_name ||= prompt(text: 'lane: ')
 
-    end_unfinished_github_deployments(lane_name)
+    stop_unfinished_github_deployments(lane_name)
   end
 
   # App Store reviews and releases
@@ -1964,7 +1964,7 @@ def add_github_deployment_tag_success(lane)
   ENV.delete('NEW_PLAY_TAG')
 end
 
-def end_unfinished_github_deployments(lane)
+def stop_unfinished_github_deployments(lane)
   deployments = get_github_deployments(lane)
 
   return unless deployments
@@ -1978,11 +1978,11 @@ def end_unfinished_github_deployments(lane)
 
     lane_name = lane.to_s
     UI.message "Github deployment #{deployment['id']} for #{lane_name} is unfinished with state: #{last_status['state']}"
-    end_unfinished_github_deployment(lane, deployment)
+    stop_unfinished_github_deployment(lane, deployment)
   end
 end
 
-def end_unfinished_github_deployment(lane, deployment)
+def stop_unfinished_github_deployment(lane, deployment)
   ENV['GITHUB_DEPLOYMENT_ID'] = deployment['id'].to_s
   ENV['BUILD_URL'] = deployment['log_url']
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1794,6 +1794,33 @@ def srg_github_create_or_update_environment(environment)
   )
 end
 
+def get_github_deployments(lane)
+  environment = github_environment(lane)
+  return unless ENV.fetch('GITHUB_TOKEN', nil) && environment
+
+  result = srg_github_get_deployments(environment)
+  deployments = result[:json]
+  return unless deployments.is_a?(Array)
+
+  UI.message "#{deployments.count} Github deployments for #{environment}"
+  deployments
+end
+
+def srg_github_get_deployments(environment)
+  encoded_environment = environment.gsub('+', '%2B')
+  github_api(
+    api_token: ENV.fetch('GITHUB_TOKEN', nil),
+    http_method: 'GET',
+    path: "#{github_api_path}/deployments?environment=#{encoded_environment}",
+    error_handlers: {
+      '*' => proc do |result|
+        UI.important 'Something went wrong with Github token and deployments API get. ⚠️'
+        UI.important result.to_s
+      end
+    }
+  )
+end
+
 def create_github_deployment(lane)
   ENV.delete('GITHUB_DEPLOYMENT_ID')
   environment = github_environment(lane)
@@ -1914,6 +1941,56 @@ def add_github_deployment_tag_success(lane)
   create_github_deployment(lane)
   update_github_deployment_success(lane)
   ENV.delete('NEW_PLAY_TAG')
+end
+
+def end_unfinished_github_deployments(lane)
+  deployments = get_github_deployments(lane)
+
+  return unless deployments
+
+  deployments.reverse.each do |deployment|
+    statuses = get_github_deployment_statuses(deployment['id'])
+    next unless statuses
+
+    last_status = statuses.first
+    next unless last_status.nil? || !['success', 'inactive', 'error'].include?(last_status['state'])
+
+    lane_name = lane.to_s
+    UI.message "Github deployment #{deployment['id']} for #{lane_name} is unfinished with state: #{last_status['state']}"
+    end_unfinished_github_deployment(lane, deployment)
+  end
+end
+
+def end_unfinished_github_deployment(lane, deployment)
+  ENV['GITHUB_DEPLOYMENT_ID'] = deployment['id'].to_s
+  ENV['BUILD_URL'] = deployment['log_url']
+
+  update_github_deployment_error(lane)
+
+  ENV.delete('GITHUB_DEPLOYMENT_ID')
+  ENV.delete('BUILD_URL')
+end
+
+def get_github_deployment_statuses(deployment_id)
+  result = srg_github_get_deployment_statuses(deployment_id)
+  statuses = result[:json]
+  return unless statuses.is_a?(Array)
+
+  statuses
+end
+
+def srg_github_get_deployment_statuses(deployment_id)
+  github_api(
+    api_token: ENV.fetch('GITHUB_TOKEN', nil),
+    http_method: 'GET',
+    path: "#{github_api_path}/deployments/#{deployment_id}/statuses",
+    error_handlers: {
+      '*' => proc do |result|
+        UI.important 'Something went wrong with Github token and deployments API statuses get. ⚠️'
+        UI.important result.to_s
+      end
+    }
+  )
 end
 
 def update_github_deployment_in_progress(lane)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -213,21 +213,6 @@ platform :ios do
     end
   end
 
-  desc 'Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.'
-  lane :iOSPrepareAppStoreReleases do |options|
-    tag_version = options[:tag_version]
-    submit_for_review = options[:submit_for_review]
-
-    options = ''
-    options += " tag_version:#{tag_version}" if tag_version
-    options += " submit_for_review:#{submit_for_review}" if submit_for_review
-
-    business_units.map do |business_unit|
-      business_unit = business_unit.downcase
-      sh "bundle exec fastlane ios iOS#{business_unit}PrepareAppStoreRelease#{options}"
-    end
-  end
-
   desc 'Applies tvOSUploadAppStoreBuilds and tvOSDistributePrivateAppStoreBuilds (or tvOSDistributePublicAppStoreBuilds). Optional `public_testflight_distribution` parameter.'
   lane :tvOSAppStoreBuilds do |options|
     public_testflight_distribution = options[:public_testflight_distribution] || false
@@ -269,6 +254,23 @@ platform :ios do
     business_units.map do |business_unit|
       business_unit = business_unit.downcase
       sh "bundle exec fastlane ios tvOS#{business_unit}DistributePublicAppStoreBuild#{options}"
+    end
+  end
+
+  # App Store reviews and releases
+
+  desc 'Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.'
+  lane :iOSPrepareAppStoreReleases do |options|
+    tag_version = options[:tag_version]
+    submit_for_review = options[:submit_for_review]
+
+    options = ''
+    options += " tag_version:#{tag_version}" if tag_version
+    options += " submit_for_review:#{submit_for_review}" if submit_for_review
+
+    business_units.map do |business_unit|
+      business_unit = business_unit.downcase
+      sh "bundle exec fastlane ios iOS#{business_unit}PrepareAppStoreRelease#{options}"
     end
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -257,6 +257,18 @@ platform :ios do
     end
   end
 
+  # Github deployments
+
+  desc 'Stop unfinished Github deployments for a lane on the current git branch. Recommended `lane` parameter.'
+  lane :stopUnfinishedGithubDeployments do |options|
+    lane_name = options[:lane]
+
+    UI.message 'Github environment is deducted from the lane name and the current git branch name.' unless lane_name
+    lane_name ||= prompt(text: 'lane: ')
+
+    end_unfinished_github_deployments(lane_name)
+  end
+
   # App Store reviews and releases
 
   desc 'Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.'
@@ -1152,7 +1164,14 @@ def what_s_new_condition(lane)
 end
 
 def cleaned_lane_condition(lane)
-  excluded_lanes = ['distribute', 'screenshots', 'appstorerelease', 'status', 'tester']
+  excluded_lanes = [
+    'distribute',
+    'screenshots',
+    'appstorerelease',
+    'status',
+    'tester',
+    'githubdeployments'
+  ]
   (lane.to_s != 'devLane') &&
     excluded_lanes.all? { |i| !lane.to_s.downcase.include? i }
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1074,6 +1074,8 @@ platform :ios do
   end
 
   error do |lane|
+    UI.important 'An action has triggered an error. End of lane execution. ⚠️'
+
     update_github_deployment_error(lane)
 
     if cleaned_lane_condition(lane)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -143,6 +143,14 @@ Distributes to private groups a tvOS App Store build on App Store Connect with t
 
 Distributes to public groups a tvOS App Store build on App Store Connect with the current version and build numbers. Optional `tag_version` parameter (`X.Y.Z-build_number`).
 
+### ios stopUnfinishedGithubDeployments
+
+```sh
+[bundle exec] fastlane ios stopUnfinishedGithubDeployments
+```
+
+Stop unfinished Github deployments for a lane on the current git branch. Recommended `lane` parameter.
+
 ### ios iOSPrepareAppStoreReleases
 
 ```sh

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -111,14 +111,6 @@ Distributes to private groups an iOS App Store build on App Store Connect with t
 
 Distributes to public groups an iOS App Store build on App Store Connect with the current version and build numbers. Optional `tag_version` parameter (`X.Y.Z-build_number`).
 
-### ios iOSPrepareAppStoreReleases
-
-```sh
-[bundle exec] fastlane ios iOSPrepareAppStoreReleases
-```
-
-Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.
-
 ### ios tvOSAppStoreBuilds
 
 ```sh
@@ -150,6 +142,14 @@ Distributes to private groups a tvOS App Store build on App Store Connect with t
 ```
 
 Distributes to public groups a tvOS App Store build on App Store Connect with the current version and build numbers. Optional `tag_version` parameter (`X.Y.Z-build_number`).
+
+### ios iOSPrepareAppStoreReleases
+
+```sh
+[bundle exec] fastlane ios iOSPrepareAppStoreReleases
+```
+
+Prepare AppStore iOS releases on App Store Connect with the current version and build numbers. No build uploads. Optional `tag_version` (`X.Y.Z-build_number`) or `submit_for_review` parameters.
 
 ### ios tvOSPrepareAppStoreReleases
 


### PR DESCRIPTION
### Motivation and Context

Sometime, the CI stops the fastlane script. Or due to AppStore Connect 500 Api response, the fastlane script stops with an error. A Github deployment could stay in a `in_progress` state.

It's not easy to run code with the exist signal is sent to the ruby code. Let's try to propose an asynchrone script to the CI to stop it with `error` state.

### Description

- Add `stopUnfinishedGithubDeployments` lane.
- Update Github environments and deployments documentation.
- Update Jira configuration for branch environments (following #452).  

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [ ] Remote configuration properties have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
