### PR TITLE
Update SRGAnalytics to 9.1.4

### DIFF
--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -88,7 +88,7 @@ name: PLCrashReporter, nameSpecified: PLCrashReporter, owner: microsoft, version
 
 name: promises, nameSpecified: Promises, owner: google, version: 2.4.0, source: https://github.com/google/promises
 
-name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.1.3, source: https://github.com/SRGSSR/srganalytics-apple
+name: srganalytics-apple, nameSpecified: SRGAnalytics, owner: SRGSSR, version: 9.1.4, source: https://github.com/SRGSSR/srganalytics-apple
 
 name: srgappearance-apple, nameSpecified: SRGAppearance, owner: SRGSSR, version: 5.2.2, source: https://github.com/SRGSSR/srgappearance-apple
 

--- a/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Application/Resources/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -262,7 +262,7 @@
 			<key>File</key>
 			<string>com.mono0926.LicensePlist/srganalytics-apple</string>
 			<key>Title</key>
-			<string>SRGAnalytics (9.1.3)</string>
+			<string>SRGAnalytics (9.1.4)</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>

--- a/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PlaySRG.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SRGSSR/srganalytics-apple.git",
       "state" : {
-        "revision" : "97ece2185ee456d0d85f0bd1608539f66e74d20f",
-        "version" : "9.1.3"
+        "revision" : "232a29c8a3ce7bec4ed7749d99a65587133980cb",
+        "version" : "9.1.4"
       }
     },
     {


### PR DESCRIPTION
## Description

Update Internal analytics library to remove a hint, asked by audience team.

## Changes Made

- Update SRGAnalytics to [9.1.4](https://github.com/SRGSSR/srganalytics-apple/releases/tag/9.1.4) (was 9.1.3).
- 
## Checklist

- [ ] I have followed the project's style guidelines.
- [ ] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes do not generate new warnings.
- [ ] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [ ] I have reviewed the contribution guidelines.