### PR TITLE
PLAYRTS-5590 Update Highlight Cell Design

### DIFF
--- a/Application/Sources/UI/Views/HighlightCell.swift
+++ b/Application/Sources/UI/Views/HighlightCell.swift
@@ -94,8 +94,7 @@ struct HighlightCell: View {
                             DiagonalGradientView(midwayStop: 0.6)
                             VerticalGradientView(midwayStop: 0.5)
                             DescriptionView(highlight: highlight)
-                                .padding(.horizontal, 30)
-                                .padding(.vertical, 30)
+                                .padding(32)
                                 .frame(width: geometry.size.width * 2 / 3, height: geometry.size.height, alignment: .bottomLeading)
                         }
                     }


### PR DESCRIPTION
## Description

Up until now, there was a linear gradient on Highlight Cells, helping make the text more legible.

This PR improves this aspect based on UI/UX requirements, by improving legibility without darkening the highlighted content too much.

In the following images, you can see the raw gradients, how they used to be and how they were implemented after various attempts to find the best result.

Please see also some screenshots to see it in action today.

<img src="https://github.com/user-attachments/assets/f1f187ab-88af-4f18-98a3-20b6488a798d" width="300">
<img src="https://github.com/user-attachments/assets/b87bd8c1-58b4-422f-b3f2-22806d12fa65" width="300">
<br>
<img src="https://github.com/user-attachments/assets/3257653f-77be-4a6e-833d-8428534ee1cf" width="300">
<img src="https://github.com/user-attachments/assets/afd6aff2-cb54-4e32-9cb9-eb17803d3f10" width="300">
<br>
<img src="https://github.com/user-attachments/assets/67a48c8d-33fe-487d-b374-e63a6f494626" width="300">
<img src="https://github.com/user-attachments/assets/e4d8466d-72ed-42a3-87cd-e5b4b60089ad" width="300">
<br>

## Changes Made

This was implemented by:

- Moving the description text at the bottom left as requested
- Tweaking the gradients, two gradients are now used (both linear):
	- One from bottom to top, in order to highlight the description text
	- One from the bottom left corner

The gradients were tweaked for large and compact size, and for different amount of text content. (see the raw gradients above)

If they need to be adjusted in the future, they now have their own view and the midway point to stop the gradient is customizable as a parameter.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.