### PR TITLE
Privacy info manifest update (PLAYRTS-5489)

### DIFF
--- a/Application/Resources/PrivacyInfo.xcprivacy
+++ b/Application/Resources/PrivacyInfo.xcprivacy
@@ -19,6 +19,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>85F4.1</string>
+				<string>E174.1</string>
 			</array>
 		</dict>
 	</array>

--- a/TV Application/Resources/PrivacyInfo.xcprivacy
+++ b/TV Application/Resources/PrivacyInfo.xcprivacy
@@ -13,6 +13,14 @@
 				<string>1C8F.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Motivation and Context

Some new emails from Apple are reported for the tvOS builds.
We missed them from #443.

Which code or library include in both iOS and tvOS build use disk space?
Not sure but maybe [YYWebImage dependency from Letterbox](https://github.com/SRGSSR/srgletterbox-apple/blob/fa32959d7899e5002a313a667876cf4265ece9b1/Package.swift#L27), as some cache disk API exists.

### Description

- Add Disk Space API accesses to tvOS.
- Update Disk Space API accesses reason for iOS.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
