### PR TITLE
Add remote configuration service url

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -5,6 +5,7 @@
   "tvSiteName": "rsi-player-tvos-apple",
   "voiceOverLanguageCode": "it",
   "appStoreProductIdentifier": 920753497,
+  "dataProviderServiceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rsi.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "rsi-player-tvos-apple",
   "voiceOverLanguageCode": "it",
   "appStoreProductIdentifier": 920753497,
-  "dataProviderServiceURL": "https://il.srf.ch",
+  "serviceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rsi.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -4,7 +4,7 @@
   "siteName": "rtr-player-ios-v",
   "tvSiteName": "rtr-player-tvos-apple",
   "appStoreProductIdentifier": 920754925,
-  "dataProviderServiceURL": "https://il.srf.ch",
+  "serviceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rtr.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -4,6 +4,7 @@
   "siteName": "rtr-player-ios-v",
   "tvSiteName": "rtr-player-tvos-apple",
   "appStoreProductIdentifier": 920754925,
+  "dataProviderServiceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rtr.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "rts-player-tvos-apple",
   "voiceOverLanguageCode": "fr",
   "appStoreProductIdentifier": 920754415,
-  "dataProviderServiceURL": "https://il.srf.ch",
+  "serviceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rts.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -5,6 +5,7 @@
   "tvSiteName": "rts-player-tvos-apple",
   "voiceOverLanguageCode": "fr",
   "appStoreProductIdentifier": 920754415,
+  "dataProviderServiceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.rts.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -5,6 +5,7 @@
   "tvSiteName": "srf-player-tvos-apple",
   "voiceOverLanguageCode": "de",
   "appStoreProductIdentifier": 638194352,
+  "dataProviderServiceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.srf.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "srf-player-tvos-apple",
   "voiceOverLanguageCode": "de",
   "appStoreProductIdentifier": 638194352,
-  "dataProviderServiceURL": "https://il.srf.ch",
+  "serviceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://www.srf.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -5,6 +5,7 @@
   "tvSiteName": "swi-player-tvos-apple",
   "voiceOverLanguageCode": "en",
   "appStoreProductIdentifier": 920785201,
+  "dataProviderServiceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://play.swissinfo.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SWI/ApplicationConfiguration.json
@@ -5,7 +5,7 @@
   "tvSiteName": "swi-player-tvos-apple",
   "voiceOverLanguageCode": "en",
   "appStoreProductIdentifier": 920785201,
-  "dataProviderServiceURL": "https://il.srf.ch",
+  "serviceURL": "https://il.srf.ch",
   "playURLs": "{\"rsi\":\"https://www.rsi.ch/play/\",\"rtr\":\"https://www.rtr.ch/play/\",\"rts\":\"https://www.rts.ch/play/\",\"srf\":\"https://www.srf.ch/play/\",\"swi\":\"https://play.swissinfo.ch/play/\"}",
   "playServiceURL": "https://play.swissinfo.ch/play/",
   "middlewareURL": "https://playfff.herokuapp.com",

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -38,6 +38,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, copy) NSNumber *appStoreProductIdentifier;
 
+@property (nonatomic, readonly, nullable) NSURL *dataProviderServiceURL;
 @property (nonatomic, readonly) NSURL *playServiceURL;
 @property (nonatomic, readonly) NSURL *middlewareURL;
 @property (nonatomic, readonly, nullable) NSURL *identityWebserviceURL;

--- a/Application/Sources/Configuration/ApplicationConfiguration.h
+++ b/Application/Sources/Configuration/ApplicationConfiguration.h
@@ -38,7 +38,7 @@ OBJC_EXPORT NSString * const ApplicationConfigurationDidChangeNotification;
 
 @property (nonatomic, readonly, copy) NSNumber *appStoreProductIdentifier;
 
-@property (nonatomic, readonly, nullable) NSURL *dataProviderServiceURL;
+@property (nonatomic, readonly, nullable) NSURL *serviceURL;
 @property (nonatomic, readonly) NSURL *playServiceURL;
 @property (nonatomic, readonly) NSURL *middlewareURL;
 @property (nonatomic, readonly, nullable) NSURL *identityWebserviceURL;

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -122,6 +122,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic, copy) NSNumber *appStoreProductIdentifier;
 
+@property (nonatomic) NSURL *dataProviderServiceURL;
 @property (nonatomic) NSDictionary<NSNumber *, NSURL *> *playURLs;
 @property (nonatomic) NSURL *playServiceURL;
 @property (nonatomic) NSURL *middlewareURL;
@@ -448,7 +449,10 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     //
     
     self.voiceOverLanguageCode = [firebaseConfiguration stringForKey:@"voiceOverLanguageCode"];
