### PR TITLE
PLAYRTS-5538 Update RTS AppStore screenshots workflow

### DIFF
--- a/UITests/Screenshots/Sources/ApplicationScreenshots~ios.swift
+++ b/UITests/Screenshots/Sources/ApplicationScreenshots~ios.swift
@@ -13,7 +13,7 @@ class ApplicationScreenshots: XCTestCase {
         [:]
     }
 
-    override func setUp() {
+    @MainActor override func setUp() {
         super.setUp()
 
         let app = XCUIApplication()
@@ -25,7 +25,7 @@ class ApplicationScreenshots: XCTestCase {
         XCUIDevice.shared.orientation = (UIDevice.current.userInterfaceIdiom == .pad) ? .landscapeLeft : .portrait
     }
 
-    func testSnapshots() {
+    @MainActor func testSnapshots() {
         if let videosTabBarItem = tabBarItem(withIdentifier: AccessibilityIdentifier.videosTabBarItem.value) {
             videosTabBarItem.tap()
             sleep(10)

--- a/UITests/Screenshots/Sources/ApplicationScreenshots~tvos.swift
+++ b/UITests/Screenshots/Sources/ApplicationScreenshots~tvos.swift
@@ -13,7 +13,7 @@ class ApplicationScreenshots: XCTestCase {
         [:]
     }
 
-    override func setUp() {
+    @MainActor override func setUp() {
         super.setUp()
 
         let app = XCUIApplication()
@@ -23,7 +23,7 @@ class ApplicationScreenshots: XCTestCase {
         continueAfterFailure = false
     }
 
-    func testSnapshots() {
+    @MainActor func testSnapshots() {
         // Wait a bit for the focus engine to determine the first focused item
         sleep(5)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -57,6 +57,8 @@
 
 ### \*\*Manual fastlane:
 
+⚠️ All screenshots lanes must be executed from a Swiss IP, to avoid geo-blocking icons on media items.
+
 - Screenshots iOS
 	- Play RSI iOS: `fastlane ios iOSrsiScreenshots`
 	- Play RTR iOS: `fastlane ios iOSrtrScreenshots`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -60,12 +60,12 @@
 - Screenshots iOS
 	- Play RSI iOS: `fastlane ios iOSrsiScreenshots`
 	- Play RTR iOS: `fastlane ios iOSrtrScreenshots`
-	- Play RTS iOS: `fastlane ios iOSrtsScreenshots`
+	- Play RTS iOS: `fastlane ios iOSrtsScreenshots` (No upload to ASC, due to some marketing images)
 	- Play SRF iOS: `fastlane ios iOSsrfScreenshots` (No upload to ASC, due to some marketing images)
 - Screenshots tvOS
 	- Play RSI tvOS: `fastlane ios tvOSrsiScreenshots`
 	- Play RTR tvOS: `fastlane ios tvOSrtrScreenshots`
-	- Play RTS tvOS: `fastlane ios tvOSrtsScreenshots`
+	- Play RTS tvOS: `fastlane ios tvOSrtsScreenshots` (No upload to ASC, due to some marketing images)
 	- Play SRF tvOS: `fastlane ios tvOSsrfScreenshots` (No upload to ASC, due to some marketing images)
 
 # Private nightlies

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -415,12 +415,12 @@ platform :ios do
     upload_screenshots(platform)
   end
 
-  desc 'RTS: Makes iOS screenshots and replaces current ones on App Store Connect.'
+  desc 'RTS: Makes iOS screenshots. No replacement made on App Store Connect.'
   lane :iOSrtsScreenshots do
     platform = 'iOS'
 
     screenshots(platform, 'RTS')
-    upload_screenshots(platform)
+    # Don't erase existing screenshots, from RTS marketing team.
   end
 
   desc 'SRF: Makes iOS screenshots. No replacement made on App Store Connect.'
@@ -553,12 +553,12 @@ platform :ios do
     upload_screenshots(platform)
   end
 
-  desc 'RTS: Makes tvOS screenshots and replaces current ones on App Store Connect.'
+  desc 'RTS: Makes tvOS screenshots. No replacement made on App Store Connect.'
   lane :tvOSrtsScreenshots do
     platform = 'tvOS'
 
     screenshots(platform, 'RTS')
-    upload_screenshots(platform)
+    # Don't erase existing screenshots, from RTS marketing team.
   end
 
   desc 'SRF: Makes tvOS screenshots. No replacement made on App Store Connect.'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -205,7 +205,7 @@ RTR: Makes iOS screenshots and replaces current ones on App Store Connect.
 [bundle exec] fastlane ios iOSrtsScreenshots
 ```
 
-RTS: Makes iOS screenshots and replaces current ones on App Store Connect.
+RTS: Makes iOS screenshots. No replacement made on App Store Connect.
 
 ### ios iOSsrfScreenshots
 
@@ -365,7 +365,7 @@ RTR: Makes tvOS screenshots and replaces current ones on App Store Connect.
 [bundle exec] fastlane ios tvOSrtsScreenshots
 ```
 
-RTS: Makes tvOS screenshots and replaces current ones on App Store Connect.
+RTS: Makes tvOS screenshots. No replacement made on App Store Connect.
 
 ### ios tvOSsrfScreenshots
 


### PR DESCRIPTION
## Description

Like SRF marketing team, RTS marketing takes care of the AppStore detail page, and its previews and screenshots.
In the fastlane scripts, remove the "upload" step, to avoid erasing the current screenshots.

## Changes Made

- Fix iOS and tvOS screenshots builds.
- Remove `upload_screenshots(platform)` for RTS screenshots lanes.

## How to test

- Running in Xcode the screenshots targets have a build success.
- Running locally in Terminal.app ` creates the expected screenshots images from the target in the repository folder `fastlane/export` but not upload anymore on AppStore Connect the new screenshots:
  - `bundle exec fastlane iOS tvOSrtsScreenshots` for RTS tvOS screenshots.
  - `bundle exec fastlane iOS iOSrtsScreenshots` for RTS iOS screenshots.

⚠️ Running SRF variants also don't upload new screenshots. But running RSI or RTR variants will replace on the AppStore Connect existing screenshots with new one. 

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.