### PR TITLE
PLAYRTS-5595 Mitigate start position for DRM VODs

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -104,7 +104,7 @@ name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 
-name: srgmediaplayer-apple, nameSpecified: srgmediaplayer-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgmediaplayer-apple
+name: srgmediaplayer-apple, nameSpecified: SRGMediaPlayer, owner: SRGSSR, version: 7.2.3, source: https://github.com/SRGSSR/srgmediaplayer-apple
 
 name: srgnetwork-apple, nameSpecified: SRGNetwork, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgnetwork-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -104,7 +104,7 @@ name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 
-name: srgmediaplayer-apple, nameSpecified: SRGMediaPlayer, owner: SRGSSR, version: 7.2.2, source: https://github.com/SRGSSR/srgmediaplayer-apple
+name: srgmediaplayer-apple, nameSpecified: srgmediaplayer-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgmediaplayer-apple
 
 name: srgnetwork-apple, nameSpecified: SRGNetwork, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgnetwork-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -104,7 +104,7 @@ name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 
-name: srgmediaplayer-apple, nameSpecified: SRGMediaPlayer, owner: SRGSSR, version: 7.2.1, source: https://github.com/SRGSSR/srgmediaplayer-apple
+name: srgmediaplayer-apple, nameSpecified: srgmediaplayer-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgmediaplayer-apple
 
 name: srgnetwork-apple, nameSpecified: SRGNetwork, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgnetwork-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -104,7 +104,7 @@ name: srgletterbox-apple, nameSpecified: SRGLetterbox, owner: SRGSSR, version: 9
 
 name: srglogger-apple, nameSpecified: SRGLogger, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srglogger-apple
 
-name: srgmediaplayer-apple, nameSpecified: srgmediaplayer-apple, owner: SRGSSR, version: , source: https://github.com/SRGSSR/srgmediaplayer-apple
+name: srgmediaplayer-apple, nameSpecified: SRGMediaPlayer, owner: SRGSSR, version: 7.2.2, source: https://github.com/SRGSSR/srgmediaplayer-apple
 
 name: srgnetwork-apple, nameSpecified: SRGNetwork, owner: SRGSSR, version: 3.1.0, source: https://github.com/SRGSSR/srgnetwork-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -326,7 +326,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgmediaplayer-apple</string>
 			<key>Title</key>
-			<string>srgmediaplayer-apple</string>
+			<string>SRGMediaPlayer (7.2.3)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -326,7 +326,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgmediaplayer-apple</string>
 			<key>Title</key>
-			<string>srgmediaplayer-apple</string>
+			<string>SRGMediaPlayer (7.2.2)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -326,7 +326,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgmediaplayer-apple</string>
 			<key>Title</key>
-			<string>SRGMediaPlayer (7.2.2)</string>
+			<string>srgmediaplayer-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -326,7 +326,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srgmediaplayer-apple</string>
 			<key>Title</key>
-			<string>SRGMediaPlayer (7.2.1)</string>
+			<string>srgmediaplayer-apple</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075222C52DD18003B3DA8 /* SRGMediaPlayer */; };
+		040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075242C52DD2E003B3DA8 /* SRGMediaPlayer */; };
+		040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075262C52DD3E003B3DA8 /* SRGMediaPlayer */; };
+		040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075282C52DD47003B3DA8 /* SRGMediaPlayer */; };
+		0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */; };
+		0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */; };
+		0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */; };
+		040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075302C52DD6E003B3DA8 /* SRGMediaPlayer */; };
+		040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075322C52DD7D003B3DA8 /* SRGMediaPlayer */; };
+		040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075342C52DD84003B3DA8 /* SRGMediaPlayer */; };
 		04030F4E2A34BD1100BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F4D2A34BD1100BC573B /* Usercentrics */; };
 		04030F512A34BD3A00BC573B /* UsercentricsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F502A34BD3A00BC573B /* UsercentricsUI */; };
 		04030F532A34BD6D00BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F522A34BD6D00BC573B /* Usercentrics */; };
@@ -3549,6 +3559,7 @@
 				6FD40A4825221C2D00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A82AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0968254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B52521C14E00F9F4FE /* SRGLetterbox in Frameworks */,
 				08F5DAF5262D99D400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D1283BAB3600A9089D /* FSCalendar in Frameworks */,
@@ -3583,6 +3594,7 @@
 				6FD40A5E25221C3A00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AA2AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0969254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B92521C15E00F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF3262D99CB00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D3283BAB5000A9089D /* FSCalendar in Frameworks */,
@@ -3617,6 +3629,7 @@
 				6FD40A7425221C4300E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A62AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096A254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545BD2521C16800F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF1262D99BF00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D5283BAB5600A9089D /* FSCalendar in Frameworks */,
@@ -3651,6 +3664,7 @@
 				6FD40A7625221C4900E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AC2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096B254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C12521C17000F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAEF262D99B400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D7283BAB5B00A9089D /* FSCalendar in Frameworks */,
@@ -3685,6 +3699,7 @@
 				6FD40A8C25221C4F00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AE2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096C254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C52521C17700F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAED262D99A900F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D9283BAB6000A9089D /* FSCalendar in Frameworks */,
@@ -3794,6 +3809,7 @@
 				6FA6C9122812D85D007C3406 /* NukeUI in Frameworks */,
 				08013F4125DC50D80099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A48256C58A70042F446 /* SRGLoggerSwift in Frameworks */,
