### PR TITLE
PLAYRTS-5562 Open player if media highlight section as only one media

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -155,6 +155,7 @@ protocol SectionProperties {
     var supportsEdition: Bool { get }
     var emptyType: EmptyContentView.`Type` { get }
     var hasHighlightedItem: Bool { get }
+    var couldHaveHighlightedItem: Bool { get }
 
     var displayedShow: SRGShow? { get }
     #if os(iOS)
@@ -296,6 +297,10 @@ private extension Content {
 
         var hasHighlightedItem: Bool {
             presentation.type == .showPromotion
+        }
+
+        var couldHaveHighlightedItem: Bool {
+            presentation.type == .highlight
         }
 
         var displayedShow: SRGShow? {
@@ -675,6 +680,10 @@ private extension Content {
         }
 
         var hasHighlightedItem: Bool {
+            false
+        }
+
+        var couldHaveHighlightedItem: Bool {
             false
         }
 

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -499,6 +499,8 @@ extension PageViewController: UICollectionViewDelegate {
                         if case let .show(show) = highlightedItem {
                             let pageViewController = PageViewController(id: .show(show))
                             navigationController.pushViewController(pageViewController, animated: true)
+                        } else if case let .media(media) = highlightedItem {
+                            play_presentMediaPlayer(with: media, position: nil, airPlaySuggestions: true, fromPushNotification: false, animated: true, completion: nil)
                         } else {
                             let sectionViewController = SectionViewController(section: section.wrappedValue, filter: model.id)
                             navigationController.pushViewController(sectionViewController, animated: true)

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -596,7 +596,9 @@ private extension PageViewModel {
                 .map { items in
                     guard let firstItem = items.first else { return Row(section: section, items: []) }
 
-                    let highlightedItem = section.properties.hasHighlightedItem ? firstItem : nil
+                    let highlightedItem = section.properties.hasHighlightedItem ? firstItem :
+                        section.properties.couldHaveHighlightedItem && items.count == 1 ? firstItem : nil
+
                     let item = Item(.item(.highlight(highlight, item: highlightedItem)), in: section)
                     return Row(section: section, items: [item])
                 }

--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -36,6 +36,8 @@ struct HighlightCell: View {
         private func action() {
             if case let .show(show) = item {
                 navigateToShow(show)
+            } else if case let .media(media) = item {
+                navigateToMedia(media)
             } else {
                 navigateToSection(section, filter: filter)
             }


### PR DESCRIPTION
## Description

**As** a user
**I want to** play the media highlight content with less tap/click if only one editorialised media in
**so that** I don’t ask myself with this highlight detail page exists with only one content.

## Changes Made

- A section could have an highlighted item now.
- If this section as only 1 item, it's the highlighted.
- `PageViewController` displays the media player page if the highlighted is a media.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.