### PR TITLE
Fix CI build number notification for nightlies

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
     tag_version = options[:tag_version] || tag_version(platform)
     branch_name = git_branch_name
 
-    notify_version_to_ci(platform, tag_version, branch_name)
+    notify_version_to_ci(platform, tag_version, branch_name) if notify_ci_condition(lane)
 
     create_or_update_github_environment(lane)
     create_github_deployment(lane)
@@ -1187,6 +1187,10 @@ end
 
 def derived_data_path
   'build/DerivedData'
+end
+
+def notify_ci_condition(lane)
+  !lane.to_s.downcase.include?('githubdeployments')
 end
 
 def appcenter_ios_nightly_appcenter_names


### PR DESCRIPTION
### Motivation and Context

Following #458 and new `stopUnfinishedGithubDeployments` lane introduction, TeamCity had a build number override.
It does not displayed the correct build number for nightlies.

### Description

- Don't notify CI for github deployments lane.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