+				0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC20266AB854009F74C6 /* Nuke in Frameworks */,
 				04030F652A34BD9300BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899D261F16D500FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3819,6 +3835,7 @@
 				6FA6C9142812D861007C3406 /* NukeUI in Frameworks */,
 				08013F4225DC50D90099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A5E256C58B20042F446 /* SRGLoggerSwift in Frameworks */,
+				0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC22266AB85B009F74C6 /* Nuke in Frameworks */,
 				04030F692A34BD9C00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899F261F16DC00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3844,6 +3861,7 @@
 				6FA6C9162812D866007C3406 /* NukeUI in Frameworks */,
 				08013F4325DC50DA0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A74256C58BB0042F446 /* SRGLoggerSwift in Frameworks */,
+				040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC24266AB862009F74C6 /* Nuke in Frameworks */,
 				04030F6D2A34BDA400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A1261F16E200FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3869,6 +3887,7 @@
 				6FA6C9182812D86C007C3406 /* NukeUI in Frameworks */,
 				08013EB425DC28F60099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A76256C58C40042F446 /* SRGLoggerSwift in Frameworks */,
+				040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC26266AB867009F74C6 /* Nuke in Frameworks */,
 				04030F712A34BDAC00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A3261F16E800FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3894,6 +3913,7 @@
 				6FA6C91A2812D871007C3406 /* NukeUI in Frameworks */,
 				08013F4425DC50DB0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A8C256C58CC0042F446 /* SRGLoggerSwift in Frameworks */,
+				040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC28266AB86D009F74C6 /* Nuke in Frameworks */,
 				04030F752A34BDB400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A5261F16EE00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -5474,6 +5494,7 @@
 				04030F502A34BD3A00BC573B /* UsercentricsUI */,
 				04FA73A72AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19262BFF49C9000B5602 /* Tabman */,
+				040075222C52DD18003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF";
 			productReference = 08C68D891D38D6F400BB8AAA /* Play SRF.app */;
@@ -5531,6 +5552,7 @@
 				04030F542A34BD6D00BC573B /* UsercentricsUI */,
 				04FA73A92AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19282BFF49F7000B5602 /* Tabman */,
+				040075242C52DD2E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS";
 			productReference = 08C68DC01D38D70D00BB8AAA /* Play RTS.app */;
@@ -5588,6 +5610,7 @@
 				04030F582A34BD7700BC573B /* UsercentricsUI */,
 				04FA73A52AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192A2BFF49FD000B5602 /* Tabman */,
+				040075262C52DD3E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI";
 			productReference = 08C68DF71D38D72000BB8AAA /* Play RSI.app */;
@@ -5645,6 +5668,7 @@
 				04030F5C2A34BD8300BC573B /* UsercentricsUI */,
 				04FA73AB2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192C2BFF4A04000B5602 /* Tabman */,
+				040075282C52DD47003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR";
 			productReference = 08C68E2E1D38D73000BB8AAA /* Play RTR.app */;
@@ -5702,6 +5726,7 @@
 				04030F602A34BD8B00BC573B /* UsercentricsUI */,
 				04FA73AD2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192E2BFF4A0B000B5602 /* Tabman */,
+				0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI";
 			productReference = 08C68E651D38D73C00BB8AAA /* Play SWI.app */;
@@ -5931,6 +5956,7 @@
 				6FA6C9112812D85D007C3406 /* NukeUI */,
 				04030F622A34BD9300BC573B /* Usercentrics */,
 				04030F642A34BD9300BC573B /* UsercentricsUI */,
+				0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF TV";
 			productReference = 6F331CE424D06B8200C096AB /* Play SRF.app */;
@@ -5975,6 +6001,7 @@
 				6FA6C9132812D861007C3406 /* NukeUI */,
 				04030F662A34BD9C00BC573B /* Usercentrics */,
 				04030F682A34BD9C00BC573B /* UsercentricsUI */,
+				0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS TV";
 			productReference = 6F331CFC24D06BA200C096AB /* Play RTS.app */;
@@ -6019,6 +6046,7 @@
 				6FA6C9152812D866007C3406 /* NukeUI */,
 				04030F6A2A34BDA400BC573B /* Usercentrics */,
 				04030F6C2A34BDA400BC573B /* UsercentricsUI */,
+				040075302C52DD6E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI TV";
 			productReference = 6F331D1424D06BB800C096AB /* Play RSI.app */;
@@ -6063,6 +6091,7 @@
 				6FA6C9172812D86C007C3406 /* NukeUI */,
 				04030F6E2A34BDAC00BC573B /* Usercentrics */,
 				04030F702A34BDAC00BC573B /* UsercentricsUI */,
+				040075322C52DD7D003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR TV";
 			productReference = 6F331D2C24D06BC600C096AB /* Play RTR.app */;
@@ -6107,6 +6136,7 @@
 				6FA6C9192812D871007C3406 /* NukeUI */,
 				04030F722A34BDB400BC573B /* Usercentrics */,
 				04030F742A34BDB400BC573B /* UsercentricsUI */,
+				040075342C52DD84003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI TV";
 			productReference = 6F331D4424D06C2600C096AB /* Play SWI.app */;
@@ -6445,6 +6475,7 @@
 				04030F4F2A34BD3A00BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-ui" */,
 				04FA73A42AA62E4B0014E7F7 /* XCRemoteSwiftPackageReference "GoogleCastSDK-no-bluetooth" */,
 				99FE19252BFF49C9000B5602 /* XCRemoteSwiftPackageReference "Tabman" */,
