### PR TITLE
PLAYRTS-5605 Show title in audios by date

### DIFF
--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -56,8 +56,7 @@ import SRGAppearanceSwift
             if let show = media.show, !areRedundant(media: media, show: show) {
                 // Unbreakable spaces before / after the separator
                 return "\(formattedTime(for: media)) · \(show.title)"
-            }
-            else {
+            } else {
                 return formattedTime(for: media)
             }
         }

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -41,9 +41,7 @@ import SRGAppearanceSwift
         switch style {
         case .show:
             if let show = media.show {
-                if areRedundant(media: media, show: show) {
-                    return show.title
-                } else if let formattedDate = formattedDate(for: media, style: .shortDate) {
+                if !areRedundant(media: media, show: show), let formattedDate = formattedDate(for: media, style: .shortDate) {
                     // Unbreakable spaces before / after the separator
                     return "\(show.title) · \(formattedDate)"
                 } else {

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -55,7 +55,13 @@ import SRGAppearanceSwift
         case .date:
             return formattedDate(for: media)
         case .time:
-            return formattedTime(for: media)
+            if let show = media.show, !areRedundant(media: media, show: show) {
+                // Unbreakable spaces before / after the separator
+                return "\(formattedTime(for: media)) · \(show.title)"
+            }
+            else {
+                return formattedTime(for: media)
+            }
         }
     }
 


### PR DESCRIPTION
## Description

**As** an audio user
**I want to** know from which show an episode is from, in the “by date” view
**so that** I can select better what I would like to listen.

Display show title in audio episodes by date if not redundant with media title.
The show title is displayed after the media published time with a medium point between “media.formattedTime · show.title”.

> [!TIP]
> Same comparaison in an existing media description representation:
> -  Using: `areRedundant(media: SRGMedia, show: SRGShow) -> BOOL`
> - "not redundant with media title": check with `title` and `subtitle` media description properties the the show title is not displayed twice.

## Changes Made

- Add show title in the `subtitle` media description string, if not redundant for `MediaDescription.Style.time` case.
- Refactor the `subtitle` logic for `MediaDescription.Style.show` case.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.