### PR TITLE
PLAYRTS-5541 Beta only audio content pages with new section types

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -610,8 +610,11 @@
    Resume playback button label */
 "Resume" = "Riprendi";
 
-/* Title label used to present medias whose playback can be resumed */
-"Resume playback" = "Riprendere la riproduzione";
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Riprendere la riproduzione";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Riprendere la riproduzione";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -610,11 +610,14 @@
    Resume playback button label */
 "Resume" = "Riprendi";
 
+/* Title label used to present medias whose playback can be resumed */
+"Resume playback" = "Riprendere la riproduzione";
+
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Riprendere la riproduzione";
+"Resume audios playback" = "Riprendere la riproduzione";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Riprendere la riproduzione";
+"Resume videos playback" = "Riprendere la riproduzione";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -610,11 +610,14 @@
    Resume playback button label */
 "Resume" = "Guardar vinavant";
 
+/* Title label used to present medias whose playback can be resumed */
+"Resume playback" = "Cuntinuar";
+
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Cuntinuar";
+"Resume audios playback" = "Cuntinuar consumaziun";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Cuntinuar";
+"Resume videos playback" = "Cuntinuar consumaziun";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -610,8 +610,11 @@
    Resume playback button label */
 "Resume" = "Guardar vinavant";
 
-/* Title label used to present medias whose playback can be resumed */
-"Resume playback" = "Cuntinuar";
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Cuntinuar";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Cuntinuar";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -610,11 +610,14 @@
    Resume playback button label */
 "Resume" = "Reprendre";
 
+/* Title label used to present medias whose playback can be resumed */
+"Resume playback" = "Reprendre la lecture";
+
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Reprendre la lecture";
+"Resume audios playback" = "Reprendre la lecture";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Reprendre la lecture";
+"Resume videos playback" = "Reprendre la lecture";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -610,8 +610,11 @@
    Resume playback button label */
 "Resume" = "Reprendre";
 
-/* Title label used to present medias whose playback can be resumed */
-"Resume playback" = "Reprendre la lecture";
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Reprendre la lecture";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Reprendre la lecture";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -610,11 +610,14 @@
    Resume playback button label */
 "Resume" = "Weiter abspielen";
 
+/* Title label used to present medias whose playback can be resumed */
+"Resume playback" = "Weiterschauen";
+
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Weiterhören";
+"Resume audios playback" = "Weiterhören";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Weiterschauen";
+"Resume videos playback" = "Weiterschauen";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -610,8 +610,11 @@
    Resume playback button label */
 "Resume" = "Weiter abspielen";
 
-/* Title label used to present medias whose playback can be resumed */
-"Resume playback" = "Weiterschauen";
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Weiterhören";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Weiterschauen";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -610,11 +610,14 @@
    Resume playback button label */
 "Resume" = "Resume";
 
+/* Title label used to present medias whose playback can be resumed */
+"Resume playback" = "Resume playback";
+
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Resume audio playback";
+"Resume audios playback" = "Resume playback";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Resume video playback";
+"Resume videos playback" = "Resume playback";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -610,8 +610,11 @@
    Resume playback button label */
 "Resume" = "Resume";
 