+				040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */,
 			);
 			productRefGroup = 08C68D501D38D49600BB8AAA /* Products */;
 			projectDirPath = "";
@@ -16411,6 +16442,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SRGSSR/srgmediaplayer-apple.git";
+			requirement = {
+				branch = "feature/dvr-start-fix";
+				kind = branch;
+			};
+		};
 		04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk";
@@ -16646,6 +16685,56 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		040075222C52DD18003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075242C52DD2E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075262C52DD3E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075282C52DD47003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075302C52DD6E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075322C52DD7D003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075342C52DD84003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
 		04030F4D2A34BD1100BC573B /* Usercentrics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */;

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -7,16 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075222C52DD18003B3DA8 /* SRGMediaPlayer */; };
-		040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075242C52DD2E003B3DA8 /* SRGMediaPlayer */; };
-		040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075262C52DD3E003B3DA8 /* SRGMediaPlayer */; };
-		040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075282C52DD47003B3DA8 /* SRGMediaPlayer */; };
-		0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */; };
-		0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */; };
-		0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */; };
-		040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075302C52DD6E003B3DA8 /* SRGMediaPlayer */; };
-		040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075322C52DD7D003B3DA8 /* SRGMediaPlayer */; };
-		040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075342C52DD84003B3DA8 /* SRGMediaPlayer */; };
 		04030F4E2A34BD1100BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F4D2A34BD1100BC573B /* Usercentrics */; };
 		04030F512A34BD3A00BC573B /* UsercentricsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F502A34BD3A00BC573B /* UsercentricsUI */; };
 		04030F532A34BD6D00BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F522A34BD6D00BC573B /* Usercentrics */; };
@@ -3559,7 +3549,6 @@
 				6FD40A4825221C2D00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A82AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0968254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B52521C14E00F9F4FE /* SRGLetterbox in Frameworks */,
 				08F5DAF5262D99D400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D1283BAB3600A9089D /* FSCalendar in Frameworks */,
@@ -3594,7 +3583,6 @@
 				6FD40A5E25221C3A00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AA2AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0969254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B92521C15E00F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF3262D99CB00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D3283BAB5000A9089D /* FSCalendar in Frameworks */,
@@ -3629,7 +3617,6 @@
 				6FD40A7425221C4300E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A62AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096A254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545BD2521C16800F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF1262D99BF00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D5283BAB5600A9089D /* FSCalendar in Frameworks */,
@@ -3664,7 +3651,6 @@
 				6FD40A7625221C4900E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AC2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096B254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C12521C17000F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAEF262D99B400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D7283BAB5B00A9089D /* FSCalendar in Frameworks */,
@@ -3699,7 +3685,6 @@
 				6FD40A8C25221C4F00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AE2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096C254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C52521C17700F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAED262D99A900F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D9283BAB6000A9089D /* FSCalendar in Frameworks */,
@@ -3809,7 +3794,6 @@
 				6FA6C9122812D85D007C3406 /* NukeUI in Frameworks */,
 				08013F4125DC50D80099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A48256C58A70042F446 /* SRGLoggerSwift in Frameworks */,
-				0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC20266AB854009F74C6 /* Nuke in Frameworks */,
 				04030F652A34BD9300BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899D261F16D500FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3835,7 +3819,6 @@
 				6FA6C9142812D861007C3406 /* NukeUI in Frameworks */,
 				08013F4225DC50D90099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A5E256C58B20042F446 /* SRGLoggerSwift in Frameworks */,
-				0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC22266AB85B009F74C6 /* Nuke in Frameworks */,
 				04030F692A34BD9C00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899F261F16DC00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3861,7 +3844,6 @@
 				6FA6C9162812D866007C3406 /* NukeUI in Frameworks */,
 				08013F4325DC50DA0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A74256C58BB0042F446 /* SRGLoggerSwift in Frameworks */,
-				040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC24266AB862009F74C6 /* Nuke in Frameworks */,
 				04030F6D2A34BDA400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A1261F16E200FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3887,7 +3869,6 @@
 				6FA6C9182812D86C007C3406 /* NukeUI in Frameworks */,
 				08013EB425DC28F60099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A76256C58C40042F446 /* SRGLoggerSwift in Frameworks */,
-				040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC26266AB867009F74C6 /* Nuke in Frameworks */,
 				04030F712A34BDAC00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A3261F16E800FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3913,7 +3894,6 @@
 				6FA6C91A2812D871007C3406 /* NukeUI in Frameworks */,
 				08013F4425DC50DB0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A8C256C58CC0042F446 /* SRGLoggerSwift in Frameworks */,
-				040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC28266AB86D009F74C6 /* Nuke in Frameworks */,
 				04030F752A34BDB400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A5261F16EE00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -5494,7 +5474,6 @@
 				04030F502A34BD3A00BC573B /* UsercentricsUI */,
 				04FA73A72AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19262BFF49C9000B5602 /* Tabman */,
-				040075222C52DD18003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF";
 			productReference = 08C68D891D38D6F400BB8AAA /* Play SRF.app */;
@@ -5552,7 +5531,6 @@
 				04030F542A34BD6D00BC573B /* UsercentricsUI */,
 				04FA73A92AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19282BFF49F7000B5602 /* Tabman */,
