### PR TITLE
Remove duplicates to avoid potential crashes

### DIFF
--- a/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideDailyViewController.swift
@@ -32,7 +32,7 @@ final class ProgramGuideDailyViewController: UIViewController {
         var snapshot = NSDiffableDataSourceSnapshot<ProgramGuideDailyViewModel.Section, ProgramGuideDailyViewModel.Item>()
         if let channel {
             snapshot.appendSections([channel])
-            snapshot.appendItems(state.items(for: channel), toSection: channel)
+            snapshot.appendItems(removeDuplicates(in: state.items(for: channel)), toSection: channel)
         }
         return snapshot
     }

--- a/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
+++ b/Application/Sources/ProgramGuide/ProgramGuideGridViewController.swift
@@ -26,7 +26,7 @@ final class ProgramGuideGridViewController: UIViewController {
         var snapshot = NSDiffableDataSourceSnapshot<ProgramGuideDailyViewModel.Section, ProgramGuideDailyViewModel.Item>()
         for section in state.sections {
             snapshot.appendSections([section])
-            snapshot.appendItems(state.items(for: section), toSection: section)
+            snapshot.appendItems(removeDuplicates(in: state.items(for: section)), toSection: section)
         }
         return snapshot
     }


### PR DESCRIPTION
## Description

This PR defensively removes potential duplicates in results returned by program TV requests. Though this should not occur in practice this still briefly occurred recently (data has since been fixed).

## Changes Made

Self-explanatory.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.