### PR TITLE
PLAYRTS-5528 Update playback end tolerance

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -25,7 +25,7 @@
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,
-  "endToleranceRatio": 0.02,
+  "endToleranceRatio": 0.07,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
   "searchSettingSubtitledHidden": true,
   "subtitleAvailabilityHidden": true,

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -23,7 +23,7 @@
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,
-  "endToleranceRatio": 0.02,
+  "endToleranceRatio": 0.07,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
   "discoverySubtitleOptionLanguage": "de",
   "audioDescriptionAvailabilityHidden": true,

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -28,7 +28,7 @@
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,
-  "endToleranceRatio": 0.02,
+  "endToleranceRatio": 0.07,
   "hiddenOnboardings": "favorites,resume_playback,watch_later",
   "showLeadPreferred": true,
   "tvGuideOtherBouquets": "srf,rsi",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -24,7 +24,7 @@
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,
-  "endToleranceRatio": 0.02,
+  "endToleranceRatio": 0.07,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",
   "audioDescriptionAvailabilityHidden": true,
   "posterImagesEnabled": true,

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -20,7 +20,7 @@
   "continuousPlaybackPlayerViewTransitionDuration": 10,
   "continuousPlaybackForegroundTransitionDuration": 0,
   "continuousPlaybackBackgroundTransitionDuration": 0,
-  "endToleranceRatio": 0.02,
+  "endToleranceRatio": 0.07,
   "searchSettingsHidden": true,
   "showsSearchHidden": true,
   "hiddenOnboardings": "account,favorites_account,resume_playback_account,watch_later_account",

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -140,7 +140,7 @@ Feeds
 
 ## Resume playback
 
-* `endTolerance` (optional, number): Duration tolerance in seconds at the end of a media to consider it as finished and does not resume from last position, but from the beginning. If empty, the default value is 0 seconds.
+* `endTolerance` (optional, number): Duration tolerance in seconds at the end of a media to consider it as finished and then subsequently not resume it from last position, but from the beginning. If empty, the default value is 0 seconds.
 * `endToleranceRatio` (optional, number): Pourcentage tolerance as float at the end of a media to consider it as finished and does not resume from last position, but from the beginning. If empty, the default value is 0.0.
 
 ## Continuous playback

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -138,6 +138,11 @@ Feeds
 * `searchSettingSubtitledHidden` (optional, boolean): Set to `true` to hide the subtitled option in the search settings.
 * `showsSearchHidden ` (optional, boolean): Set to `true` to hide show search results.
 
+## Resume playback
+
+* `endTolerance` (optional, number): Duration tolerance in seconds at the end of a media to consider it as finished and does not resume from last position, but from the beginning. If empty, the default value is 0 seconds.
+* `endToleranceRatio` (optional, number): Pourcentage tolerance as float at the end of a media to consider it as finished and does not resume from last position, but from the beginning. If empty, the default value is 0.0.
+
 ## Continuous playback
 
 * `continuousPlaybackPlayerViewTransitionDuration` (optional, number): Duration in seconds for continuous playback when the player view is displayed. If empty, continuous playback is disabled; if equal to 0, upcoming media playback starts immediately.

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -141,7 +141,7 @@ Feeds
 ## Resume playback
 
 * `endTolerance` (optional, number): Duration tolerance in seconds at the end of a media to consider it as finished and then subsequently not resume it from last position, but from the beginning. If empty, the default value is 0 seconds.
-* `endToleranceRatio` (optional, number): Pourcentage tolerance as float at the end of a media to consider it as finished and does not resume from last position, but from the beginning. If empty, the default value is 0.0.
+* `endToleranceRatio` (optional, number): Percentage tolerance as a floating number at the end of a media to consider it as finished and then subsequently not resume it from last position, but from the beginning. If empty, the default value is 0.0.
 
 ## Continuous playback
 


### PR DESCRIPTION
## Description

From a user feedback, the "resume playback " swimlane contains too much videos and audios which look finished.

The PR proposes to switch to 7% instead of 2%, after weeks of tests.
It also fix missing documentation.

## Changes Made

- Update local configuration json files.
- Update remote configuration documentation.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.