-				040075242C52DD2E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS";
 			productReference = 08C68DC01D38D70D00BB8AAA /* Play RTS.app */;
@@ -5610,7 +5588,6 @@
 				04030F582A34BD7700BC573B /* UsercentricsUI */,
 				04FA73A52AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192A2BFF49FD000B5602 /* Tabman */,
-				040075262C52DD3E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI";
 			productReference = 08C68DF71D38D72000BB8AAA /* Play RSI.app */;
@@ -5668,7 +5645,6 @@
 				04030F5C2A34BD8300BC573B /* UsercentricsUI */,
 				04FA73AB2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192C2BFF4A04000B5602 /* Tabman */,
-				040075282C52DD47003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR";
 			productReference = 08C68E2E1D38D73000BB8AAA /* Play RTR.app */;
@@ -5726,7 +5702,6 @@
 				04030F602A34BD8B00BC573B /* UsercentricsUI */,
 				04FA73AD2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192E2BFF4A0B000B5602 /* Tabman */,
-				0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI";
 			productReference = 08C68E651D38D73C00BB8AAA /* Play SWI.app */;
@@ -5956,7 +5931,6 @@
 				6FA6C9112812D85D007C3406 /* NukeUI */,
 				04030F622A34BD9300BC573B /* Usercentrics */,
 				04030F642A34BD9300BC573B /* UsercentricsUI */,
-				0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF TV";
 			productReference = 6F331CE424D06B8200C096AB /* Play SRF.app */;
@@ -6001,7 +5975,6 @@
 				6FA6C9132812D861007C3406 /* NukeUI */,
 				04030F662A34BD9C00BC573B /* Usercentrics */,
 				04030F682A34BD9C00BC573B /* UsercentricsUI */,
-				0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS TV";
 			productReference = 6F331CFC24D06BA200C096AB /* Play RTS.app */;
@@ -6046,7 +6019,6 @@
 				6FA6C9152812D866007C3406 /* NukeUI */,
 				04030F6A2A34BDA400BC573B /* Usercentrics */,
 				04030F6C2A34BDA400BC573B /* UsercentricsUI */,
-				040075302C52DD6E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI TV";
 			productReference = 6F331D1424D06BB800C096AB /* Play RSI.app */;
@@ -6091,7 +6063,6 @@
 				6FA6C9172812D86C007C3406 /* NukeUI */,
 				04030F6E2A34BDAC00BC573B /* Usercentrics */,
 				04030F702A34BDAC00BC573B /* UsercentricsUI */,
-				040075322C52DD7D003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR TV";
 			productReference = 6F331D2C24D06BC600C096AB /* Play RTR.app */;
@@ -6136,7 +6107,6 @@
 				6FA6C9192812D871007C3406 /* NukeUI */,
 				04030F722A34BDB400BC573B /* Usercentrics */,
 				04030F742A34BDB400BC573B /* UsercentricsUI */,
-				040075342C52DD84003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI TV";
 			productReference = 6F331D4424D06C2600C096AB /* Play SWI.app */;
@@ -6475,7 +6445,6 @@
 				04030F4F2A34BD3A00BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-ui" */,
 				04FA73A42AA62E4B0014E7F7 /* XCRemoteSwiftPackageReference "GoogleCastSDK-no-bluetooth" */,
 				99FE19252BFF49C9000B5602 /* XCRemoteSwiftPackageReference "Tabman" */,
-				040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */,
 			);
 			productRefGroup = 08C68D501D38D49600BB8AAA /* Products */;
 			projectDirPath = "";
@@ -16442,14 +16411,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SRGSSR/srgmediaplayer-apple.git";
-			requirement = {
-				branch = "feature/dvr-start-fix";
-				kind = branch;
-			};
-		};
 		04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk";
@@ -16685,56 +16646,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		040075222C52DD18003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075242C52DD2E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075262C52DD3E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075282C52DD47003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075302C52DD6E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075322C52DD7D003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075342C52DD84003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
 		04030F4D2A34BD1100BC573B /* Usercentrics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */;

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -7,16 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075222C52DD18003B3DA8 /* SRGMediaPlayer */; };
-		040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075242C52DD2E003B3DA8 /* SRGMediaPlayer */; };
-		040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075262C52DD3E003B3DA8 /* SRGMediaPlayer */; };
-		040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075282C52DD47003B3DA8 /* SRGMediaPlayer */; };
-		0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */; };
-		0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */; };
-		0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */; };
-		040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075302C52DD6E003B3DA8 /* SRGMediaPlayer */; };
-		040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075322C52DD7D003B3DA8 /* SRGMediaPlayer */; };
-		040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075342C52DD84003B3DA8 /* SRGMediaPlayer */; };
 		04030F4E2A34BD1100BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F4D2A34BD1100BC573B /* Usercentrics */; };
 		04030F512A34BD3A00BC573B /* UsercentricsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F502A34BD3A00BC573B /* UsercentricsUI */; };
 		04030F532A34BD6D00BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F522A34BD6D00BC573B /* Usercentrics */; };
@@ -3559,7 +3549,6 @@
 				6FD40A4825221C2D00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A82AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0968254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B52521C14E00F9F4FE /* SRGLetterbox in Frameworks */,
 				08F5DAF5262D99D400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D1283BAB3600A9089D /* FSCalendar in Frameworks */,
