### PR TITLE
Update LicensePlist version

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -197,4 +197,4 @@ name: YYWebImage, nameSpecified: YYWebImage, owner: SRGSSR, version: 1.0.5-srg3,
 
 add-version-numbers: true
 
-LicensePlist Version: 3.24.10
+LicensePlist Version: 3.25.1


### PR DESCRIPTION
## Description

After running `brew update` on all casts and formulas, [LicensePlist](https://github.com/mono0926/LicensePlist/releases) version is 3.25.1. @mutaben and me have it now on our developer devices.

## Changes Made

- Update the LicensePlist result file.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.