### PR TITLE
Add shared issue tracker configuration

### DIFF
--- a/.issuetracker
+++ b/.issuetracker
@@ -1,0 +1,11 @@
+# Integration with Issue Tracker
+#
+# (note that '\' need to be escaped).
+
+[issuetracker "GitHub Rule"]
+  regex = "#(\\d+)"
+  url = "https://github.com/srgssr/playsrg-apple/issues/$1"
+
+[issuetracker "Jira Rule"]
+  regex = "(PLAYSRG|PLAY|PLAYRTS|SMAC|ADI)-(\\d+)"
+  url = "https://srgssr-ch.atlassian.net/browse/$1-$2"


### PR DESCRIPTION
## Description

The project information can be found in issue / PR on the open source GitHub repository, but also in the closed Jira project at SRGSSR.
We can share the issue tracker configuration for new colleagues. 

## Changes Made

- add the shared `.issuetracker` file, created by [Fork Mac app](https://fork.dev).

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have reviewed the contribution guidelines.