### PR TITLE
PLAYRTS-500 Fix build name on main branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1336,7 +1336,9 @@ def version_suffix(version_suffix, branch_name)
 end
 
 def build_name(branch_name)
-  if branch_name.include? 'feature/'
+  if branch_name == github_main_branch
+    ''
+  elsif branch_name.include? 'feature/'
     branch_name.sub('feature/', '').strip
   elsif branch_name.include? 'release/'
     branch_name.sub('release/', '').strip
@@ -1364,7 +1366,7 @@ def nightly_changelog(platform, service, branch_name)
 
   changelog = 'No change log found for this build.' unless changelog && !changelog.empty?
 
-  "Built from #{build_name(branch_name)} branch\n\n#{changelog}"
+  "Built from #{branch_name} branch\n\n#{changelog}"
 end
 
 # Save the git commit hash in a local text file for nightlies

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1328,11 +1328,9 @@ end
 
 def version_suffix(version_suffix, branch_name)
   build_name = build_name(branch_name)
-  if build_name == github_main_branch
-    version_suffix
-  else
-    "#{version_suffix}+#{build_name}"
-  end
+  return version_suffix if build_name.empty?
+
+  "#{version_suffix}+#{build_name}"
 end
 
 def build_name(branch_name)


### PR DESCRIPTION
## Description

Build from the `main` branch must not have the "main" build name.
It's a regression from #515 workflow modification.

## Changes Made

- Fix the build name and avoid `main` in build name and version suffix from the main branch.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.