### PR TITLE
PLAYNEXT-2555 Fix DeepLink bug for "by date" and "AZ" when channel is nil

### DIFF
--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -635,15 +635,23 @@ extension PageViewController: UIScrollViewDelegate {
             case .showByDate:
                 let date = applicationSectionInfo.options?[ApplicationSectionOptionKey.showByDateDateKey] as? Date
                 if let navigationController {
-                    let showByDateViewController = Self.showByDateViewController(transmission: .radio, radioChannel: radioChannel, date: date)
-                    navigationController.pushViewController(showByDateViewController, animated: false)
+                    let targetViewController = if let radioChannel = applicationSectionInfo.radioChannel {
+                        Self.showByDateViewController(transmission: .radio, radioChannel: radioChannel, date: date)
+                    } else {
+                        ProgramGuideViewController(date: date)
+                    }
+                    navigationController.pushViewController(targetViewController, animated: false)
                 }
                 return true
             case .showAZ:
                 if let navigationController {
                     let initialSectionId = applicationSectionInfo.options?[ApplicationSectionOptionKey.showAZIndexKey] as? String
-                    let showsViewController = SectionViewController.showsViewController(for: .radio, channelUid: radioChannel?.uid, initialSectionId: initialSectionId)
-                    navigationController.pushViewController(showsViewController, animated: true)
+                    let targetViewController = if let radioChannel = applicationSectionInfo.radioChannel {
+                        SectionViewController.showsViewController(for: .radio, channelUid: radioChannel.uid, initialSectionId: initialSectionId)
+                    } else {
+                        SectionViewController.showsViewController(for: .TV, channelUid: nil, initialSectionId: initialSectionId)
+                    }
+                    navigationController.pushViewController(targetViewController, animated: true)
                 }
                 return true
             default:


### PR DESCRIPTION
## Description

A bug was reported, where the TV program page deep link (from the web) for SRF was leading to a radio page within the app.

After investigating and discussing with @pyby, it turns out that there was a missing bit in the implementation.

According to the documentation:

> For media, show and page links, an optional channel_id=[channel_id] parameter can be added, which resets the homepage to the specified radio channel homepage. If this parameter is not specified or does not match a valid channel, the homepage is reset to the TV one instead.

## Changes Made

- Fixed the logic to check if the radio channel is nil, if it is, load a TV page instead
- Do the same for AZ

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.