### PR TITLE
Git hook to append Jira issue key (PLAYRTS-5503)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,29 +38,13 @@ Templates are available when you want to contribute:
 
 Quality checks can be run using:
 
-```shell
+```
 make check-quality
 ```
 
 This ensures that Swift files, and scripts conform to common best practices.
 
 Objective-C files currently have no formal code conventions, but we try to keep our codebase consistent. In general, having a look at the code itself should be enough for you to discover how you should write your changes.
-
-### Git hooks installation
-
-Project git hooks can be installed to help quality checks by running the following command:
-
-```shell
-make git-hook-install
-```
-
-### Git hooks uninstallation
-
-Project git hooks can be uninstalled by running the following command:
-
-```shell
-make git-hook-uninstall
-```
 
 ## Code review
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,8 +29,8 @@ If you are not sure about the likelihood of a change you propose to be accepted,
 
 Templates are available when you want to contribute:
 
-* [Issues](https://github.com/SRGSSR/playsrg-ios/issues/new): Please follow our issue template. You can omit information which does not make sense but, in general, the more details you can provide, the better. This ensures we can quickly reproduce the problem you are facing, increasing the likelihood we can fix it. 
-* [Pull requests](https://github.com/SRGSSR/playsrg-ios/compare): Please follow our code conventions, test your code well, and write unit tests when this makes sense. We will review your work and, if successful, merge it back into the main development branch.
+* [Issues](https://github.com/SRGSSR/playsrg-apple/issues): Please follow our issue template. You can omit information which does not make sense but, in general, the more details you can provide, the better. This ensures we can quickly reproduce the problem you are facing, increasing the likelihood we can fix it. 
+* [Pull requests](https://github.com/SRGSSR/playsrg-apple/pulls): Please follow our code conventions, test your code well, and write unit tests when this makes sense. We will review your work and, if successful, merge it back into the main development branch.
 
 ## Code conventions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,7 +131,7 @@ Some links to [internal Jira SRGSSR instance](https://srgssr-ch.atlassian.net) c
 
 ### Git hooks installation
 
-Project git hooks can be installed to help quality checks and commit messages for internal SRGSSR project. Install its by running the following command:
+Project git hooks can be installed to help quality checks and commit messages for internal SRGSSR project. Install them by running the following command:
 
 ```
 make git-hook-install

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,18 @@ In the iOS application settings, licenses of libraries used in the project can b
 brew install licenseplist
 ```
 
+### SRGSSR project
+
+Some links to [internal Jira SRGSSR instance](https://srgssr-ch.atlassian.net) can be found in commit messages, branch names or pull request titles.
+
+### Git hooks installation
+
+Project git hooks can be installed to help quality checks and commit messages for internal SRGSSR project. Install its by running the following command:
+
+```
+make git-hook-install
+```
+
 ## Translations
 
 Translation tool is [crowdin.com](https://crowdin.com/project/play-srg). The following scripts need [Crowdin CLI](https://crowdin.github.io/crowdin-cli/).

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ This ensures that Swift files, and scripts are conform to common best practices.
 
 ### Licenses for libraries used in the project
 
-In the iOS application settings, licenses of libraries used in the project can be consulted. To build the list, running an iOS target required [LicensePlist](https://github.com/mono0926/LicensePlist).
+In the iOS application settings, licenses of libraries used in the project can be consulted. To build the list, running an iOS target requires [LicensePlist](https://github.com/mono0926/LicensePlist).
 
 ```
 brew install licenseplist

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,10 +35,6 @@ Depending on the business unit some functionalities might not be available (e.g.
 
 The project runs on iOS 14.1, tvOS 14 and above and must be opened with the latest Xcode version.
 
-## Contributing
-
-If you want to contribute to the project, have a look at our [contributing guide](CONTRIBUTING.md).
-
 ## Required tools
 
 - Building the project requires command-line tools for icon generation, easily installed with [Homebrew](https://brew.sh/):
@@ -52,6 +48,12 @@ If you want to contribute to the project, have a look at our [contributing guide
 	```
 	which pod
 	pod --version
+	```
+	
+	If not, install it:
+	
+	```
+	brew install cocoapods
 	```
 
 ## Building the project
@@ -88,6 +90,40 @@ The project can be built without private settings but some features might not be
 ### Running the project
 
 Simply open the project with Xcode and wait until all dependencies have been retrieved. Then build and run the project.
+
+## Contributing
+
+If you want to contribute to the project as an external contributor, have a look at our [contributing guide](CONTRIBUTING.md).
+
+### Quality checks
+
+Checking quality, the project requires command-line tools:
+
+```
+brew install swiftlint shellcheck yamllint
+```
+
+For `rubocop`, be sure that this tool is available on your system, or execute:
+
+```
+bundle install --path vendor/bundle
+```
+
+When all command-line tools are installed, check code quality can be done using:
+
+```
+make check-quality
+```
+
+This ensures that Swift files, and scripts are conform to common best practices.
+
+### Licenses for libraries used in the project
+
+In the iOS application settings, licenses of libraries used in the project can be consulted. To build the list, running an iOS target required [LicensePlist](https://github.com/mono0926/LicensePlist).
+
+```
+brew install licenseplist
+```
 
 ## Translations
 

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#================================================================
+# Append Jira issue id into commit message
+#================================================================
+
+# Inspired from: https://community.atlassian.com/t5/Bitbucket-questions/automatically-append-JIRA-issue-ID-into-commit-message/qaq-p/605991
+
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Search jira issue id from the branch name in a pattern such a "feature/ABC-123-description"
+JIRA_ISSUE=$(echo "$BRANCH_NAME" | sed -nr 's,[a-z]+/([A-Z0-9]+-[0-9]+)-.+,\1,p')
+
+# A developer may have already prepended the commit message with the branch jira issue id
+JIRA_ISSUE_IN_COMMIT=$(grep -c "$JIRA_ISSUE" "$1")
+
+# Only amend commit message if jira issue id was found and not already in commit message
+if [ -n "$JIRA_ISSUE" ]  && ! [ "$JIRA_ISSUE_IN_COMMIT" -ge 1 ]; then
+ echo "📝 Prepending jira issue $JIRA_ISSUE to commit message"
+ sed -i.bak -e "1s/^/$JIRA_ISSUE /" "$1"
+fi

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,21 +1,21 @@
 #!/bin/sh
 
 #================================================================
-# Append Jira issue id into commit message
+# Append Jira issue key into commit message
 #================================================================
 
 # Inspired from: https://community.atlassian.com/t5/Bitbucket-questions/automatically-append-JIRA-issue-ID-into-commit-message/qaq-p/605991
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-# Search jira issue id from the branch name in a pattern such a "feature/ABC-123-description"
-JIRA_ISSUE=$(echo "$BRANCH_NAME" | sed -nr 's,[a-z]+/([A-Z0-9]+-[0-9]+)-.+,\1,p')
+# Search jira issue key from the branch name in a pattern such a "feature/ABC-123-description"
+JIRA_ISSUE_KEY=$(echo "$BRANCH_NAME" | sed -nr 's,[a-z]+/([A-Z0-9]+-[0-9]+)-.+,\1,p')
 
-# A developer may have already prepended the commit message with the branch jira issue id
-JIRA_ISSUE_IN_COMMIT=$(grep -c "$JIRA_ISSUE" "$1")
+# A developer may have already prepended the commit message with the branch jira issue key
+JIRA_ISSUE_KEY_IN_COMMIT=$(grep -c "$JIRA_ISSUE_KEY" "$1")
 
-# Only amend commit message if jira issue id was found and not already in commit message
-if [ -n "$JIRA_ISSUE" ]  && ! [ "$JIRA_ISSUE_IN_COMMIT" -ge 1 ]; then
- echo "📝 Prepending jira issue $JIRA_ISSUE to commit message"
- sed -i.bak -e "1s/^/$JIRA_ISSUE /" "$1"
+# Only amend commit message if jira issue key was found and not already in commit message
+if [ -n "$JIRA_ISSUE_KEY" ]  && ! [ "$JIRA_ISSUE_KEY_IN_COMMIT" -ge 1 ]; then
+ echo "📝 Prepending jira issue $JIRA_ISSUE_KEY to commit message"
+ sed -i.bak -e "1s/^/$JIRA_ISSUE_KEY /" "$1"
 fi


### PR DESCRIPTION
## Description

For the internal SRGSSR project tool, Jira, and its deployment feature, the commit message must includes Jira issue id.
SRF colleagues uses it since years, with including in the branch name, the jira issue id.

It's follow the Jira environment mapping configuration introduction, with #452.

This PR proposes to add a `commit-msg` git hook to append Jira issue id into commit message.

ℹ️ The commit messages in this PR were done with this new `commit-msg` git hook 😇

## Changes Made

- Add git `commit-msg` hook to modify commit message if the jira issue id exist in the branch name.
  - The format is adapted to a simple one: “JIRA-KEY Original commit message”.
- Nice documentations update about required command-lines tools, thanks to @mutaben new contributions.
- Add mention about the internal Jira SRGSSR project.

The git `commit-msg` hook is executed with:
- Signed commit.
- Normal commit.
- Append commit.

Not executed with a git interactive rebase and message rewordings.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.