### PR TITLE
PLAYRTS-5582 Fix tab bar offset when scrolling

### DIFF
--- a/Application/Sources/UI/Controllers/PageContainerViewController.swift
+++ b/Application/Sources/UI/Controllers/PageContainerViewController.swift
@@ -167,6 +167,11 @@ extension PageContainerViewController: ScrollableContentContainer {
     var play_scrollableChildViewController: UIViewController? {
         tabContainerViewController.currentViewController
     }
+
+    func play_contentOffsetDidChange(inScrollableView scrollView: UIScrollView) {
+        let adjustedOffset = scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+        tabBarTopConstraint?.constant = max(-adjustedOffset, 0.0)
+    }
 }
 
 extension PageContainerViewController: SRGAnalyticsContainerViewTracking {


### PR DESCRIPTION
## Description

After changing component (#486) and making multiple fixes (#491), we introduced a regression which caused the navigation bar to scroll **over** the top tab bar.

This PR fixes this.

## Changes Made

A category function implementation is reintroduced and the tab bar top constraint is updated accordingly.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.