### PR TITLE
Improve error message (PLAYRTS-5527)

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "Il media non può essere riprodotto.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "La pagina non può essere aperta.";
 

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "Il medium na po betg vegnir avert.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "La preschentaziun na po betg vegnir averta.";
 

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "Le contenu ne peut être ouvert.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "La page ne peut être ouverte.";
 

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "Der Inhalt kann nicht geöffnet werden.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "Seite konnte nicht geöffnet werden.";
 

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "The media cannot be opened.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "The page cannot be opened.";
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -685,9 +685,15 @@ extension PageViewController: SectionHeaderViewAction {
         
         SRGDataProvider.current!.contentPage(for: ApplicationConfiguration.shared.vendor, uid: id)
             .receive(on: DispatchQueue.main)
-            .sink { error in
-                if case .failure(let failure) = error {
-                    Banner.showError(failure as NSError)
+            .sink { result in
+                if case .failure = result {
+                    let error = NSError(
+                        domain: PlayErrorDomain,
+                        code: PlayErrorCode.notFound.rawValue,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: NSLocalizedString("The page cannot be opened.", comment: "Error message when a page cannot be opened from a page section title")
+                        ])
+                    Banner.showError(error)
                 }
             } receiveValue: { contentPage in
                 let pageViewController = PageViewController.pageViewController(for: contentPage)

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -738,7 +738,8 @@
    Error message when a media cannot be opened via Handoff, deep linking or a push notification */
 "The media cannot be opened." = "The media cannot be opened.";
 
-/* Error message when a page cannot be opened via Handoff, deep linking or a push notification
+/* Error message when a page cannot be opened from a page section title
+   Error message when a page cannot be opened via Handoff, deep linking or a push notification
    Error message when a topic cannot be opened via Handoff, deep linking or a push notification */
 "The page cannot be opened." = "The page cannot be opened.";
 


### PR DESCRIPTION
## Description

Following #479 , a test when a content page is not avaible, the error message on iOS was too technical.
The PR propose to use same user error message as used in deep links.

| Currently  | Proposition |
| ------------- | ------------- |
|  ![Banner error message - before](https://github.com/SRGSSR/playsrg-apple/assets/380522/32d5f8ea-f80f-4eb4-bf99-0ff8ae8187cd) | ![Banner error message - after](https://github.com/SRGSSR/playsrg-apple/assets/380522/1810ce10-279b-4ef7-991a-10fcb12353ed) |

Code path to test: [Test swimlane page link not found.patch](https://github.com/SRGSSR/playsrg-apple/files/15355520/Test.swimlane.page.link.not.found.patch)


## Changes Made

- Update banner error message with page section link to micro page can't be loaded.
- Update translation files, according to.  

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.