### PR TITLE
PLAYNEXT-1277 Remove most searched shows

### DIFF
--- a/Application/Sources/Search/SearchViewController.swift
+++ b/Application/Sources/Search/SearchViewController.swift
@@ -615,7 +615,7 @@ private extension SearchViewController {
                             MediaCellSize.grid(layoutWidth: layoutWidth, spacing: spacing)
                         }
                     }
-                case .mostSearchedShows, .shows:
+                case .shows:
                     let layoutSection = NSCollectionLayoutSection.horizontal(layoutWidth: layoutWidth, horizontalMargin: Self.layoutHorizontalMargin, spacing: Self.itemSpacing) { _, _ in
                         ShowCellSize.swimlane(for: .default)
                     }
@@ -684,8 +684,6 @@ private extension SearchViewController {
                 }
             case .shows:
                 return NSLocalizedString("Shows", comment: "Show search result header")
-            case .mostSearchedShows:
-                return NSLocalizedString("Most searched shows", comment: "Most searched shows header")
             case .topics:
                 return NSLocalizedString("Topics", comment: "Topics header")
             case .loading:

--- a/Application/Sources/Search/SearchViewModel.swift
+++ b/Application/Sources/Search/SearchViewModel.swift
@@ -110,7 +110,6 @@ extension SearchViewModel {
     enum Section: Hashable {
         case medias
         case shows
-        case mostSearchedShows
         case topics
         case loading
     }
@@ -135,12 +134,9 @@ extension SearchViewModel {
 private extension SearchViewModel {
     static func searchSuggestion() -> AnyPublisher<(rows: [Row], suggestions: [SRGSearchSuggestion]?), Error> {
         if !ApplicationConfiguration.shared.areShowsUnavailable {
-            Publishers.CombineLatest(
-                mostSearchedShows(),
-                topics()
-            )
-            .map { (rows: [$0, $1], suggestions: nil) }
-            .eraseToAnyPublisher()
+            topics()
+                .map { (rows: [$0], suggestions: nil) }
+                .eraseToAnyPublisher()
         } else {
             Just([])
                 .map { (rows: $0, suggestions: nil) }
@@ -198,15 +194,6 @@ private extension SearchViewModel {
             }
             .prepend((items: [Item.loading], suggestions: nil))
             .map { (row: Row(section: .medias, items: $0.items), suggestions: $0.suggestions) }
-            .eraseToAnyPublisher()
-    }
-
-    static func mostSearchedShows() -> AnyPublisher<Row, Error> {
-        let vendor = ApplicationConfiguration.shared.vendor
-        return SRGDataProvider.current!.mostSearchedShows(for: vendor, matching: constant(iOS: .none, tvOS: .TV))
-            .map { removeDuplicates(in: $0.map { Item.show($0) }) }
-            .prepend([Item.loading])
-            .map { Row(section: .mostSearchedShows, items: $0) }
             .eraseToAnyPublisher()
     }
 


### PR DESCRIPTION
## Description

The legacy Social View is being shutdown, and some calls won't have a successor.

Most searched is one of them, that's why everything associated with it needs to be removed.

Although I'm fairly certain nothing would break and it just wouldn't show up when returning nothing, it's still good ro remove clutter from code.

## Changes Made

- Remove calls and aspects related to most searched

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.