### PR TITLE
Fix cell image background (PLAYRTS-5510)

### DIFF
--- a/Application/Sources/Content/SectionShowHeaderView.swift
+++ b/Application/Sources/Content/SectionShowHeaderView.swift
@@ -53,6 +53,7 @@ struct SectionShowHeaderView: View {
     var body: some View {
         Stack(direction: direction, alignment: alignment, spacing: 0) {
             ImageView(source: imageUrl)
+                .background(Color.black)
                 .aspectRatio(16 / 9, contentMode: .fit)
                 .overlay(ImageOverlay(horizontalSizeClass: horizontalSizeClass))
                 .adaptiveMainFrame(for: horizontalSizeClass)

--- a/Application/Sources/Content/SectionShowHeaderView.swift
+++ b/Application/Sources/Content/SectionShowHeaderView.swift
@@ -52,8 +52,7 @@ struct SectionShowHeaderView: View {
     
     var body: some View {
         Stack(direction: direction, alignment: alignment, spacing: 0) {
-            ImageView(source: imageUrl)
-                .background(Color.black)
+            ShowVisualView(source: imageUrl)
                 .aspectRatio(16 / 9, contentMode: .fit)
                 .overlay(ImageOverlay(horizontalSizeClass: horizontalSizeClass))
                 .adaptiveMainFrame(for: horizontalSizeClass)

--- a/Application/Sources/Content/SectionShowHeaderView.swift
+++ b/Application/Sources/Content/SectionShowHeaderView.swift
@@ -46,13 +46,9 @@ struct SectionShowHeaderView: View {
         return (horizontalSizeClass == .compact) ? .center : .leading
     }
     
-    private var imageUrl: URL? {
-        return url(for: show.image, size: .medium)
-    }
-    
     var body: some View {
         Stack(direction: direction, alignment: alignment, spacing: 0) {
-            ShowVisualView(source: imageUrl)
+            ShowVisualView(show: show, size: .medium)
                 .aspectRatio(16 / 9, contentMode: .fit)
                 .overlay(ImageOverlay(horizontalSizeClass: horizontalSizeClass))
                 .adaptiveMainFrame(for: horizontalSizeClass)

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -85,8 +85,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
             Group {
                 if isVerticalLayout(horizontalSizeClass: horizontalSizeClass, isLandscape: isLandscape) {
                     VStack(alignment: .leading, spacing: 0) {
-                        ImageView(source: model.imageUrl)
-                            .background(Color.black)
+                        ShowVisualView(source: model.imageUrl)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .layoutPriority(1)
                         DescriptionView(model: model, compactLayout: horizontalSizeClass == .compact)
@@ -100,8 +99,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
                     HStack(spacing: constant(iOS: padding, tvOS: 50)) {
                         DescriptionView(model: model, compactLayout: false)
                             .primaryColor(primaryColor)
-                        ImageView(source: model.imageUrl)
-                            .background(Color.black)
+                        ShowVisualView(source: model.imageUrl)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .frame(width: UIScreen.main.bounds.width * 0.35)
                     }

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -85,7 +85,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
             Group {
                 if isVerticalLayout(horizontalSizeClass: horizontalSizeClass, isLandscape: isLandscape) {
                     VStack(alignment: .leading, spacing: 0) {
-                        ShowVisualView(source: model.imageUrl)
+                        ShowVisualView(show: model.show, size: .large)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .layoutPriority(1)
                         DescriptionView(model: model, compactLayout: horizontalSizeClass == .compact)
@@ -99,7 +99,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
                     HStack(spacing: constant(iOS: padding, tvOS: 50)) {
                         DescriptionView(model: model, compactLayout: false)
                             .primaryColor(primaryColor)
-                        ShowVisualView(source: model.imageUrl)
+                        ShowVisualView(show: model.show, size: .large)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .frame(width: UIScreen.main.bounds.width * 0.35)
                     }

--- a/Application/Sources/Content/ShowHeaderView.swift
+++ b/Application/Sources/Content/ShowHeaderView.swift
@@ -86,6 +86,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
                 if isVerticalLayout(horizontalSizeClass: horizontalSizeClass, isLandscape: isLandscape) {
                     VStack(alignment: .leading, spacing: 0) {
                         ImageView(source: model.imageUrl)
+                            .background(Color.black)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .layoutPriority(1)
                         DescriptionView(model: model, compactLayout: horizontalSizeClass == .compact)
@@ -100,6 +101,7 @@ struct ShowHeaderView: View, PrimaryColorSettable {
                         DescriptionView(model: model, compactLayout: false)
                             .primaryColor(primaryColor)
                         ImageView(source: model.imageUrl)
+                            .background(Color.black)
                             .aspectRatio(ShowHeaderView.imageAspectRatio, contentMode: .fit)
                             .frame(width: UIScreen.main.bounds.width * 0.35)
                     }

--- a/Application/Sources/Content/ShowHeaderViewModel.swift
+++ b/Application/Sources/Content/ShowHeaderViewModel.swift
@@ -75,10 +75,6 @@ final class ShowHeaderViewModel: ObservableObject {
         return show?.broadcastInformation?.message
     }
     
-    var imageUrl: URL? {
-        return url(for: show?.image, size: .large)
-    }
-    
     var favoriteIcon: ImageResource {
         return isFavorite ? .favoriteFull : .favorite
     }

--- a/Application/Sources/Helpers/Colors.swift
+++ b/Application/Sources/Helpers/Colors.swift
@@ -9,6 +9,7 @@ import SwiftUI
 extension Color {
     static let darkGray = Color(.darkGray)
     static let placeholder = Color(.placeholder)
+    static let thumbnailBackground = Color(.thumbnailBackground)
 }
 
 extension UIColor {
@@ -19,10 +20,11 @@ extension UIColor {
         }
     }
     
-    public static var placeholder = UIColor(white: 1, alpha: 0.1)
+    static var placeholder = UIColor(white: 1, alpha: 0.1)
+    @objc static var thumbnailBackground = UIColor.black
     
 #if DEBUG
-    public static func random(alpha: CGFloat = 1) -> UIColor {
+    static func random(alpha: CGFloat = 1) -> UIColor {
         return UIColor(red: .random(in: 0...1), green: .random(in: 0...1), blue: .random(in: 0...1), alpha: alpha)
     }
 #endif

--- a/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
+++ b/Application/Sources/Helpers/Extensions/UIColor+PlaySRG.swift
@@ -27,10 +27,6 @@ extension UIColor {
         }
     }
     
-    @objc static var play_grayThumbnailImageViewBackground: UIColor {
-        return play_hexadecimal("#202020")
-    }
-    
     @objc static var play_blackDurationLabelBackground: UIColor {
         return UIColor(white: 0.0, alpha: 0.5)
     }

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -111,7 +111,7 @@ struct FeaturedShowContent: FeaturedContent {
     }
     
     func visualView() -> some View {
-        return ImageView(source: url(for: show?.image, size: .medium))
+        return ShowVisualView(source: url(for: show?.image, size: .medium))
     }
     
 #if os(tvOS)

--- a/Application/Sources/Model/FeaturedContent.swift
+++ b/Application/Sources/Model/FeaturedContent.swift
@@ -111,7 +111,7 @@ struct FeaturedShowContent: FeaturedContent {
     }
     
     func visualView() -> some View {
-        return ShowVisualView(source: url(for: show?.image, size: .medium))
+        return ShowVisualView(show: show, size: .medium)
     }
     
 #if os(tvOS)

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -369,7 +369,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     self.showWrapperView.layer.cornerRadius = LayoutStandardViewCornerRadius;
     self.showWrapperView.layer.masksToBounds = YES;
     
-    self.showThumbnailImageView.backgroundColor = UIColor.blackColor;
+    self.showThumbnailImageView.backgroundColor = UIColor.thumbnailBackground;
     
     self.moreEpisodesLabel.textColor = UIColor.srg_grayD2Color;
     

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -369,7 +369,7 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     self.showWrapperView.layer.cornerRadius = LayoutStandardViewCornerRadius;
     self.showWrapperView.layer.masksToBounds = YES;
     
-    self.showThumbnailImageView.backgroundColor = UIColor.play_grayThumbnailImageViewBackground;
+    self.showThumbnailImageView.backgroundColor = UIColor.blackColor;
     
     self.moreEpisodesLabel.textColor = UIColor.srg_grayD2Color;
     

--- a/Application/Sources/Player/ProgramTableViewCell.m
+++ b/Application/Sources/Player/ProgramTableViewCell.m
@@ -40,7 +40,7 @@
     self.backgroundColor = UIColor.clearColor;
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     
-    self.thumbnailWrapperView.backgroundColor = UIColor.blackColor;
+    self.thumbnailWrapperView.backgroundColor = UIColor.thumbnailBackground;
     self.thumbnailWrapperView.layer.cornerRadius = LayoutStandardViewCornerRadius;
     self.thumbnailWrapperView.layer.masksToBounds = YES;
     

--- a/Application/Sources/Player/ProgramTableViewCell.m
+++ b/Application/Sources/Player/ProgramTableViewCell.m
@@ -40,7 +40,7 @@
     self.backgroundColor = UIColor.clearColor;
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     
-    self.thumbnailWrapperView.backgroundColor = UIColor.play_grayThumbnailImageViewBackground;
+    self.thumbnailWrapperView.backgroundColor = UIColor.blackColor;
     self.thumbnailWrapperView.layer.cornerRadius = LayoutStandardViewCornerRadius;
     self.thumbnailWrapperView.layer.masksToBounds = YES;
     

--- a/Application/Sources/ProgramGuide/ProgramView.swift
+++ b/Application/Sources/ProgramGuide/ProgramView.swift
@@ -92,7 +92,7 @@ struct ProgramView: View {
         var body: some View {
             ZStack {
                 ImageView(source: model.imageUrl)
-                    .background(Color.black)
+                    .background(Color.thumbnailBackground)
                 BlockingOverlay(media: model.currentMedia, messageDisplayed: true)
                 
                 if let progress = model.progress {

--- a/Application/Sources/ProgramGuide/ProgramView.swift
+++ b/Application/Sources/ProgramGuide/ProgramView.swift
@@ -92,6 +92,7 @@ struct ProgramView: View {
         var body: some View {
             ZStack {
                 ImageView(source: model.imageUrl)
+                    .background(Color.black)
                 BlockingOverlay(media: model.currentMedia, messageDisplayed: true)
                 
                 if let progress = model.progress {

--- a/Application/Sources/UI/Views/FeaturedContentCell.swift
+++ b/Application/Sources/UI/Views/FeaturedContentCell.swift
@@ -63,7 +63,6 @@ struct FeaturedContentCell<Content: FeaturedContent>: View, PrimaryColorSettable
             ExpandingCardButton(action: content.action) {
                 HStack(spacing: 0) {
                     content.visualView()
-                        .background(Color.black)
                         .aspectRatio(FeaturedContentCellSize.aspectRatio, contentMode: .fit)
                         .layoutPriority(1)
                     FeaturedDescriptionView(content: content, alignment: descriptionAlignment, detailed: detailed)
@@ -80,7 +79,6 @@ struct FeaturedContentCell<Content: FeaturedContent>: View, PrimaryColorSettable
 #else
             Stack(direction: direction, spacing: 0) {
                 content.visualView()
-                    .background(Color.black)
                     .aspectRatio(FeaturedContentCellSize.aspectRatio, contentMode: .fit)
                     .layoutPriority(1)
                 FeaturedDescriptionView(content: content, alignment: descriptionAlignment, detailed: detailed)

--- a/Application/Sources/UI/Views/FeaturedContentCell.swift
+++ b/Application/Sources/UI/Views/FeaturedContentCell.swift
@@ -63,6 +63,7 @@ struct FeaturedContentCell<Content: FeaturedContent>: View, PrimaryColorSettable
             ExpandingCardButton(action: content.action) {
                 HStack(spacing: 0) {
                     content.visualView()
+                        .background(Color.black)
                         .aspectRatio(FeaturedContentCellSize.aspectRatio, contentMode: .fit)
                         .layoutPriority(1)
                     FeaturedDescriptionView(content: content, alignment: descriptionAlignment, detailed: detailed)
@@ -79,6 +80,7 @@ struct FeaturedContentCell<Content: FeaturedContent>: View, PrimaryColorSettable
 #else
             Stack(direction: direction, spacing: 0) {
                 content.visualView()
+                    .background(Color.black)
                     .aspectRatio(FeaturedContentCellSize.aspectRatio, contentMode: .fit)
                     .layoutPriority(1)
                 FeaturedDescriptionView(content: content, alignment: descriptionAlignment, detailed: detailed)

--- a/Application/Sources/UI/Views/MediaVisualView.swift
+++ b/Application/Sources/UI/Views/MediaVisualView.swift
@@ -41,6 +41,7 @@ struct MediaVisualView<Content: View>: View {
     var body: some View {
         ZStack {
             ImageView(source: model.imageUrl(for: size), contentMode: contentMode)
+                .background(Color.black)
             content(media)
             BlockingOverlay(media: media)
             

--- a/Application/Sources/UI/Views/MediaVisualView.swift
+++ b/Application/Sources/UI/Views/MediaVisualView.swift
@@ -38,7 +38,7 @@ struct MediaVisualView<Content: View>: View {
     var body: some View {
         ZStack {
             ImageView(source: model.imageUrl(for: size), contentMode: contentMode)
-                .background(Color.black)
+                .background(Color.thumbnailBackground)
             content(media)
             BlockingOverlay(media: media)
             

--- a/Application/Sources/UI/Views/MediaVisualView.swift
+++ b/Application/Sources/UI/Views/MediaVisualView.swift
@@ -4,9 +4,6 @@
 //  License information is available from the LICENSE file.
 //
 
-import NukeUI
-import SRGDataProviderModel
-import SRGUserData
 import SwiftUI
 
 // MARK: View

--- a/Application/Sources/UI/Views/ShowButton.swift
+++ b/Application/Sources/UI/Views/ShowButton.swift
@@ -38,7 +38,7 @@ struct ShowButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                ImageView(source: imageUrl)
+                ShowVisualView(source: imageUrl)
                     .aspectRatio(16 / 9, contentMode: .fit)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(show.title)

--- a/Application/Sources/UI/Views/ShowButton.swift
+++ b/Application/Sources/UI/Views/ShowButton.swift
@@ -23,10 +23,6 @@ struct ShowButton: View {
         self.action = action
     }
     
-    private var imageUrl: URL? {
-        return url(for: show.image, size: .small)
-    }
-    
     private var favoriteIcon: ImageResource {
         return isFavorite ? .favoriteFull : .favorite
     }
@@ -38,7 +34,7 @@ struct ShowButton: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                ShowVisualView(source: imageUrl)
+                ShowVisualView(show: show, size: .small)
                     .aspectRatio(16 / 9, contentMode: .fit)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(show.title)

--- a/Application/Sources/UI/Views/ShowCell.swift
+++ b/Application/Sources/UI/Views/ShowCell.swift
@@ -39,6 +39,7 @@ struct ShowCell: View, PrimaryColorSettable {
 #if os(tvOS)
             LabeledCardButton(aspectRatio: ShowCellSize.aspectRatio(for: imageVariant), action: action) {
                 ImageView(source: model.imageUrl(with: imageVariant))
+                    .background(Color.srgGray23)
                     .unredactable()
                     .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: .isButton)
             } label: {

--- a/Application/Sources/UI/Views/ShowCell.swift
+++ b/Application/Sources/UI/Views/ShowCell.swift
@@ -39,7 +39,7 @@ struct ShowCell: View, PrimaryColorSettable {
 #if os(tvOS)
             LabeledCardButton(aspectRatio: ShowCellSize.aspectRatio(for: imageVariant), action: action) {
                 ImageView(source: model.imageUrl(with: imageVariant))
-                    .background(Color.srgGray23)
+                    .background(Color.black)
                     .unredactable()
                     .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: .isButton)
             } label: {
@@ -53,6 +53,7 @@ struct ShowCell: View, PrimaryColorSettable {
 #else
             VStack(spacing: 0) {
                 ImageView(source: model.imageUrl(with: imageVariant))
+                    .background(Color.black)
                     .aspectRatio(ShowCellSize.aspectRatio(for: imageVariant), contentMode: .fit)
                 if imageVariant != .poster {
                     DescriptionView(model: model, style: style)

--- a/Application/Sources/UI/Views/ShowCell.swift
+++ b/Application/Sources/UI/Views/ShowCell.swift
@@ -38,7 +38,7 @@ struct ShowCell: View, PrimaryColorSettable {
         Group {
 #if os(tvOS)
             LabeledCardButton(aspectRatio: ShowCellSize.aspectRatio(for: imageVariant), action: action) {
-                ShowVisualView(source: model.imageUrl(with: imageVariant))
+                ShowVisualView(show: model.show, size: .small, imageVariant: imageVariant)
                     .unredactable()
                     .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: .isButton)
             } label: {
@@ -51,7 +51,7 @@ struct ShowCell: View, PrimaryColorSettable {
             }
 #else
             VStack(spacing: 0) {
-                ShowVisualView(source: model.imageUrl(with: imageVariant))
+                ShowVisualView(show: model.show, size: .small, imageVariant: imageVariant)
                     .aspectRatio(ShowCellSize.aspectRatio(for: imageVariant), contentMode: .fit)
                 if imageVariant != .poster {
                     DescriptionView(model: model, style: style)

--- a/Application/Sources/UI/Views/ShowCell.swift
+++ b/Application/Sources/UI/Views/ShowCell.swift
@@ -38,8 +38,7 @@ struct ShowCell: View, PrimaryColorSettable {
         Group {
 #if os(tvOS)
             LabeledCardButton(aspectRatio: ShowCellSize.aspectRatio(for: imageVariant), action: action) {
-                ImageView(source: model.imageUrl(with: imageVariant))
-                    .background(Color.black)
+                ShowVisualView(source: model.imageUrl(with: imageVariant))
                     .unredactable()
                     .accessibilityElement(label: accessibilityLabel, hint: accessibilityHint, traits: .isButton)
             } label: {
@@ -52,8 +51,7 @@ struct ShowCell: View, PrimaryColorSettable {
             }
 #else
             VStack(spacing: 0) {
-                ImageView(source: model.imageUrl(with: imageVariant))
-                    .background(Color.black)
+                ShowVisualView(source: model.imageUrl(with: imageVariant))
                     .aspectRatio(ShowCellSize.aspectRatio(for: imageVariant), contentMode: .fit)
                 if imageVariant != .poster {
                     DescriptionView(model: model, style: style)

--- a/Application/Sources/UI/Views/ShowCellViewModel.swift
+++ b/Application/Sources/UI/Views/ShowCellViewModel.swift
@@ -38,8 +38,4 @@ extension ShowCellViewModel {
     var title: String? {
         return show?.title
     }
-    
-    func imageUrl(with imageVariant: SRGImageVariant) -> URL? {
-        return imageVariant == .poster ? url(for: show?.posterImage, size: .small) : url(for: show?.image, size: .small)
-    }
 }

--- a/Application/Sources/UI/Views/ShowVisualView.swift
+++ b/Application/Sources/UI/Views/ShowVisualView.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Nuke
+import SwiftUI
+
+// MARK: View
+
+/// Behavior: h-exp, v-exp
+struct ShowVisualView: View {
+    let source: ImageRequestConvertible?
+    let contentMode: ImageView.ContentMode
+    
+    init(source: ImageRequestConvertible?, contentMode: ImageView.ContentMode = .aspectFit) {
+        self.source = source
+        self.contentMode = contentMode
+    }
+    
+    var body: some View {
+        ImageView(source: source, contentMode: contentMode)
+            .background(Color.black)
+    }
+}
+
+// MARK: Preview
+
+struct ShowVisualView_Previews: PreviewProvider {
+    private static func showImageUrl(for show: SRGShow) -> URL? {
+        return SRGDataProvider.current!.url(for: show.image, size: .medium)
+    }
+    
+    static var previews: some View {
+        Group {
+            ShowVisualView(source: showImageUrl(for: Mock.show(.standard)))
+            ShowVisualView(source: showImageUrl(for: Mock.show(.overflow)))
+            ShowVisualView(source: showImageUrl(for: Mock.show(.short)))
+        }
+        .frame(width: 600, height: 500)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/Application/Sources/UI/Views/ShowVisualView.swift
+++ b/Application/Sources/UI/Views/ShowVisualView.swift
@@ -4,39 +4,48 @@
 //  License information is available from the LICENSE file.
 //
 
-import Nuke
 import SwiftUI
 
 // MARK: View
 
 /// Behavior: h-exp, v-exp
 struct ShowVisualView: View {
-    let source: ImageRequestConvertible?
+    let show: SRGShow?
+    let size: SRGImageSize
+    let imageVariant: SRGImageVariant
     let contentMode: ImageView.ContentMode
     
-    init(source: ImageRequestConvertible?, contentMode: ImageView.ContentMode = .aspectFit) {
-        self.source = source
+    init(
+        show: SRGShow?,
+        size: SRGImageSize,
+        imageVariant: SRGImageVariant = .default,
+        contentMode: ImageView.ContentMode = .aspectFit
+    ) {
+        self.show = show
+        self.size = size
+        self.imageVariant = imageVariant
         self.contentMode = contentMode
     }
     
     var body: some View {
-        ImageView(source: source, contentMode: contentMode)
+        ImageView(source: imageUrl, contentMode: contentMode)
             .background(Color.black)
+    }
+    
+    private var imageUrl: URL? {
+        return imageVariant == .poster ? url(for: show?.posterImage, size: size) : url(for: show?.image, size: size)
     }
 }
 
 // MARK: Preview
 
 struct ShowVisualView_Previews: PreviewProvider {
-    private static func showImageUrl(for show: SRGShow) -> URL? {
-        return SRGDataProvider.current!.url(for: show.image, size: .medium)
-    }
-    
     static var previews: some View {
         Group {
-            ShowVisualView(source: showImageUrl(for: Mock.show(.standard)))
-            ShowVisualView(source: showImageUrl(for: Mock.show(.overflow)))
-            ShowVisualView(source: showImageUrl(for: Mock.show(.short)))
+            ShowVisualView(show: Mock.show(.standard), size: .small)
+            ShowVisualView(show: Mock.show(.standard), size: .small, imageVariant: .poster)
+            ShowVisualView(show: Mock.show(.overflow), size: .small)
+            ShowVisualView(show: Mock.show(.short), size: .small)
         }
         .frame(width: 600, height: 500)
         .previewLayout(.sizeThatFits)

--- a/Application/Sources/UI/Views/ShowVisualView.swift
+++ b/Application/Sources/UI/Views/ShowVisualView.swift
@@ -29,7 +29,7 @@ struct ShowVisualView: View {
     
     var body: some View {
         ImageView(source: imageUrl, contentMode: contentMode)
-            .background(Color.black)
+            .background(Color.thumbnailBackground)
     }
     
     private var imageUrl: URL? {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -227,6 +227,16 @@
 		046845AD2BF56A13003A0073 /* ColorsSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046845A52BF56A13003A0073 /* ColorsSettable.swift */; };
 		046845AE2BF56A13003A0073 /* ColorsSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046845A52BF56A13003A0073 /* ColorsSettable.swift */; };
 		046845AF2BF56A13003A0073 /* ColorsSettable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046845A52BF56A13003A0073 /* ColorsSettable.swift */; };
+		0468459B2BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		0468459C2BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		0468459D2BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		0468459E2BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		0468459F2BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		046845A02BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		046845A12BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		046845A22BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		046845A32BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
+		046845A42BF513E2003A0073 /* ShowVisualView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0468459A2BF513E2003A0073 /* ShowVisualView.swift */; };
 		046F8DC02B778E5300A71091 /* RadioChannelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046F8DBF2B778E5300A71091 /* RadioChannelsViewController.swift */; };
 		046F8DC12B778E5300A71091 /* RadioChannelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046F8DBF2B778E5300A71091 /* RadioChannelsViewController.swift */; };
 		046F8DC22B778E5300A71091 /* RadioChannelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046F8DBF2B778E5300A71091 /* RadioChannelsViewController.swift */; };
@@ -2830,6 +2840,7 @@
 		045F8A0E2BA5A8A5005DDCEE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		0463DA0F2A73D8B000CD6556 /* ProgramAndChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramAndChannel.swift; sourceTree = "<group>"; };
 		046845A52BF56A13003A0073 /* ColorsSettable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsSettable.swift; sourceTree = "<group>"; };
+		0468459A2BF513E2003A0073 /* ShowVisualView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowVisualView.swift; sourceTree = "<group>"; };
 		046F8DBF2B778E5300A71091 /* RadioChannelsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioChannelsViewController.swift; sourceTree = "<group>"; };
 		046F8DC52B779E9B00A71091 /* PageContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContainerViewController.swift; sourceTree = "<group>"; };
 		046F8DCB2B77D5F700A71091 /* UIVisualEffectView+PlaySRG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVisualEffectView+PlaySRG.swift"; sourceTree = "<group>"; };
@@ -4851,6 +4862,7 @@
 				04F184CD28EC5EE500B1207C /* ShowButton.swift */,
 				6FB1ADF924EFEF2C00E80C1E /* ShowCell.swift */,
 				6FF0C84626B44F6A006B3C6A /* ShowCellViewModel.swift */,
+				0468459A2BF513E2003A0073 /* ShowVisualView.swift */,
 				6FD4C2D5268B6CBB00F06F63 /* SimpleButton.swift */,
 				6FB899FE26335B090012F1B0 /* Stack.swift */,
 				04395F1A2B1BB72400F6A634 /* TableLoadMoreFooterView.swift */,
@@ -8583,6 +8595,7 @@
 				0451D7EE2B1CEDAD005A2150 /* Banner.swift in Sources */,
 				04395F272B1BC44200F6A634 /* StoreReview.swift in Sources */,
 				08209308208F522A00711DE4 /* PushService.m in Sources */,
+				0468459B2BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6F362A8A26A0706F00CBCC9D /* ProgramGuideDailyViewController.swift in Sources */,
 				6FE38A27270CF860004DD296 /* CarPlayTemplateListController.swift in Sources */,
 				047030E72BBD51340032FA74 /* TopicGradientView.swift in Sources */,
@@ -8771,6 +8784,7 @@
 				042F6F2A29E0710C003F46AA /* UIStackView+PlaySRG.swift in Sources */,
 				6F3CCE9A26CAC7A2004039E2 /* Blur.swift in Sources */,
 				6F73BFB726563C830032D742 /* Content.swift in Sources */,
+				0468459C2BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FD1EF432861A3C500BCBF19 /* PlayNavigationView.swift in Sources */,
 				6F8A545B2655100400AE78FD /* SectionViewController.swift in Sources */,
 				6F9122C01DC8708400725EEB /* PlayErrors.m in Sources */,
@@ -9038,6 +9052,7 @@
 				042F6F2B29E0710C003F46AA /* UIStackView+PlaySRG.swift in Sources */,
 				6F3CCE9B26CAC7A2004039E2 /* Blur.swift in Sources */,
 				6F73BFB826563C830032D742 /* Content.swift in Sources */,
+				0468459D2BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FD1EF442861A3C500BCBF19 /* PlayNavigationView.swift in Sources */,
 				6F8A545C2655100400AE78FD /* SectionViewController.swift in Sources */,
 				6F9122C11DC8708400725EEB /* PlayErrors.m in Sources */,
@@ -9305,6 +9320,7 @@
 				042F6F2C29E0710C003F46AA /* UIStackView+PlaySRG.swift in Sources */,
 				6F3CCE9C26CAC7A2004039E2 /* Blur.swift in Sources */,
 				6F73BFB926563C830032D742 /* Content.swift in Sources */,
+				0468459E2BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FD1EF452861A3C500BCBF19 /* PlayNavigationView.swift in Sources */,
 				6F8A545D2655100400AE78FD /* SectionViewController.swift in Sources */,
 				6F9122C21DC8708400725EEB /* PlayErrors.m in Sources */,
@@ -9657,6 +9673,7 @@
 				6F4CF73A281341B7006AFE6D /* ImageView.swift in Sources */,
 				048FD2132A124CB300929AE5 /* ProfileAccountHeaderViewModel.swift in Sources */,
 				6F0506EB245468EE0053253E /* SplitViewController.m in Sources */,
+				0468459F2BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				041DD1832B1BA8B100C9368A /* TableView.swift in Sources */,
 				04395F1F2B1BB72400F6A634 /* TableLoadMoreFooterView.swift in Sources */,
 				6F4760971EB37DF2003021EA /* UIImageView+PlaySRG.m in Sources */,
@@ -9856,6 +9873,7 @@
 				6FEC89EF261F19A000FF9762 /* ContentInsets.m in Sources */,
 				08F5DB15262DC7F700F717D0 /* Logger.swift in Sources */,
 				6F8125E72638C37900EB029E /* LabeledCardButton.swift in Sources */,
+				046845A02BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FC24A8326395F3E00CACC20 /* FeaturedDescriptionView.swift in Sources */,
 				6F151E27256BF5CF009082F8 /* ProgressBar.swift in Sources */,
 				6FB89A0426335B090012F1B0 /* Stack.swift in Sources */,
@@ -10012,6 +10030,7 @@
 				6FEC89F0261F19A100FF9762 /* ContentInsets.m in Sources */,
 				08F5DB16262DC7F700F717D0 /* Logger.swift in Sources */,
 				6F8125E82638C37900EB029E /* LabeledCardButton.swift in Sources */,
+				046845A12BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FC24A8426395F3E00CACC20 /* FeaturedDescriptionView.swift in Sources */,
 				6F151E28256BF5CF009082F8 /* ProgressBar.swift in Sources */,
 				6FB89A0526335B090012F1B0 /* Stack.swift in Sources */,
@@ -10168,6 +10187,7 @@
 				6FEC89F1261F19A100FF9762 /* ContentInsets.m in Sources */,
 				08F5DB17262DC7F700F717D0 /* Logger.swift in Sources */,
 				6F8125E92638C37900EB029E /* LabeledCardButton.swift in Sources */,
+				046845A22BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FC24A8526395F3E00CACC20 /* FeaturedDescriptionView.swift in Sources */,
 				6F151E29256BF5CF009082F8 /* ProgressBar.swift in Sources */,
 				6FB89A0626335B090012F1B0 /* Stack.swift in Sources */,
@@ -10324,6 +10344,7 @@
 				6FEC8A0B261F19A300FF9762 /* ContentInsets.m in Sources */,
 				08F5DB18262DC7F700F717D0 /* Logger.swift in Sources */,
 				6F8125EA2638C37900EB029E /* LabeledCardButton.swift in Sources */,
+				046845A32BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				6FC24A8626395F3E00CACC20 /* FeaturedDescriptionView.swift in Sources */,
 				6F151E2A256BF5CF009082F8 /* ProgressBar.swift in Sources */,
 				6FB89A0726335B090012F1B0 /* Stack.swift in Sources */,
@@ -10545,6 +10566,7 @@
 				6F1EE83E268A1B0E004A48CA /* ShowHeaderView.swift in Sources */,
 				6F091D64270DE4FE00210713 /* Publishers.swift in Sources */,
 				6FFFB9BB252CA310004E40AE /* MediaDetailViewModel.swift in Sources */,
+				046845A42BF513E2003A0073 /* ShowVisualView.swift in Sources */,
 				08E6136A25843C8300C5FE4B /* PlayApplication.m in Sources */,
 				6F8A54632655100500AE78FD /* SectionViewController.swift in Sources */,
 				6FC44B4E25DE552500DE6E6F /* Recommendation.m in Sources */,


### PR DESCRIPTION
## Description

After some refactoring, we discovered that image not in 16:9 ratio don't have background anymore on iOS, or the default card buttons on tvOS. Let's fix it.

## Changes Made

- Add black background on media images for iOS and tvOS.
- ~Use same gray show image background on tvOS as iOS.~
- Introduce `ShowVisualView` to apply also a black background on show images for iOS and tvOS.

- [x] Rebase on `develop` after PR #451 merge, for `ShowHeaderView`.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.