@@ -3594,7 +3583,6 @@
 				6FD40A5E25221C3A00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AA2AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0969254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B92521C15E00F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF3262D99CB00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D3283BAB5000A9089D /* FSCalendar in Frameworks */,
@@ -3629,7 +3617,6 @@
 				6FD40A7425221C4300E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A62AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096A254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545BD2521C16800F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF1262D99BF00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D5283BAB5600A9089D /* FSCalendar in Frameworks */,
@@ -3664,7 +3651,6 @@
 				6FD40A7625221C4900E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AC2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096B254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C12521C17000F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAEF262D99B400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D7283BAB5B00A9089D /* FSCalendar in Frameworks */,
@@ -3699,7 +3685,6 @@
 				6FD40A8C25221C4F00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AE2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096C254861A0009DEDD2 /* SwiftMessages in Frameworks */,
-				0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C52521C17700F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAED262D99A900F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D9283BAB6000A9089D /* FSCalendar in Frameworks */,
@@ -3809,7 +3794,6 @@
 				6FA6C9122812D85D007C3406 /* NukeUI in Frameworks */,
 				08013F4125DC50D80099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A48256C58A70042F446 /* SRGLoggerSwift in Frameworks */,
-				0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC20266AB854009F74C6 /* Nuke in Frameworks */,
 				04030F652A34BD9300BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899D261F16D500FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3835,7 +3819,6 @@
 				6FA6C9142812D861007C3406 /* NukeUI in Frameworks */,
 				08013F4225DC50D90099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A5E256C58B20042F446 /* SRGLoggerSwift in Frameworks */,
-				0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC22266AB85B009F74C6 /* Nuke in Frameworks */,
 				04030F692A34BD9C00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899F261F16DC00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3861,7 +3844,6 @@
 				6FA6C9162812D866007C3406 /* NukeUI in Frameworks */,
 				08013F4325DC50DA0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A74256C58BB0042F446 /* SRGLoggerSwift in Frameworks */,
-				040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC24266AB862009F74C6 /* Nuke in Frameworks */,
 				04030F6D2A34BDA400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A1261F16E200FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3887,7 +3869,6 @@
 				6FA6C9182812D86C007C3406 /* NukeUI in Frameworks */,
 				08013EB425DC28F60099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A76256C58C40042F446 /* SRGLoggerSwift in Frameworks */,
-				040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC26266AB867009F74C6 /* Nuke in Frameworks */,
 				04030F712A34BDAC00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A3261F16E800FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3913,7 +3894,6 @@
 				6FA6C91A2812D871007C3406 /* NukeUI in Frameworks */,
 				08013F4425DC50DB0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A8C256C58CC0042F446 /* SRGLoggerSwift in Frameworks */,
-				040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC28266AB86D009F74C6 /* Nuke in Frameworks */,
 				04030F752A34BDB400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A5261F16EE00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -5494,7 +5474,6 @@
 				04030F502A34BD3A00BC573B /* UsercentricsUI */,
 				04FA73A72AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19262BFF49C9000B5602 /* Tabman */,
-				040075222C52DD18003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF";
 			productReference = 08C68D891D38D6F400BB8AAA /* Play SRF.app */;
@@ -5552,7 +5531,6 @@
 				04030F542A34BD6D00BC573B /* UsercentricsUI */,
 				04FA73A92AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19282BFF49F7000B5602 /* Tabman */,
-				040075242C52DD2E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS";
 			productReference = 08C68DC01D38D70D00BB8AAA /* Play RTS.app */;
@@ -5610,7 +5588,6 @@
 				04030F582A34BD7700BC573B /* UsercentricsUI */,
 				04FA73A52AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192A2BFF49FD000B5602 /* Tabman */,
-				040075262C52DD3E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI";
 			productReference = 08C68DF71D38D72000BB8AAA /* Play RSI.app */;
@@ -5668,7 +5645,6 @@
 				04030F5C2A34BD8300BC573B /* UsercentricsUI */,
 				04FA73AB2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192C2BFF4A04000B5602 /* Tabman */,
-				040075282C52DD47003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR";
 			productReference = 08C68E2E1D38D73000BB8AAA /* Play RTR.app */;
@@ -5726,7 +5702,6 @@
 				04030F602A34BD8B00BC573B /* UsercentricsUI */,
 				04FA73AD2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192E2BFF4A0B000B5602 /* Tabman */,
-				0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI";
 			productReference = 08C68E651D38D73C00BB8AAA /* Play SWI.app */;
@@ -5956,7 +5931,6 @@
 				6FA6C9112812D85D007C3406 /* NukeUI */,
 				04030F622A34BD9300BC573B /* Usercentrics */,
 				04030F642A34BD9300BC573B /* UsercentricsUI */,
-				0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF TV";
 			productReference = 6F331CE424D06B8200C096AB /* Play SRF.app */;
@@ -6001,7 +5975,6 @@
 				6FA6C9132812D861007C3406 /* NukeUI */,
 				04030F662A34BD9C00BC573B /* Usercentrics */,
 				04030F682A34BD9C00BC573B /* UsercentricsUI */,
-				0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS TV";
 			productReference = 6F331CFC24D06BA200C096AB /* Play RTS.app */;
@@ -6046,7 +6019,6 @@
 				6FA6C9152812D866007C3406 /* NukeUI */,
 				04030F6A2A34BDA400BC573B /* Usercentrics */,
 				04030F6C2A34BDA400BC573B /* UsercentricsUI */,
