### PR TITLE
PLAYRTS-5584 Remove Play SWI link in deployment pages

### DIFF
--- a/fastlane/gh-pages/deployments/build.html
+++ b/fastlane/gh-pages/deployments/build.html
@@ -129,36 +129,31 @@ img {
         'rsi': '1525999232',
         'rtr': '1525999511',
         'rts': '1525999108',
-        'srf': '1525999251',
-        'swi': '1525912081'
+        'srf': '1525999251'
       },
       'beta': {
         'rsi': '1541523749',
         'rtr': '1541523913',
         'rts': '1541524094',
-        'srf': '1541523775',
-        'swi': '1541523969'
+        'srf': '1541523775'
       },
       'testflight': {
         'rsi': '920753497',
         'rtr': '920754925',
         'rts': '920754415',
-        'srf': '638194352',
-        'swi': '920785201'
+        'srf': '638194352'
       },
       'appstore': {
         'rsi': '920753497',
         'rtr': '920754925',
         'rts': '920754415',
-        'srf': '638194352',
-        'swi': '920785201'
+        'srf': '638194352'
       },
       'none': {
         'rsi': '920753497',
         'rtr': '920754925',
         'rts': '920754415',
-        'srf': '638194352',
-        'swi': '920785201'
+        'srf': '638194352'
       }
     };
     return applicationIds[configuration][bu];
@@ -233,7 +228,7 @@ img {
         break;
     }
 
-    bus = ['rsi', 'rtr', 'rts', 'srf', 'swi'];
+    bus = ['rsi', 'rtr', 'rts', 'srf'];
     for (bu of bus) {
       document.write('<p><a href="' + getApplicationLink(configuration, bu) + '" target="_blank"><img src="./icon_' + bu + '-' + getPlatform() + '-' + configuration + '.png" height="60"/></a></p>');
     }


### PR DESCRIPTION
## Description

Following #498, an unexpected Github page link is still displayed: On the deployment page, Play SWI link.

Example: https://srgssr.github.io/playsrg-apple/deployments/build.html?configuration=Nightly&platform=iOS&version=3.8.8-541+PLAYRTS-5578-ios18-update

![Screenshot 2024-08-17 at 18 00 58](https://github.com/user-attachments/assets/781d6a12-9a3b-4b44-9183-923d379d785d)

## Changes Made

- Remove Play SWI in Github deployment page code generator.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.