### PR TITLE
PLAYNEXT-2415 Fix layout for favorite shows

### DIFF
--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -648,11 +648,11 @@ private extension Content {
         var imageVariant: SRGImageVariant {
             switch configuredSection {
             // swiftlint:disable:next line_length
-            case .availableEpisodes, .favoriteShows, .history, .watchLater, .tvEpisodesForDay, .tvLive, .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll, .tvLiveCenterEpisodes, .tvLiveCenterEpisodesAll, .tvScheduledLivestreams, .tvScheduledLivestreamsNews, .tvScheduledLivestreamsSport, .tvScheduledLivestreamsSignLanguage:
+            case .availableEpisodes, .history, .watchLater, .tvEpisodesForDay, .tvLive, .tvLiveCenterScheduledLivestreams, .tvLiveCenterScheduledLivestreamsAll, .tvLiveCenterEpisodes, .tvLiveCenterEpisodesAll, .tvScheduledLivestreams, .tvScheduledLivestreamsNews, .tvScheduledLivestreamsSport, .tvScheduledLivestreamsSignLanguage:
                 ContentType.videoOrTV.imageVariant(mediaType: mediaType)
             case .radioEpisodesForDay, .radioFavoriteShows, .radioLatest, .radioLatestEpisodes, .radioLatestEpisodesFromFavorites, .radioMostPopular, .radioResumePlayback, .radioWatchLater, .radioLive, .radioLiveSatellite, .radioAllShows:
                 ContentType.audioOrRadio.imageVariant(mediaType: mediaType)
-            case .radioLatestVideos, .tvAllShows:
+            case .radioLatestVideos, .tvAllShows, .favoriteShows:
                 ContentType.mixed.imageVariant(mediaType: mediaType)
             #if os(iOS)
                 case .downloads, .notifications:


### PR DESCRIPTION
## Description

The last batch of changes related to PAC audio curation introduced an unwanted change.
The favorite shows section is shown in 2/3 aspect ratio for SRF.
This PR fixes it.

## Changes Made

- Enforce mixed content type image variant for favorite shows

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.