### PR TITLE
PLAYNEXT-500 Check pull request labels

### DIFF
--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,0 +1,79 @@
+name: PR needs one allowed label
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-pr-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y jq
+          pip install yq # Tool to parse YAML files
+
+      - name: Read allowed labels from .github/release.yml
+        id: read_labels
+        run: |
+          # Will read allowed PR labels from .github/release.yml file.
+          allowed_labels=$(yq '.changelog.categories[].labels[] | select(. != "*")' .github/release.yml)
+          allowed_labels=$(echo "$allowed_labels" | tr -d '"')
+
+          if [ -z "$allowed_labels" ]; then
+            echo "Error: No allowed labels found in .github/release.yml."
+            exit 1
+          fi
+
+          echo "Allowed labels from release.yml:"
+          echo "$allowed_labels"
+          echo "---"
+
+          # Convert to an array of strings
+          allowed_labels=$(echo "$allowed_labels" | tr '\n' ';')
+
+          # set the allowed labels in the GITHUB_OUTPUT
+          echo "ALLOWED_LABELS=${allowed_labels}" >> "$GITHUB_OUTPUT"
+
+      - name: Check PR Labels
+        id: check_labels
+        env:
+          ALLOWED_LABELS: ${{ steps.read_labels.outputs.ALLOWED_LABELS }}
+        run: |
+          # Will check that PR has exactly one of the allowed labels.
+          if [ -z "$ALLOWED_LABELS" ]; then
+            echo "Error: No allowed labels found from .github/release.yml. Configuration issue."
+            exit 1
+          fi
+
+          pr_labels=$(jq -r '.pull_request.labels[].name' $GITHUB_EVENT_PATH)
+
+          if [ -z "$pr_labels" ]; then
+            echo "Error: PR has no labels. Please add one of the allowed labels: $ALLOWED_LABELS"
+            exit 1
+          fi
+
+          echo "Labels on PR:"
+          echo "$pr_labels"
+          echo "---"
+
+          # Convert the string an to an array of strings
+          IFS=';' read -r -a allowed_labels_list <<< "$ALLOWED_LABELS"
+
+          count=0
+          for label in "${allowed_labels_list[@]}"; do
+            echo "Checking allowed label \"$label\" in PR labels."
+            if echo "$pr_labels" | grep -q "^$label$"; then
+              count=$((count + 1))
+            fi
+          done
+
+          echo "Allowed label count: $count"
+
+          if [ "$count" -ne 1 ]; then
+            echo "Error: PR must have exactly one of the allowed labels: $ALLOWED_LABELS"
+            exit 1
+          fi

--- a/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
+++ b/docs/GITHUB_ENVIRONMENTS_AND_DEPLOYMENTS.md
@@ -85,5 +85,5 @@ If the fastlane execution finished with an error, or killed with an exit signal,
 ### Inactive state
 
 - [By default](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#inactive-deployments), the non-transient, non-production environment deployments created by fastlane scripts have `auto_inactive` = `true`. So that a new `success` deployment sets all previous `success` deployments to `inactive` state. It's also activated to production environment deployments because the App Store distribution only allows the latest version of the application.
-- When closing a PR, a [Github action](https://github.com/SRGSSR/playsrg-apple/actions) (pr-closure.yml) is updating state to `inactive` to lastest `success` deployment for nighty branch environnements and beta branch environnements.
+- When closing a PR, a [Github action](https://github.com/SRGSSR/playsrg-apple/actions/workflows/pr-closure.yml) (pr-closure.yml) is updating state to `inactive` to lastest `success` deployment for nighty branch environnements and beta branch environnements.
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -96,7 +96,9 @@ When the feature or the bug fix branch is ready to be tested and reviewed:
 
 1. A [pull request](https://github.com/SRGSSR/playsrg-apple/pulls) is opened from the branch to be merged to the `main` branch.
 2. Set the Jira ticket id in the PR title and a comprehensive title. Example: `JIRA-1236 Feature C`. The Github PR id will be added during the merge, later.
-3. Add [one label](https://github.com/SRGSSR/playsrg-apple/labels) to the PR (used for automatically generated Github release notes, later).
+3. Add [one label](https://github.com/SRGSSR/playsrg-apple/labels) to the PR.
+	- They are used for automatically generated Github release notes, later with tag releases.
+	- A [Github action](https://github.com/SRGSSR/playsrg-apple/actions/workflows/check-pr-labels.yml) is checking that one allowed label is added.
 4. Add reviewers to the PR. At least one team member has to review the PR. 
    - Conversations, code propositions, architecture or UI/UX remarks could be added and has to be solved.
 5. ✅ When the feature or the bug fix is validated and the PR is reviewed, add the PR to the Github queue.


### PR DESCRIPTION
## Description

The workflow documentation mentionnes to add a label to any PR, to help tag release notes.
A GitHub Action can check that allowed labels are used.

## Changes Made

- Add a new GitHub action, which read allowed labels from `.github/release.yml` and compare with the labels on PR.
- Update documentation to mentioned GitHub actions.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.