-				040075302C52DD6E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI TV";
 			productReference = 6F331D1424D06BB800C096AB /* Play RSI.app */;
@@ -6091,7 +6063,6 @@
 				6FA6C9172812D86C007C3406 /* NukeUI */,
 				04030F6E2A34BDAC00BC573B /* Usercentrics */,
 				04030F702A34BDAC00BC573B /* UsercentricsUI */,
-				040075322C52DD7D003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR TV";
 			productReference = 6F331D2C24D06BC600C096AB /* Play RTR.app */;
@@ -6136,7 +6107,6 @@
 				6FA6C9192812D871007C3406 /* NukeUI */,
 				04030F722A34BDB400BC573B /* Usercentrics */,
 				04030F742A34BDB400BC573B /* UsercentricsUI */,
-				040075342C52DD84003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI TV";
 			productReference = 6F331D4424D06C2600C096AB /* Play SWI.app */;
@@ -6475,7 +6445,6 @@
 				04030F4F2A34BD3A00BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-ui" */,
 				04FA73A42AA62E4B0014E7F7 /* XCRemoteSwiftPackageReference "GoogleCastSDK-no-bluetooth" */,
 				99FE19252BFF49C9000B5602 /* XCRemoteSwiftPackageReference "Tabman" */,
-				040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */,
 			);
 			productRefGroup = 08C68D501D38D49600BB8AAA /* Products */;
 			projectDirPath = "";
@@ -16442,14 +16411,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SRGSSR/srgmediaplayer-apple.git";
-			requirement = {
-				branch = develop;
-				kind = branch;
-			};
-		};
 		04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk";
@@ -16685,56 +16646,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		040075222C52DD18003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075242C52DD2E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075262C52DD3E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075282C52DD47003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075302C52DD6E003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075322C52DD7D003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
-		040075342C52DD84003B3DA8 /* SRGMediaPlayer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
-			productName = SRGMediaPlayer;
-		};
 		04030F4D2A34BD1100BC573B /* Usercentrics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */;

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075222C52DD18003B3DA8 /* SRGMediaPlayer */; };
+		040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075242C52DD2E003B3DA8 /* SRGMediaPlayer */; };
+		040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075262C52DD3E003B3DA8 /* SRGMediaPlayer */; };
+		040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075282C52DD47003B3DA8 /* SRGMediaPlayer */; };
+		0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */; };
+		0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */; };
+		0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */; };
+		040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075302C52DD6E003B3DA8 /* SRGMediaPlayer */; };
+		040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075322C52DD7D003B3DA8 /* SRGMediaPlayer */; };
+		040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 040075342C52DD84003B3DA8 /* SRGMediaPlayer */; };
 		04030F4E2A34BD1100BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F4D2A34BD1100BC573B /* Usercentrics */; };
 		04030F512A34BD3A00BC573B /* UsercentricsUI in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F502A34BD3A00BC573B /* UsercentricsUI */; };
 		04030F532A34BD6D00BC573B /* Usercentrics in Frameworks */ = {isa = PBXBuildFile; productRef = 04030F522A34BD6D00BC573B /* Usercentrics */; };
@@ -3549,6 +3559,7 @@
 				6FD40A4825221C2D00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A82AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0968254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075232C52DD18003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B52521C14E00F9F4FE /* SRGLetterbox in Frameworks */,
 				08F5DAF5262D99D400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D1283BAB3600A9089D /* FSCalendar in Frameworks */,
@@ -3583,6 +3594,7 @@
 				6FD40A5E25221C3A00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AA2AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F0969254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075252C52DD2E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545B92521C15E00F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF3262D99CB00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D3283BAB5000A9089D /* FSCalendar in Frameworks */,
@@ -3617,6 +3629,7 @@
 				6FD40A7425221C4300E621EF /* PaperOnboarding in Frameworks */,
 				04FA73A62AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096A254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075272C52DD3E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545BD2521C16800F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAF1262D99BF00F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D5283BAB5600A9089D /* FSCalendar in Frameworks */,
@@ -3651,6 +3664,7 @@
 				6FD40A7625221C4900E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AC2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096B254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				040075292C52DD47003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C12521C17000F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAEF262D99B400F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D7283BAB5B00A9089D /* FSCalendar in Frameworks */,
@@ -3685,6 +3699,7 @@
 				6FD40A8C25221C4F00E621EF /* PaperOnboarding in Frameworks */,
 				04FA73AE2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth in Frameworks */,
 				084F096C254861A0009DEDD2 /* SwiftMessages in Frameworks */,
+				0400752B2C52DD4F003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F2545C52521C17700F9F4FE /* SRGUserData in Frameworks */,
 				08F5DAED262D99A900F717D0 /* SRGLoggerSwift in Frameworks */,
 				6F2345D9283BAB6000A9089D /* FSCalendar in Frameworks */,
@@ -3794,6 +3809,7 @@
 				6FA6C9122812D85D007C3406 /* NukeUI in Frameworks */,
 				08013F4125DC50D80099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A48256C58A70042F446 /* SRGLoggerSwift in Frameworks */,
+				0400752D2C52DD5B003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC20266AB854009F74C6 /* Nuke in Frameworks */,
 				04030F652A34BD9300BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899D261F16D500FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3819,6 +3835,7 @@
 				6FA6C9142812D861007C3406 /* NukeUI in Frameworks */,
 				08013F4225DC50D90099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A5E256C58B20042F446 /* SRGLoggerSwift in Frameworks */,