-/* Title label used to present medias whose playback can be resumed */
-"Resume playback" = "Resume playback";
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Resume audio playback";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Resume video playback";
 
 /* Label to present the search view
    Search shortcut label

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -94,7 +94,7 @@ name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version:
 
 name: srgcontentprotection-apple, nameSpecified: SRGContentProtection, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgcontentprotection-apple
 
-name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 19.0.5, source: https://github.com/SRGSSR/srgdataprovider-apple
+name: srgdataprovider-apple, nameSpecified: SRGDataProvider, owner: SRGSSR, version: 19.0.6, source: https://github.com/SRGSSR/srgdataprovider-apple
 
 name: srgdiagnostics-apple, nameSpecified: SRGDiagnostics, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgdiagnostics-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -286,7 +286,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgdataprovider-apple</string>
 			<key>Title</key>
-			<string>SRGDataProvider (19.0.5)</string>
+			<string>SRGDataProvider (19.0.6)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Sources/Calendar/CalendarViewController.m
+++ b/Application/Sources/Calendar/CalendarViewController.m
@@ -22,6 +22,7 @@
 
 @interface CalendarViewController ()
 
+@property (nonatomic) SRGTransmission transmission;
 @property (nonatomic) RadioChannel *radioChannel;
 @property (nonatomic) NSDate *initialDate;
 
@@ -46,6 +47,7 @@
 - (instancetype)initWithRadioChannel:(RadioChannel *)radioChannel date:(NSDate *)date
 {
     if (self = [self init]) {
+        self.transmission = radioChannel ? SRGTransmissionRadio : SRGTransmissionTV;
         self.radioChannel = radioChannel;
         self.initialDate = date;
         self.selectionFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
@@ -257,7 +259,7 @@
         }
     }
     
-    UIViewController *newDailyMediasViewController = [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] channelUid:self.radioChannel.uid];
+    UIViewController *newDailyMediasViewController = [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] transmission:self.transmission channelUid:self.radioChannel.uid];
     [self.pageViewController setViewControllers:@[newDailyMediasViewController] direction:navigationDirection animated:animated completion:nil];
     [self play_setNeedsScrollableViewUpdate];
     
@@ -433,7 +435,7 @@
     
     UIViewController<DailyMediasViewController> *currentDailyMediasViewController = (UIViewController<DailyMediasViewController> *)viewController;
     NSDate *date = [NSCalendar.srg_defaultCalendar dateByAddingComponents:dateComponents toDate:currentDailyMediasViewController.date options:0];
-    return [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] channelUid:self.radioChannel.uid];
+    return [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] transmission:self.transmission channelUid:self.radioChannel.uid];
 }
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerAfterViewController:(UIViewController *)viewController
@@ -447,7 +449,7 @@
     dateComponents.day = 1;
     
     NSDate *date = [NSCalendar.srg_defaultCalendar dateByAddingComponents:dateComponents toDate:currentDailyMediasViewController.date options:0];
-    return [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] channelUid:self.radioChannel.uid];
+    return [SectionViewController mediasViewControllerForDay:[SRGDay dayFromDate:date] transmission:self.transmission channelUid:self.radioChannel.uid];
 }
 
 #pragma mark UIPageViewControllerDelegate protocol

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -210,8 +210,10 @@ private extension Content {
                     NSLocalizedString("Latest episodes from your favorites", comment: "Title label used to present the latest episodes from TV favorite shows")
                 case .livestreams:
                     NSLocalizedString("TV channels", comment: "Title label to present main TV livestreams")
-                case .continueWatching, .continueListening:
-                    NSLocalizedString("Resume playback", comment: "Title label used to present medias whose playback can be resumed")
+                case .continueWatching:
+                    NSLocalizedString("Resume video playback", comment: "Title label used to present videos whose playback can be resumed")
+                case .continueListening:
+                    NSLocalizedString("Resume audio playback", comment: "Title label used to present audios whose playback can be resumed")
                 case .watchLater:
                     NSLocalizedString("Later", comment: "Title Label used to present the video later list")
                 case .showAccess:
@@ -596,7 +598,7 @@ private extension Content {
             case .radioMostPopular:
                 return NSLocalizedString("Most listened to", comment: "Title label used to present the radio most popular audio medias")
             case .radioResumePlayback:
-                return NSLocalizedString("Resume playback", comment: "Title label used to present medias whose playback can be resumed")
+                return NSLocalizedString("Resume audio playback", comment: "Title label used to present audios whose playback can be resumed")
             case .radioWatchLater, .watchLater:
                 return NSLocalizedString("Later", comment: "Title Label used to present the audio later list")
             case .tvLive:

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -210,7 +210,7 @@ private extension Content {
                     NSLocalizedString("Latest episodes from your favorites", comment: "Title label used to present the latest episodes from TV favorite shows")
                 case .livestreams:
                     NSLocalizedString("TV channels", comment: "Title label to present main TV livestreams")
-                case .continueWatching:
+                case .continueWatching, .continueListening:
                     NSLocalizedString("Resume playback", comment: "Title label used to present medias whose playback can be resumed")
                 case .watchLater:
                     NSLocalizedString("Later", comment: "Title Label used to present the video later list")
@@ -265,7 +265,7 @@ private extension Content {
             switch contentSection.type {
             case .predefined:
                 switch presentation.type {
-                case .favoriteShows, .continueWatching, .watchLater:
+                case .favoriteShows, .continueWatching, .watchLater, .continueListening:
                     true
                 default:
                     false
@@ -283,7 +283,7 @@ private extension Content {
                     .favoriteShows
                 case .myProgram:
                     .episodesFromFavorites
-                case .continueWatching:
+                case .continueWatching, .continueListening:
                     .resumePlayback
                 case .watchLater:
                     .watchLater
@@ -327,7 +327,7 @@ private extension Content {
                     AnalyticsPageTitle.favorites.rawValue
                 case .myProgram:
                     AnalyticsPageTitle.latestEpisodesFromFavorites.rawValue
-                case .continueWatching:
+                case .continueWatching, .continueListening:
                     AnalyticsPageTitle.resumePlayback.rawValue
                 case .watchLater:
                     AnalyticsPageTitle.watchLater.rawValue
@@ -367,7 +367,7 @@ private extension Content {
                 AnalyticsEvent.favorite(action: .remove, source: source, urn: nil)
             case .watchLater:
                 AnalyticsEvent.watchLater(action: .remove, source: source, urn: nil)
-            case .continueWatching:
+            case .continueWatching, .continueListening:
                 AnalyticsEvent.historyRemove(source: source, urn: nil)
             default:
                 nil
@@ -463,7 +463,7 @@ private extension Content {
                     return dataProvider.tvTopics(for: contentSection.vendor)
                         .map { $0.map { .topic($0) } }
                         .eraseToAnyPublisher()
-                case .continueWatching:
+                case .continueWatching, .continueListening:
                     return dataProvider.resumePlaybackPublisher(pageSize: pageSize, paginatedBy: paginator, filter: filter)
                         .map { $0.map { .media($0) } }
                         .eraseToAnyPublisher()
@@ -505,7 +505,7 @@ private extension Content {
                 switch contentSection.presentation.type {
                 case .favoriteShows, .myProgram:
                     UserInteractionSignal.favoriteUpdates()
-                case .continueWatching:
+                case .continueWatching, .continueListening:
                     UserInteractionSignal.historyUpdates()
                 case .watchLater:
                     UserInteractionSignal.watchLaterUpdates()
@@ -536,7 +536,7 @@ private extension Content {
                 Content.removeFromFavorites(items)
             case .watchLater:
                 Content.removeFromWatchLater(items)
-            case .continueWatching:
+            case .continueWatching, .continueListening:
                 Content.removeFromHistory(items)
             default:
                 break

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -211,9 +211,9 @@ private extension Content {
                 case .livestreams:
                     NSLocalizedString("TV channels", comment: "Title label to present main TV livestreams")
                 case .continueWatching:
-                    NSLocalizedString("Resume video playback", comment: "Title label used to present videos whose playback can be resumed")
+                    NSLocalizedString("Resume videos playback", comment: "Title label used to present videos whose playback can be resumed")
                 case .continueListening:
-                    NSLocalizedString("Resume audio playback", comment: "Title label used to present audios whose playback can be resumed")
+                    NSLocalizedString("Resume audios playback", comment: "Title label used to present audios whose playback can be resumed")
                 case .watchLater:
                     NSLocalizedString("Later", comment: "Title Label used to present the video later list")
                 case .showAccess:
@@ -598,7 +598,7 @@ private extension Content {
             case .radioMostPopular:
                 return NSLocalizedString("Most listened to", comment: "Title label used to present the radio most popular audio medias")
             case .radioResumePlayback:
-                return NSLocalizedString("Resume audio playback", comment: "Title label used to present audios whose playback can be resumed")
+                return NSLocalizedString("Resume audios playback", comment: "Title label used to present audios whose playback can be resumed")
             case .radioWatchLater, .watchLater:
                 return NSLocalizedString("Later", comment: "Title Label used to present the audio later list")
             case .tvLive:

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -57,10 +57,8 @@ final class PageViewController: UIViewController {
 
     #if os(iOS)
         private static func showByDateViewController(transmission: SRGTransmission, radioChannel: RadioChannel?, date: Date?) -> UIViewController {
-            if transmission == .radio, let radioChannel {
-                CalendarViewController(radioChannel: radioChannel, date: date)
-            } else if transmission == .radio, let radioChannel = ApplicationConfiguration.shared.radioHomepageChannels.first {
-                // FIXME: Load all radio episodes by date, not only from the first channel.
+            // FIXME: If `radioChannel` is null, load all radio episodes by date, not only from the first radio channel.
+            if transmission == .radio, let radioChannel = radioChannel ?? ApplicationConfiguration.shared.radioHomepageChannels.first {
                 CalendarViewController(radioChannel: radioChannel, date: date)
             } else if !ApplicationConfiguration.shared.isTvGuideUnavailable {
                 ProgramGuideViewController(date: date)

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -56,8 +56,11 @@ final class PageViewController: UIViewController {
     }
 
     #if os(iOS)
-        private static func showByDateViewController(radioChannel: RadioChannel?, date: Date?) -> UIViewController {
-            if let radioChannel {
+        private static func showByDateViewController(transmission: SRGTransmission, radioChannel: RadioChannel?, date: Date?) -> UIViewController {
+            if transmission == .radio, let radioChannel {
+                CalendarViewController(radioChannel: radioChannel, date: date)
+            } else if transmission == .radio, let radioChannel = ApplicationConfiguration.shared.radioHomepageChannels.first {
+                // FIXME: Load all radio episodes by date, not only from the first channel.
                 CalendarViewController(radioChannel: radioChannel, date: date)
             } else if !ApplicationConfiguration.shared.isTvGuideUnavailable {
                 ProgramGuideViewController(date: date)
@@ -620,14 +623,14 @@ extension PageViewController: UIScrollViewDelegate {
             case .showByDate:
                 let date = applicationSectionInfo.options?[ApplicationSectionOptionKey.showByDateDateKey] as? Date
                 if let navigationController {
-                    let showByDateViewController = Self.showByDateViewController(radioChannel: radioChannel, date: date)
+                    let showByDateViewController = Self.showByDateViewController(transmission: .radio, radioChannel: radioChannel, date: date)
                     navigationController.pushViewController(showByDateViewController, animated: false)
                 }
                 return true
             case .showAZ:
                 if let navigationController {
                     let initialSectionId = applicationSectionInfo.options?[ApplicationSectionOptionKey.showAZIndexKey] as? String
-                    let showsViewController = SectionViewController.showsViewController(forChannelUid: radioChannel?.uid, initialSectionId: initialSectionId)
+                    let showsViewController = SectionViewController.showsViewController(forTransmission: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId)
                     navigationController.pushViewController(showsViewController, animated: false)
                 }
                 return true
@@ -643,16 +646,16 @@ extension PageViewController: UIScrollViewDelegate {
     }
 
     extension PageViewController: ShowAccessCellActions {
-        func openShowAZ() {
-            if let navigationController {
-                let showsViewController = SectionViewController.showsViewController(forChannelUid: radioChannel?.uid)
+        func openShowAZ(sender _: Any?, event: ShowAccessEvent?) {
+            if let navigationController, let event {
+                let showsViewController = SectionViewController.showsViewController(forTransmission: event.transmission, channelUid: radioChannel?.uid)
                 navigationController.pushViewController(showsViewController, animated: true)
             }
         }
 
-        func openShowByDate() {
-            if let navigationController {
-                let showByDateViewController = Self.showByDateViewController(radioChannel: radioChannel, date: nil)
+        func openShowByDate(sender _: Any?, event: ShowAccessEvent?) {
+            if let navigationController, let event {
+                let showByDateViewController = Self.showByDateViewController(transmission: event.transmission, radioChannel: radioChannel, date: nil)
                 navigationController.pushViewController(showByDateViewController, animated: true)
             }
         }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -628,7 +628,7 @@ extension PageViewController: UIScrollViewDelegate {
             case .showAZ:
                 if let navigationController {
                     let initialSectionId = applicationSectionInfo.options?[ApplicationSectionOptionKey.showAZIndexKey] as? String
-                    let showsViewController = SectionViewController.showsViewController(forTransmission: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId)
+                    let showsViewController = SectionViewController.showsViewController(for: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId)
                     navigationController.pushViewController(showsViewController, animated: false)
                 }
                 return true
@@ -646,7 +646,7 @@ extension PageViewController: UIScrollViewDelegate {
     extension PageViewController: ShowAccessCellActions {
         func openShowAZ(sender _: Any?, event: ShowAccessEvent?) {
             if let navigationController, let event {
-                let showsViewController = SectionViewController.showsViewController(forTransmission: event.transmission, channelUid: radioChannel?.uid)
+                let showsViewController = SectionViewController.showsViewController(for: event.transmission, channelUid: radioChannel?.uid)
                 navigationController.pushViewController(showsViewController, animated: true)
             }
         }

--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -1014,6 +1014,8 @@ private extension PageViewController {
                         case .video:
                             let style: ShowAccessCell.Style = !ApplicationConfiguration.shared.isTvGuideUnavailable ? .programGuide : .calendar
                             ShowAccessCell(style: style).primaryColor(primaryColor)
+                        case .audio:
+                            ShowAccessCell(style: .calendar).primaryColor(primaryColor)
                         default:
                             ShowAccessCell(style: .calendar).primaryColor(primaryColor)
                         }

--- a/Application/Sources/Content/PageViewModel.swift
+++ b/Application/Sources/Content/PageViewModel.swift
@@ -709,7 +709,7 @@ private extension PageViewModel {
 
         var canOpenPage: Bool {
             switch presentation.type {
-            case .favoriteShows, .myProgram, .continueWatching, .topicSelector, .watchLater:
+            case .favoriteShows, .myProgram, .continueWatching, .continueListening, .topicSelector, .watchLater:
                 true
             default:
                 if presentation.contentLink != nil {

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -436,7 +436,7 @@ extension SectionViewController {
         }
     }
 
-    @objc static func showsViewController(for transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
+    static func showsViewController(for transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
         if transmission == .radio, let channelUid {
             SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
         } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
@@ -447,7 +447,7 @@ extension SectionViewController {
         }
     }
 
-    @objc static func showsViewController(for transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
+    static func showsViewController(for transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
         showsViewController(for: transmission, channelUid: channelUid, initialSectionId: nil)
     }
 }

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -436,7 +436,7 @@ extension SectionViewController {
         }
     }
 
-    @objc static func showsViewController(forTransmission transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
+    @objc static func showsViewController(for transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
         if transmission == .radio, let channelUid {
             SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
         } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
@@ -447,8 +447,8 @@ extension SectionViewController {
         }
     }
 
-    @objc static func showsViewController(forTransmission transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
-        showsViewController(forTransmission: transmission, channelUid: channelUid, initialSectionId: nil)
+    @objc static func showsViewController(for transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
+        showsViewController(for: transmission, channelUid: channelUid, initialSectionId: nil)
     }
 }
 

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -428,10 +428,8 @@ extension SectionViewController {
     }
 
     @objc static func mediasViewController(forDay day: SRGDay, transmission: SRGTransmission, channelUid: String?) -> SectionViewController & DailyMediasViewController {
-        if transmission == .radio, let channelUid {
-            SectionViewController(section: .configured(.radioEpisodesForDay(day, channelUid: channelUid)))
-        } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
-            // FIXME: Load all radio episodes by date, not only from the first channel.
+        // FIXME: If `channelUid` is null, load all radio episodes by date, not only from the first radio channel uid.
+        if transmission == .radio, let channelUid = channelUid ?? ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
             SectionViewController(section: .configured(.radioEpisodesForDay(day, channelUid: channelUid)))
         } else {
             SectionViewController(section: .configured(.tvEpisodesForDay(day)))

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -427,24 +427,30 @@ extension SectionViewController {
         SectionViewController(section: .configured(.watchLater))
     }
 
-    @objc static func mediasViewController(forDay day: SRGDay, channelUid: String?) -> SectionViewController & DailyMediasViewController {
-        if let channelUid {
+    @objc static func mediasViewController(forDay day: SRGDay, transmission: SRGTransmission, channelUid: String?) -> SectionViewController & DailyMediasViewController {
+        if transmission == .radio, let channelUid {
+            SectionViewController(section: .configured(.radioEpisodesForDay(day, channelUid: channelUid)))
+        } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
+            // FIXME: Load all radio episodes by date, not only from the first channel.
             SectionViewController(section: .configured(.radioEpisodesForDay(day, channelUid: channelUid)))
         } else {
             SectionViewController(section: .configured(.tvEpisodesForDay(day)))
         }
     }
 
-    @objc static func showsViewController(forChannelUid channelUid: String?, initialSectionId: String?) -> SectionViewController {
-        if let channelUid {
+    @objc static func showsViewController(forTransmission transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
+        if transmission == .radio, let channelUid {
+            SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
+        } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
+            // FIXME: Load all radio A to Z shows, not only from the first channel.
             SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
         } else {
             SectionViewController(section: .configured(.tvAllShows), initialSectionId: initialSectionId)
         }
     }
 
-    @objc static func showsViewController(forChannelUid channelUid: String?) -> SectionViewController {
-        showsViewController(forChannelUid: channelUid, initialSectionId: nil)
+    @objc static func showsViewController(forTransmission transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
+        showsViewController(forTransmission: transmission, channelUid: channelUid, initialSectionId: nil)
     }
 }
 

--- a/Application/Sources/UI/Views/ShowAccessCell.swift
+++ b/Application/Sources/UI/Views/ShowAccessCell.swift
@@ -5,13 +5,27 @@
 //
 
 import SRGAppearanceSwift
+import SRGDataProviderModel
 import SwiftUI
 
 // MARK: Contract
 
 @objc protocol ShowAccessCellActions: AnyObject {
-    func openShowAZ()
-    func openShowByDate()
+    func openShowAZ(sender: Any?, event: ShowAccessEvent?)
+    func openShowByDate(sender: Any?, event: ShowAccessEvent?)
+}
+
+class ShowAccessEvent: UIEvent {
+    let transmission: SRGTransmission
+
+    init(transmission: SRGTransmission) {
+        self.transmission = transmission
+        super.init()
+    }
+
+    override init() {
+        fatalError("init() is not available")
+    }
 }
 
 // MARK: View
@@ -48,14 +62,23 @@ struct ShowAccessCell: View, PrimaryColorSettable {
         }
     }
 
+    private var transmission: SRGTransmission {
+        switch style {
+        case .programGuide:
+            .TV
+        case .calendar:
+            .radio
+        }
+    }
+
     var body: some View {
         HStack {
             ExpandingButton(icon: showAZButtonProperties.icon, label: showAZButtonProperties.label, accessibilityLabel: showAZButtonProperties.accessibilityLabel) {
-                firstResponder.sendAction(#selector(ShowAccessCellActions.openShowAZ))
+                firstResponder.sendAction(#selector(ShowAccessCellActions.openShowAZ), for: ShowAccessEvent(transmission: transmission))
             }
             .primaryColor(primaryColor)
             ExpandingButton(icon: showByDateButtonProperties.icon, label: showByDateButtonProperties.label, accessibilityLabel: showByDateButtonProperties.accessibilityLabel) {
-                firstResponder.sendAction(#selector(ShowAccessCellActions.openShowByDate))
+                firstResponder.sendAction(#selector(ShowAccessCellActions.openShowByDate), for: ShowAccessEvent(transmission: transmission))
             }
             .primaryColor(primaryColor)
         }

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -16535,7 +16535,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = "feature/PLAYRTS-5541-content-presentation-type-update";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -16535,8 +16535,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 19.0.5;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -16535,8 +16535,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 19.0.4;
+				branch = "feature/PLAYRTS-5541-content-presentation-type-update";
+				kind = branch;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -16548,7 +16548,7 @@
 			repositoryURL = "https://github.com/SRGSSR/srgdataprovider-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 19.0.5;
+				minimumVersion = 19.0.6;
 			};
 		};
 		6F7269A72836CFE90072BA0B /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */ = {

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -2896,6 +2896,8 @@
 		04E031CE28BD0EF000450D38 /* RemoteCommandCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteCommandCenter.swift; sourceTree = "<group>"; };
 		04E4DEEA283678C900698BF8 /* ServiceMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceMessage.swift; sourceTree = "<group>"; };
 		04EB14C1299E312200FD004A /* SheetTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SheetTextView.swift; sourceTree = "<group>"; };
+		04EE93332C628653008C6C33 /* Accessibility.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Accessibility.strings; sourceTree = "<group>"; };
+		04EE93342C628653008C6C33 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
 		04F184CD28EC5EE500B1207C /* ShowButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowButton.swift; sourceTree = "<group>"; };
 		04F184E728F097E900B1207C /* BadgeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeList.swift; sourceTree = "<group>"; };
 		04FB9CA62A04327900A9B69E /* ProfileHelp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileHelp.swift; sourceTree = "<group>"; };
@@ -3972,6 +3974,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		04EE93352C628653008C6C33 /* Translations */ = {
+			isa = PBXGroup;
+			children = (
+				04EE93332C628653008C6C33 /* Accessibility.strings */,
+				04EE93342C628653008C6C33 /* Localizable.strings */,
+			);
+			path = Translations;
+			sourceTree = "<group>";
+		};
 		0806E7B41D50D8DD002ED406 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -4473,6 +4484,7 @@
 				6F0136DF21395B8400B95405 /* Xcode */,
 				E65311E31D3E6FD100B4B8BB /* Frameworks */,
 				45D67F958D75253E27BCDE9C /* Pods */,
+				04EE93352C628653008C6C33 /* Translations */,
 				08C68D501D38D49600BB8AAA /* Products */,
 			);
 			sourceTree = "<group>";

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgdataprovider-apple.git",
       "state" : {
-        "revision" : "338405f27723e378f4770626a71798464b15506c",
-        "version" : "19.0.5"
+        "revision" : "a315d507213ed16adc3d827aadc6b266c6e21275",
+        "version" : "19.0.6"
       }
     },
     {

--- a/TV Application/Sources/SceneDelegate.swift
+++ b/TV Application/Sources/SceneDelegate.swift
@@ -90,7 +90,7 @@ final class SceneDelegate: UIResponder {
         }
 
         if !configuration.areShowsUnavailable {
-            let showsViewController = SectionViewController.showsViewController(forTransmission: .TV, channelUid: nil)
+            let showsViewController = SectionViewController.showsViewController(for: .TV, channelUid: nil)
             showsViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Shows", comment: "Shows tab title"), image: nil, tag: 4)
             showsViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.showsTabBarItem.value
             viewControllers.append(showsViewController)

--- a/TV Application/Sources/SceneDelegate.swift
+++ b/TV Application/Sources/SceneDelegate.swift
@@ -90,7 +90,7 @@ final class SceneDelegate: UIResponder {
         }
 
         if !configuration.areShowsUnavailable {
-            let showsViewController = SectionViewController.showsViewController(forChannelUid: nil)
+            let showsViewController = SectionViewController.showsViewController(forTransmission: .TV, channelUid: nil)
             showsViewController.tabBarItem = UITabBarItem(title: NSLocalizedString("Shows", comment: "Shows tab title"), image: nil, tag: 4)
             showsViewController.tabBarItem.accessibilityIdentifier = AccessibilityIdentifier.showsTabBarItem.value
             viewControllers.append(showsViewController)

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -613,6 +613,12 @@
 /* Title label used to present medias whose playback can be resumed */
 "Resume playback" = "Resume playback";
 
+/* Title label used to present audios whose playback can be resumed */
+"Resume audio playback" = "Resume audio playback";
+
+/* Title label used to present videos whose playback can be resumed */
+"Resume video playback" = "Resume video playback";
+
 /* Label to present the search view
    Search shortcut label
    Search tab bar title

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -614,10 +614,10 @@
 "Resume playback" = "Resume playback";
 
 /* Title label used to present audios whose playback can be resumed */
-"Resume audio playback" = "Resume audio playback";
+"Resume audios playback" = "Resume audios playback";
 
 /* Title label used to present videos whose playback can be resumed */
-"Resume video playback" = "Resume video playback";
+"Resume videos playback" = "Resume videos playback";
 
 /* Label to present the search view
    Search shortcut label


### PR DESCRIPTION
## Description


This PR proposes an internal test only for audios tab, following #487 with two new supported sections:
- show access (with only the first radio channel for now)
- continue hearing section.
- For all (public and beta): update section translations for SRF ("resume video playback" and "resume audio playback").

## Changes Made

- Connect show access section to audio content.
  - Only first radio channel for A to Z page if it's the landing PAC audio page.
  - Only first radio channel for show by date page if it's the landing PAC audio page.
  - Use the calendar icon for audio pages.
-  Add audio resume playback section support (Continue hearing). https://github.com/SRGSSR/srgdataprovider-apple/pull/68
- For all (public and beta): update section translations for SRF ("resume video playback" and "resume audio playback").

Before merging:
- [x] Use `SRGDataProvider` SDK official release.
- [x] Update Crowdin with update transitions for "resume playback" audio and video.
- [x] Use `SRGDataProvider` SDK same official release as `develop` to fix merge conflict.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.