### PR TITLE
Update branch beta GitHub environments to inactive state

### DIFF
--- a/.github/workflows/pr-closure.yml
+++ b/.github/workflows/pr-closure.yml
@@ -42,19 +42,6 @@ jobs:
           # Remove "feature/" from the head branch
           BUILD_NAME=$(echo "$HEAD_BRANCH" | sed 's/feature\///g')
 
-          # Define environment names
-          IOS_ENVIRONMENT=$(echo "playsrg-ios-nightly+$BUILD_NAME" | jq -R -r @uri)
-          TVOS_ENVIRONMENT=$(echo "playsrg-tvos-nightly+$BUILD_NAME" | jq -R -r @uri)
-
-          echo "Working with iOS environment: $IOS_ENVIRONMENT"
-          echo "Working with tvOS environment: $TVOS_ENVIRONMENT"
-
-          # Get the latest active deployment for iOS
-          IOS_DEPLOYMENT=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_URL?environment=$IOS_ENVIRONMENT" | jq '.[0]')
-
-          # Get the latest active deployment for tvOS
-          TVOS_DEPLOYMENT=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_URL?environment=$TVOS_ENVIRONMENT" | jq '.[0]')
-
           # Function to fetch log and environment URLs from status URL
           fetch_status_urls() {
             STATUS_URL=$1
@@ -65,54 +52,43 @@ jobs:
             echo "$LOG_URL,$ENVIRONMENT_URL"
           }
 
-          if [ "$IOS_DEPLOYMENT" != "null" ]; then
-            DEPLOYMENT_ID=$(echo "$IOS_DEPLOYMENT" | jq -r '.id')
-            STATUSES_URL=$(echo "$IOS_DEPLOYMENT" | jq -r '.statuses_url')
+          # Function to set inactive state to the latest deployment
+          set_inactive_latest_deployment() {
+              local ENVIRONMENT=$1
+              local ENVIRONMENT_ENCODED=$(echo "$ENVIRONMENT" | jq -R -r @uri)
 
-            echo "Working with iOS deployment ID: $DEPLOYMENT_ID"
+              # Get the latest active deployment
+              local DEPLOYMENTS_FULL_URL="$DEPLOYMENTS_URL?environment=$ENVIRONMENT_ENCODED"
+              local DEPLOYMENT_DATA=$(curl -s -H "$AUTHORIZATION" "$DEPLOYMENTS_FULL_URL" | jq '.[0]')
 
-            URLS=$(fetch_status_urls "$STATUSES_URL")
-            IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
+              if [ "$DEPLOYMENT_DATA" != "null" ]; then
+                  local DEPLOYMENT_ID=$(echo "$DEPLOYMENT_DATA" | jq -r '.id')
+                  local STATUSES_URL=$(echo "$DEPLOYMENT_DATA" | jq -r '.statuses_url')
 
-            # Mark the latest deployment for iOS nightly as inactive
-            DEPLOYMENT_URL="$DEPLOYMENTS_URL/$DEPLOYMENT_ID/statuses"
-            BODY="{\"state\": \"inactive\", \"description\": \"The PR is closed.\", \
-              \"log_url\": \"$LOG_URL\", \"environment_url\": \"$ENVIRONMENT_URL\"}"
-            RESPONSE=$(curl -s -X POST -H "$AUTHORIZATION" -H "$ACCEPT" "$DEPLOYMENT_URL" -d "$BODY")
+                  echo "Working with $ENVIRONMENT deployment ID: $DEPLOYMENT_ID"
 
-            # Extract information from the response
-            RESPONSE_STATE=$(echo "$RESPONSE" | jq -r '.state')
-            RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
+                  local URLS=$(fetch_status_urls "$STATUSES_URL")
+                  IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
 
-            # Output the information
-            echo "-> Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
-          else
-            IOS_ENVIRONMENT=$(printf '%b' "${IOS_ENVIRONMENT//%/\\x}")
-            echo "-> No deployment for $IOS_ENVIRONMENT environment. No update."
-          fi
+                  # Mark the latest deployment as inactive
+                  local DEPLOYMENT_URL="$DEPLOYMENTS_URL/$DEPLOYMENT_ID/statuses"
+                  local BODY="{\"state\": \"inactive\", \"description\": \"The PR is closed.\", \
+                    \"log_url\": \"$LOG_URL\", \"environment_url\": \"$ENVIRONMENT_URL\"}"
+                  local RESPONSE=$(curl -s -X POST -H "$AUTHORIZATION" -H "$ACCEPT" "$DEPLOYMENT_URL" -d "$BODY")
 
-          if [ "$TVOS_DEPLOYMENT" != "null" ]; then
-            DEPLOYMENT_ID=$(echo "$TVOS_DEPLOYMENT" | jq -r '.id')
-            STATUSES_URL=$(echo "$TVOS_DEPLOYMENT" | jq -r '.statuses_url')
+                  # Extract information from the response
+                  local RESPONSE_STATE=$(echo "$RESPONSE" | jq -r '.state')
+                  local RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
 
-            echo "Working with tvOS deployment ID: $DEPLOYMENT_ID"
+                  # Output the information
+                  echo "-> Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
+              else
+                  echo "-> No deployment for $ENVIRONMENT environment. No update."
+              fi
+          }
 
