### PR TITLE
PLAYRTS-5533 Always enable blur on bar to avoid UI glitches

### DIFF
--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -61,7 +61,6 @@ class PageContainerViewController: UIViewController {
     
     private func configureBarView() {
         let blurView = UIVisualEffectView.play_blurView
-        blurView.alpha = 1.0
         self.blurView = blurView
         
         let barView = TMBarView<TMHorizontalBarLayout, TMTabItemBarButton, TMLineBarIndicator>()


### PR DESCRIPTION
This is a follow up PR to https://github.com/SRGSSR/playsrg-apple/pull/486.

The only change is to always enable blur to avoid a UI glitch that occurs when scrolling.