### PR TITLE
PLAYNEXT-704 Adapt show access to new channel presentation with action sheet selector

### DIFF
--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -635,8 +635,7 @@ extension PageViewController: UIScrollViewDelegate {
             case .showAZ:
                 if let navigationController {
                     let initialSectionId = applicationSectionInfo.options?[ApplicationSectionOptionKey.showAZIndexKey] as? String
-                    let showsViewController = SectionViewController.showsViewController(for: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId)
-                    navigationController.pushViewController(showsViewController, animated: false)
+                    SectionViewController.openShowsViewController(for: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId, in: navigationController, sourceView: nil)
                 }
                 return true
             default:
@@ -651,10 +650,9 @@ extension PageViewController: UIScrollViewDelegate {
     }
 
     extension PageViewController: ShowAccessCellActions {
-        func openShowAZ(sender _: Any?, event: ShowAccessEvent?) {
+        func openShowAZ(sender: Any?, event: ShowAccessEvent?) {
             if let navigationController, let event {
-                let showsViewController = SectionViewController.showsViewController(for: event.transmission, channelUid: radioChannel?.uid)
-                navigationController.pushViewController(showsViewController, animated: true)
+                SectionViewController.openShowsViewController(for: event.transmission, channelUid: radioChannel?.uid, in: navigationController, sourceView: sender as? UIView)
             }
         }
 

--- a/Application/Sources/Content/SectionViewController.swift
+++ b/Application/Sources/Content/SectionViewController.swift
@@ -436,19 +436,34 @@ extension SectionViewController {
         }
     }
 
-    static func showsViewController(for transmission: SRGTransmission, channelUid: String?, initialSectionId: String?) -> SectionViewController {
+    static func openShowsViewController(for transmission: SRGTransmission, channelUid: String?, initialSectionId: String?, in navigationController: UINavigationController, sourceView: UIView?) {
         if transmission == .radio, let channelUid {
-            SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
-        } else if transmission == .radio, let channelUid = ApplicationConfiguration.shared.radioHomepageChannels.first?.uid {
-            // FIXME: Load all radio A to Z shows, not only from the first channel.
-            SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId)
+            navigationController.pushViewController(SectionViewController(section: .configured(.radioAllShows(channelUid: channelUid)), initialSectionId: initialSectionId), animated: true)
+        } else if transmission == .radio {
+            let radiosForAZAccess = ApplicationConfiguration.shared.radioHomepageChannels
+            let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+            let actions = radiosForAZAccess.map { (name: $0.name, uid: $0.uid) }
+
+            for action in actions {
+                actionSheet.addAction(UIAlertAction(title: action.name, style: .default, handler: { _ in
+                    navigationController.pushViewController(SectionViewController(section: .configured(.radioAllShows(channelUid: action.uid)), initialSectionId: initialSectionId), animated: true)
+                }))
+            }
+
+            actionSheet.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button of action sheet"), style: .cancel, handler: { _ in
+                navigationController.dismiss(animated: true)
+            }))
+
+            actionSheet.popoverPresentationController?.sourceView = sourceView
+            navigationController.present(actionSheet, animated: true)
         } else {
-            SectionViewController(section: .configured(.tvAllShows), initialSectionId: initialSectionId)
+            navigationController.pushViewController(SectionViewController(section: .configured(.tvAllShows), initialSectionId: initialSectionId), animated: true)
         }
     }
 
-    static func showsViewController(for transmission: SRGTransmission, channelUid: String?) -> SectionViewController {
-        showsViewController(for: transmission, channelUid: channelUid, initialSectionId: nil)
+    static func openShowsViewController(for transmission: SRGTransmission, channelUid: String?, in navigationController: UINavigationController, sourceView: UIView?) {
+        openShowsViewController(for: transmission, channelUid: channelUid, initialSectionId: nil, in: navigationController, sourceView: sourceView)
     }
 }
 


### PR DESCRIPTION
## Description

With the new PAC audio page, the show access A-Z button can now be ambiguous since many audio channels are displayed at once.

The design was left open to developer in order to be able to show the list.

I went with a simple and well known pattern, that would be the default for this kind of operation from the HIG, the action sheet.

Another design route is suggested in #539 

Of course it is still open for discussion and we can totally revamp should a better proposal come to us. 

https://github.com/user-attachments/assets/f462c38e-d9d8-4526-b74c-58500533c048

## Changes Made

- Refactor a bit the helper methods to build `showsViewController(...)` method since with the action sheet, it not only needs to build a `SectionViewController`, but also select it asynchronously after user selection.
- Wire the next VC according to user selection and and show it 

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.