### PR TITLE
CI: clean untracked files when an error occurred

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1101,7 +1101,7 @@ platform :ios do
     if cleaned_lane_condition(lane)
       clean_build_artifacts
       ENV.delete('DERIVED_DATA_CLEANED')
-      reset_git_repo(skip_clean: true, force: true)
+      reset_git_repo(force: true)
     end
   end
 end


### PR DESCRIPTION
## Description

When Xcode 15 pushed a build phases reorder (#374) to have the custom icons, a risk reappeared again to not have a clean repository during a build issue.

The issue came again because of a [tvOS build issue](https://github.com/SRGSSR/playsrg-apple/commit/e92cdfbb0dabeb6e49e2c4ef445e37b5bd461a31): https://github.com/SRGSSR/playsrg-apple/deployments/playsrg-tvos-nightly%2BPLAYRTS-5527-swimlane-link-to-micropage

The copied original application icons [are not removed](https://playcity.eu.ngrok.io/buildConfiguration/playsrgios_NightliesTvOS/443707?buildTab=log&linesState=138&logView=flowAware&focusLine=245):
```
16:25:53   Uncommitted changes:
16:25:53   ?? OriginalAppIcon.appiconset/
16:25:53   ?? OriginalAppStoreTVIcon.appiconset/
16:25:53   ?? OriginalTVAppIcon.appiconset/
```

This PR proposes to force a full clean if an error occurred, including cache and untracked files like the `last-#{service}#{platform}nightlies-success-git-commit-hash.txt` files.

## Changes Made

- Update `Fastfile` error handles, to not skip git clean during the reset step. 

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.