-            URLS=$(fetch_status_urls "$STATUSES_URL")
-            IFS=',' read -r LOG_URL ENVIRONMENT_URL <<< "$URLS"
-
-            # Mark the latest deployment for tvOS nightly as inactive
-            DEPLOYMENT_URL="$DEPLOYMENTS_URL/$DEPLOYMENT_ID/statuses"
-            BODY="{\"state\": \"inactive\", \"description\": \"The PR is closed.\", \
-              \"log_url\": \"$LOG_URL\", \"environment_url\": \"$ENVIRONMENT_URL\"}"
-            RESPONSE=$(curl -s -X POST -H "$AUTHORIZATION" -H "$ACCEPT" "$DEPLOYMENT_URL" -d "$BODY")
-
-            # Extract information from the response
-            RESPONSE_STATE=$(echo "$RESPONSE" | jq -r '.state')
-            RESPONSE_ENVIRONMENT=$(echo "$RESPONSE" | jq -r '.environment')
-
-            # Output the information
-            echo "-> Update $RESPONSE_ENVIRONMENT latest deployment to $RESPONSE_STATE state."
-          else
-            TVOS_ENVIRONMENT=$(printf '%b' "${TVOS_ENVIRONMENT//%/\\x}")
-            echo "-> No deployment for $TVOS_ENVIRONMENT environment. No update."
-          fi
+          # Set inactive state to the latest deployment of branch environments
+          set_inactive_latest_deployment "playsrg-ios-nightly+$BUILD_NAME"
+          set_inactive_latest_deployment "playsrg-tvos-nightly+$BUILD_NAME"
+          set_inactive_latest_deployment "playsrg-ios-beta+$BUILD_NAME"
+          set_inactive_latest_deployment "playsrg-tvos-beta+$BUILD_NAME"

--- a/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
@@ -85,5 +85,5 @@ If the fastlane execution finished with an error, or killed with an exit signal,
 ### Inactive state
 
 - [By default](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#inactive-deployments), the non-transient, non-production environment deployments created by fastlane scripts have `auto_inactive` = `true`. So that a new `success` deployment sets all previous `success` deployments to `inactive` state. It's also activated to production environment deployments because the App Store distribution only allows the latest version of the application.
-- When closing a PR, a [Github action](https://github.com/SRGSSR/playsrg-apple/actions) (pr-closure.yml) is updating state to `inactive` to lastest `success` deployment for nighty branch environnements.
+- When closing a PR, a [Github action](https://github.com/SRGSSR/playsrg-apple/actions) (pr-closure.yml) is updating state to `inactive` to lastest `success` deployment for nighty branch environnements and beta branch environnements.
 


### PR DESCRIPTION
### Motivation and Context

Topic: #447.

The #449 PR added a GitHub action to update deployment state to inactive.
It was only for the nightly iOS and tvOS branches environments.

The proportion is to add beta branches environments in the list of state updates.

### Description

- Update bash script to support iOS and tvOS beta branches environments.

### Checklist

- The branch should be rebased onto the `develop` branch for whole tests with nighties, but it's not required.*
- The code followed the code style as `make quality` passes with a green tick on the last commit.
- [x] Remote configuration properties have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] Issues are linked to the PR, if any.

\* The project uses Github merge queue feature, which rebases onto the `develop` branch before squashing and merging the PR. 