+				0400752F2C52DD66003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC22266AB85B009F74C6 /* Nuke in Frameworks */,
 				04030F692A34BD9C00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC899F261F16DC00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3844,6 +3861,7 @@
 				6FA6C9162812D866007C3406 /* NukeUI in Frameworks */,
 				08013F4325DC50DA0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A74256C58BB0042F446 /* SRGLoggerSwift in Frameworks */,
+				040075312C52DD6E003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC24266AB862009F74C6 /* Nuke in Frameworks */,
 				04030F6D2A34BDA400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A1261F16E200FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3869,6 +3887,7 @@
 				6FA6C9182812D86C007C3406 /* NukeUI in Frameworks */,
 				08013EB425DC28F60099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A76256C58C40042F446 /* SRGLoggerSwift in Frameworks */,
+				040075332C52DD7D003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC26266AB867009F74C6 /* Nuke in Frameworks */,
 				04030F712A34BDAC00BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A3261F16E800FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -3894,6 +3913,7 @@
 				6FA6C91A2812D871007C3406 /* NukeUI in Frameworks */,
 				08013F4425DC50DB0099A6E8 /* TVServices.framework in Frameworks */,
 				6FF12A8C256C58CC0042F446 /* SRGLoggerSwift in Frameworks */,
+				040075352C52DD84003B3DA8 /* SRGMediaPlayer in Frameworks */,
 				6F17DC28266AB86D009F74C6 /* Nuke in Frameworks */,
 				04030F752A34BDB400BC573B /* UsercentricsUI in Frameworks */,
 				6FEC89A5261F16EE00FF9762 /* DZNEmptyDataSet in Frameworks */,
@@ -5474,6 +5494,7 @@
 				04030F502A34BD3A00BC573B /* UsercentricsUI */,
 				04FA73A72AA62E5C0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19262BFF49C9000B5602 /* Tabman */,
+				040075222C52DD18003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF";
 			productReference = 08C68D891D38D6F400BB8AAA /* Play SRF.app */;
@@ -5531,6 +5552,7 @@
 				04030F542A34BD6D00BC573B /* UsercentricsUI */,
 				04FA73A92AA62E640014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE19282BFF49F7000B5602 /* Tabman */,
+				040075242C52DD2E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS";
 			productReference = 08C68DC01D38D70D00BB8AAA /* Play RTS.app */;
@@ -5588,6 +5610,7 @@
 				04030F582A34BD7700BC573B /* UsercentricsUI */,
 				04FA73A52AA62E4B0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192A2BFF49FD000B5602 /* Tabman */,
+				040075262C52DD3E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI";
 			productReference = 08C68DF71D38D72000BB8AAA /* Play RSI.app */;
@@ -5645,6 +5668,7 @@
 				04030F5C2A34BD8300BC573B /* UsercentricsUI */,
 				04FA73AB2AA62E760014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192C2BFF4A04000B5602 /* Tabman */,
+				040075282C52DD47003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR";
 			productReference = 08C68E2E1D38D73000BB8AAA /* Play RTR.app */;
@@ -5702,6 +5726,7 @@
 				04030F602A34BD8B00BC573B /* UsercentricsUI */,
 				04FA73AD2AA62E7D0014E7F7 /* GoogleCastSDK-no-bluetooth */,
 				99FE192E2BFF4A0B000B5602 /* Tabman */,
+				0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI";
 			productReference = 08C68E651D38D73C00BB8AAA /* Play SWI.app */;
@@ -5931,6 +5956,7 @@
 				6FA6C9112812D85D007C3406 /* NukeUI */,
 				04030F622A34BD9300BC573B /* Usercentrics */,
 				04030F642A34BD9300BC573B /* UsercentricsUI */,
+				0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SRF TV";
 			productReference = 6F331CE424D06B8200C096AB /* Play SRF.app */;
@@ -5975,6 +6001,7 @@
 				6FA6C9132812D861007C3406 /* NukeUI */,
 				04030F662A34BD9C00BC573B /* Usercentrics */,
 				04030F682A34BD9C00BC573B /* UsercentricsUI */,
+				0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTS TV";
 			productReference = 6F331CFC24D06BA200C096AB /* Play RTS.app */;
@@ -6019,6 +6046,7 @@
 				6FA6C9152812D866007C3406 /* NukeUI */,
 				04030F6A2A34BDA400BC573B /* Usercentrics */,
 				04030F6C2A34BDA400BC573B /* UsercentricsUI */,
+				040075302C52DD6E003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RSI TV";
 			productReference = 6F331D1424D06BB800C096AB /* Play RSI.app */;
@@ -6063,6 +6091,7 @@
 				6FA6C9172812D86C007C3406 /* NukeUI */,
 				04030F6E2A34BDAC00BC573B /* Usercentrics */,
 				04030F702A34BDAC00BC573B /* UsercentricsUI */,
+				040075322C52DD7D003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play RTR TV";
 			productReference = 6F331D2C24D06BC600C096AB /* Play RTR.app */;
@@ -6107,6 +6136,7 @@
 				6FA6C9192812D871007C3406 /* NukeUI */,
 				04030F722A34BDB400BC573B /* Usercentrics */,
 				04030F742A34BDB400BC573B /* UsercentricsUI */,
