### PR TITLE
PLAYNEXT-832 Fix hero stage title and subtitle

### DIFF
--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -20,6 +20,8 @@ import SRGAppearanceSwift
         case date
         /// Time information emphasis
         case time
+        /// Title information emphasis
+        case title
     }
 
     static func title(for media: SRGMedia, style: Style) -> String? {
@@ -31,6 +33,8 @@ import SRGAppearanceSwift
                 media.title
             }
         case .date, .time:
+            media.title
+        case .title:
             media.title
         }
     }
@@ -58,6 +62,12 @@ import SRGAppearanceSwift
                 return "\(formattedTime(for: media)) · \(show.title)"
             } else {
                 return formattedTime(for: media)
+            }
+        case .title:
+            if let show = media.show, !areRedundant(media: media, show: show) {
+                return show.title
+            } else {
+                return summary(for: media)
             }
         }
     }

--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -253,7 +253,7 @@ import SRGAppearanceSwift
     }
 
     private static func areRedundant(media: SRGMedia, show: SRGShow) -> Bool {
-        media.title.lowercased() == show.title.lowercased()
+        media.title.lowercased().contains(show.title.lowercased())
     }
 
     private static func shouldDisplayExpirationDate(for media: SRGMedia) -> Bool {

--- a/Application/Sources/UI/Views/HeroMediaCell.swift
+++ b/Application/Sources/UI/Views/HeroMediaCell.swift
@@ -82,12 +82,12 @@ struct HeroMediaCell: View {
 
         private var subtitle: String? {
             guard let media else { return nil }
-            return MediaDescription.subtitle(for: media, style: .show)
+            return MediaDescription.subtitle(for: media, style: .title)
         }
 
         private var title: String? {
             guard let media else { return nil }
-            return MediaDescription.title(for: media, style: .show)
+            return MediaDescription.title(for: media, style: .title)
         }
 
         var body: some View {


### PR DESCRIPTION
## Description

In PAC, the Play CMS, editors can update media title and lead. If the media title is set to the show title, the current logic is to displays only the date. In the hero stage, it's no correct anymore, from an UX point of view.

If the media title contains the show title, Play web does not display the show title, which is correct, from an UX point of view.
Play web does not display the media published date anymore.

## Changes Made

- Add `title` style for `MediaDescription`, to avoid displaying date, in subtitles but alors in title.
- Update `areRedundant(media:, show:)` like Play web implementation.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.