### PR TITLE
PLAYRTS-5521 Use 16:9 images in alphabetical TV shows view

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -633,7 +633,7 @@ private extension Content {
         var imageVariant: SRGImageVariant {
             switch configuredSection {
             case .tvAllShows:
-                return ContentType.videoOrTV.imageVariant
+                return .default
             case .radioAllShows:
                 return ContentType.audioOrRadio.imageVariant
             default:


### PR DESCRIPTION
## Description

**As** a user
**I want to** easily find the show i’m looking for in Show AZ view
**So that** display show items in portrait with title. So the search is easier.

## Changes Made

- In the TV show AZ view, switch show cells layout from poster to default 16:9 image variant with displayed title.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.