+				040075342C52DD84003B3DA8 /* SRGMediaPlayer */,
 			);
 			productName = "Play SWI TV";
 			productReference = 6F331D4424D06C2600C096AB /* Play SWI.app */;
@@ -6445,6 +6475,7 @@
 				04030F4F2A34BD3A00BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-ui" */,
 				04FA73A42AA62E4B0014E7F7 /* XCRemoteSwiftPackageReference "GoogleCastSDK-no-bluetooth" */,
 				99FE19252BFF49C9000B5602 /* XCRemoteSwiftPackageReference "Tabman" */,
+				040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */,
 			);
 			productRefGroup = 08C68D501D38D49600BB8AAA /* Products */;
 			projectDirPath = "";
@@ -16411,6 +16442,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SRGSSR/srgmediaplayer-apple.git";
+			requirement = {
+				branch = develop;
+				kind = branch;
+			};
+		};
 		04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://bitbucket.org/usercentricscode/usercentrics-spm-sdk";
@@ -16646,6 +16685,56 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		040075222C52DD18003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075242C52DD2E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075262C52DD3E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075282C52DD47003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752A2C52DD4F003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752C2C52DD5B003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		0400752E2C52DD66003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075302C52DD6E003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075322C52DD7D003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
+		040075342C52DD84003B3DA8 /* SRGMediaPlayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 040075212C52DD18003B3DA8 /* XCRemoteSwiftPackageReference "srgmediaplayer-apple" */;
+			productName = SRGMediaPlayer;
+		};
 		04030F4D2A34BD1100BC573B /* Usercentrics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 04030F4C2A34BD1100BC573B /* XCRemoteSwiftPackageReference "usercentrics-spm-sdk" */;

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "75d50617ff4a439adbeebc3e2d4183dcbcc7d8f6d67362af3f661f231f7d23a7",
+  "originHash" : "dc6cb5aa8ec915b03236c12d8d3937cf14feb462acc8d12dbb1279f4cf49a549",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgmediaplayer-apple.git",
       "state" : {
-        "revision" : "cbf8cf3c1914cf40b663c7cd60d626420fe2a7e9",
-        "version" : "7.2.2"
+        "branch" : "feature/dvr-start-fix",
+        "revision" : "cb6facef41e7cfffed0f051d795a6d8544222959"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c5e353bb3292ed471bf2f0e1c2cca74b214eb094f711dc181f2495a4768a3ce1",
+  "originHash" : "75d50617ff4a439adbeebc3e2d4183dcbcc7d8f6d67362af3f661f231f7d23a7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgmediaplayer-apple.git",
       "state" : {
-        "branch" : "develop",
-        "revision" : "fab4f77ec0f6effcb8c3d08e0e006db0219ac8b0"
+        "revision" : "cbf8cf3c1914cf40b663c7cd60d626420fe2a7e9",
+        "version" : "7.2.2"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "75d50617ff4a439adbeebc3e2d4183dcbcc7d8f6d67362af3f661f231f7d23a7",
+  "originHash" : "c5e353bb3292ed471bf2f0e1c2cca74b214eb094f711dc181f2495a4768a3ce1",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgmediaplayer-apple.git",
       "state" : {
-        "revision" : "717608146d3787bd269d5a524e109ee30be828e4",
-        "version" : "7.2.1"
+        "branch" : "develop",
+        "revision" : "fab4f77ec0f6effcb8c3d08e0e006db0219ac8b0"
       }
     },
     {

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dc6cb5aa8ec915b03236c12d8d3937cf14feb462acc8d12dbb1279f4cf49a549",
+  "originHash" : "75d50617ff4a439adbeebc3e2d4183dcbcc7d8f6d67362af3f661f231f7d23a7",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -366,8 +366,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srgmediaplayer-apple.git",
       "state" : {
-        "branch" : "feature/dvr-start-fix",
-        "revision" : "cb6facef41e7cfffed0f051d795a6d8544222959"
+        "revision" : "354b2c5bb53b412504c49c85639620677aeb4948",
+        "version" : "7.2.3"
       }
     },
     {


### PR DESCRIPTION
## Description

Open a VOD with DRM published with the new stream packaging SRGSSR solution, like [In her car - Deux soeurs - Bicanal (Episode 1/10 - Saison 1) - Play RTS](https://www.rts.ch/play/tv/redirect/detail/14714861)  or  [Top Models - 9263 - Play RTS](https://www.rts.ch/play/tv/top-models/video/9263?urn=urn:rts:video:15043155) (mostly all VOD with DRM in RTS Series topic).

### What happened?
The playback didn’t start at the beginning, but somewhere in the stream

### What should have happened?
The playback must starts at position 0.0 for VoD and AoD if no saved position in the user history (user data history). 

## Changes Made

- Update SRGMediaPlayer to [7.2.3](https://github.com/SRGSSR/srgmediaplayer-apple/releases/tag/7.2.3) which mitigates startup issue with malformed on-demand streams containing misaligned timestamps
  - EDIT: SRGMediaPlayer to [7.2.2](https://github.com/SRGSSR/srgmediaplayer-apple/releases/tag/7.2.2) created a new playback start issue on LSVS with DRM (LA 1, LA 2, RTS 1, RTS 2). So that why 7.2.3 release is used.. 
  
## Hints
  
 Internal tests: https://srgssr-ch.atlassian.net/browse/PLAYRTS-5595

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.