### PR TITLE
PLAYNEXT-2272 Remove logic to tweak title in case of redundancy

### DIFF
--- a/Application/Sources/UI/Helpers/MediaDescription.swift
+++ b/Application/Sources/UI/Helpers/MediaDescription.swift
@@ -46,14 +46,14 @@ import SRGAppearanceSwift
         case .date:
             return formattedDate(for: media)
         case .time:
-            if let show = media.show, !areRedundant(media: media, show: show) {
+            if let show = media.show {
                 // Unbreakable spaces before / after the separator
                 return "\(formattedTime(for: media)) · \(show.title)"
             } else {
                 return formattedTime(for: media)
             }
         case .title:
-            if let show = media.show, !areRedundant(media: media, show: show) {
+            if let show = media.show {
                 return show.title
             } else {
                 return summary(for: media)


### PR DESCRIPTION
## Description

I was asked to remove all remaining logic that was tweak the title when show and media titles were identical.

## Changes Made

- Remove condition of call to `areRedundant` function
- Leave the `areRedundant` function since it still deduplicates title for accessibility and this can be annoying

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.