### PR TITLE
Fix Beta and TestFlight tag Github deployments

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1986,7 +1986,7 @@ def github_deployment_ref_tag(lane)
   return new_tag if new_tag && !new_tag.empty?
 
   tag = last_git_tag(pattern: "#{platform(lane).downcase}/*")
-  tag_commit = sh("git rev-list -n 1 tags/#{tag}")
+  tag_commit = sh("git rev-list -n 1 tags/#{tag}").strip
   return unless tag_commit && !tag_commit.empty?
 
   return unless last_git_commit[:commit_hash] == tag_commit


### PR DESCRIPTION
### Motivation and Context

Topic: #447.

AppStoreBuilds and TestFlight public distributions not work as expected with #464.
Only tag deployments should be used if scripts runs on the tagged commit.

Investigate and fix it.

### Description

- Fixing the `sh` command. It returned a breaking line, which brake the commit _sha_ comparaison.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
