### PR TITLE
Rename Github deployment task

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1898,7 +1898,8 @@ def srg_github_create_deployment_body(environment, ref)
     auto_merge: false,
     required_contexts: [],
     environment:,
-    description: "Start #{environment} deployment"
+    task: 'Build and distribute',
+    description: "Build and distribute for #{environment} environment."
   }
 end
 


### PR DESCRIPTION
### Motivation and Context

Jira displays the deployment task name. Default is `deploy` but [it can be updated](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#create-a-deployment).
Related to #447.

### Description

- Update deployment task and description.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
