### PR TITLE
PLAYNEXT-2579 Add youth protection overlay

### DIFF
--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -2419,7 +2419,6 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
 #pragma mark Youth protection overlay
 
 - (void)scheduleYouthProtectionOverlay:(nullable NSNotification *)notification {
-    SRGMediaType mediaType = self.letterboxController.media.mediaType;
     SRGMediaPlayerPlaybackState playbackState;
     if (notification) {
         playbackState = [notification.userInfo[SRGMediaPlayerPlaybackStateKey] integerValue];


### PR DESCRIPTION
## Description

It was request that a youth protection overlay be displayed on the player so that burn-in youth protection info can be retired.

This PR implements it:

https://github.com/user-attachments/assets/9a17de37-20e0-4651-8b49-145a7c38bf98

## Changes Made

- Add overlay views to `MediaPlayerViewController`
- Schedule timer so that the overlay is shown 10 seconds after playback starts 
- Reset flag so that overlay is shown again if the media changes
- Timer management

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.