-    
+
+    NSString *dataProviderServiceURLString = [firebaseConfiguration stringForKey:@"dataProviderServiceURL"];
+    self.dataProviderServiceURL = dataProviderServiceURLString ? [NSURL URLWithString:dataProviderServiceURLString] : nil;
+
     NSString *identityWebserviceURLString = [firebaseConfiguration stringForKey:@"identityWebserviceURL"];
     self.identityWebserviceURL = identityWebserviceURLString ? [NSURL URLWithString:identityWebserviceURLString] : nil;
     

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -122,7 +122,7 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
 
 @property (nonatomic, copy) NSNumber *appStoreProductIdentifier;
 
-@property (nonatomic) NSURL *dataProviderServiceURL;
+@property (nonatomic) NSURL *serviceURL;
 @property (nonatomic) NSDictionary<NSNumber *, NSURL *> *playURLs;
 @property (nonatomic) NSURL *playServiceURL;
 @property (nonatomic) NSURL *middlewareURL;
@@ -450,8 +450,8 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
     
     self.voiceOverLanguageCode = [firebaseConfiguration stringForKey:@"voiceOverLanguageCode"];
 
-    NSString *dataProviderServiceURLString = [firebaseConfiguration stringForKey:@"dataProviderServiceURL"];
-    self.dataProviderServiceURL = dataProviderServiceURLString ? [NSURL URLWithString:dataProviderServiceURLString] : nil;
+    NSString *serviceURLString = [firebaseConfiguration stringForKey:@"serviceURL"];
+    self.serviceURL = serviceURLString ? [NSURL URLWithString:serviceURLString] : nil;
 
     NSString *identityWebserviceURLString = [firebaseConfiguration stringForKey:@"identityWebserviceURL"];
     self.identityWebserviceURL = identityWebserviceURLString ? [NSURL URLWithString:identityWebserviceURLString] : nil;

--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -83,7 +83,7 @@ struct Service: Identifiable, Equatable {
     }
 
     @objc static func url(forServiceId serviceId: String) -> URL {
-        ApplicationConfiguration().dataProviderServiceURL != nil ? ApplicationConfiguration().dataProviderServiceURL! :
+        ApplicationConfiguration().serviceURL != nil ? ApplicationConfiguration().serviceURL! :
             Service.service(forId: serviceId).url
     }
 }

--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -83,6 +83,7 @@ struct Service: Identifiable, Equatable {
     }
 
     @objc static func url(forServiceId serviceId: String) -> URL {
-        Service.service(forId: serviceId).url
+        ApplicationConfiguration().dataProviderServiceURL != nil ? ApplicationConfiguration().dataProviderServiceURL! :
+            Service.service(forId: serviceId).url
     }
 }

--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -83,7 +83,6 @@ struct Service: Identifiable, Equatable {
     }
 
     @objc static func url(forServiceId serviceId: String) -> URL {
-        ApplicationConfiguration().serviceURL != nil ? ApplicationConfiguration().serviceURL! :
-            Service.service(forId: serviceId).url
+        ApplicationConfiguration().serviceURL ?? Service.service(forId: serviceId).url
     }
 }

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -26,7 +26,7 @@ If a remote configuration is found to be invalid (usually a mandatory parameter 
 * `faqURL` (optional, string): The URL of the FAQs.
 * `dataProtectionURL` (optional, string): The URL of the data protection information page.
 * `impressumURL` (optional, string): The URL of the impressum page. If none is provided, the corresponding menu entry will not be displayed.
-* `dataProviderServiceURL` (optional, string): The URL of the DataProvider service. If set, it overrides the local server non production option.
+* `serviceURL` (optional, string): The URL of the Content service (DataProvider). If set, it overrides the local server option available in beta builds only.
 * `identityWebserviceURL` (optional, string): The URL of the identity webservices.
 * `identityWebsiteURL` (optional, string): The URL of the identity web portal.
 * `userDataServiceURL` (optional, string): The URL of the service with which user data can be synchronized (history, preferences, playlists).

--- a/docs/REMOTE_CONFIGURATION.md
+++ b/docs/REMOTE_CONFIGURATION.md
@@ -25,7 +25,8 @@ If a remote configuration is found to be invalid (usually a mandatory parameter 
 * `feedbackURL` (optional, string): The URL of the feedback form.
 * `faqURL` (optional, string): The URL of the FAQs.
 * `dataProtectionURL` (optional, string): The URL of the data protection information page.
-* `impressumURL` (optional, string): The URL of the impressum page. If none is provided, the corresponding menu entry will not be displayed. 
+* `impressumURL` (optional, string): The URL of the impressum page. If none is provided, the corresponding menu entry will not be displayed.
+* `dataProviderServiceURL` (optional, string): The URL of the DataProvider service. If set, it overrides the local server non production option.
 * `identityWebserviceURL` (optional, string): The URL of the identity webservices.
 * `identityWebsiteURL` (optional, string): The URL of the identity web portal.
 * `userDataServiceURL` (optional, string): The URL of the service with which user data can be synchronized (history, preferences, playlists).


### PR DESCRIPTION
## Description

To decide if we would like this hot fix and expedite review by Apple.

## Changes Made

- Add an optional remote configuration property to override DataProdvider service url, named `serviceURL`.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.