### PR TITLE
PLAYNEXT-1020 Add MacOS minimum OS version

### DIFF
--- a/Application/Application-Info.plist
+++ b/Application/Application-Info.plist
@@ -304,5 +304,7 @@
 	<string>$(CONFIG__PLAY_MMF_SERVICE_URL)</string>
 	<key>UserCentricsRuleSetId</key>
 	<string>$(CONFIG__USER_CENTRICS_RULE_SET_ID)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>12.0.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

ITMS reported this issue:

> Hello,
> 
> We noticed one or more issues with a recent delivery for the following app:
> 
> Play SRF: Streaming TV & Radio
> Version 3.8.9
> Build 461
> Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-90899: Macs with Apple silicon support issue - The app isn‘t compatible with the provided minimum macOS version of 11.0. It can run on macOS 12.0 or later. Please specify an LSMinimumSystemVersion value of 12.0 or later in a new build, or select a compatible version in App Store Connect. For details, visit: https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/manage-availability-of-iphone-and-ipad-apps-on-macs-with-apple-silicon.
> 
> Apple Developer Relations

## Changes Made

Add `LSMinimumSystemVersion` to iOS/iPadOS info plist.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.