### PR TITLE
PLAYNEXT-3096 Add VPN or Proxy detection settings

### DIFF
--- a/Application/Sources/Application/AppDelegate.m
+++ b/Application/Sources/Application/AppDelegate.m
@@ -124,6 +124,7 @@ static void *s_kvoContext = &s_kvoContext;
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
     [defaults addObserver:self forKeyPath:PlaySRGSettingServiceEnvironment options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld  context:s_kvoContext];
     [defaults addObserver:self forKeyPath:PlaySRGSettingUserLocation options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
+    [defaults addObserver:self forKeyPath:PlaySRGSettingProxyDetection options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
 #endif
     
     // Various setups
@@ -379,7 +380,7 @@ static void *s_kvoContext = &s_kvoContext;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if (s_kvoContext == context) {
-        if ([keyPath isEqualToString:PlaySRGSettingServiceEnvironment] || [keyPath isEqualToString:PlaySRGSettingUserLocation]) {
+        if ([keyPath isEqualToString:PlaySRGSettingServiceEnvironment] || [keyPath isEqualToString:PlaySRGSettingUserLocation] || [keyPath isEqualToString:PlaySRGSettingProxyDetection]) {
             id oldValue = change[NSKeyValueChangeOldKey];
             id newValue = change[NSKeyValueChangeNewKey];
             

--- a/Application/Sources/Application/SceneDelegate.m
+++ b/Application/Sources/Application/SceneDelegate.m
@@ -60,6 +60,7 @@ static void *s_kvoContext = &s_kvoContext;
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
     [defaults addObserver:self forKeyPath:PlaySRGSettingServiceEnvironment options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
     [defaults addObserver:self forKeyPath:PlaySRGSettingUserLocation options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
+    [defaults addObserver:self forKeyPath:PlaySRGSettingProxyDetection options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
     [defaults addObserver:self forKeyPath:PlaySRGSettingPosterImages options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
     [defaults addObserver:self forKeyPath:PlaySRGSettingPodcastImages options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
     [defaults addObserver:self forKeyPath:PlaySRGSettingAudioHomepageOption options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:s_kvoContext];
@@ -72,6 +73,7 @@ static void *s_kvoContext = &s_kvoContext;
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
     [defaults removeObserver:self forKeyPath:PlaySRGSettingServiceEnvironment];
     [defaults removeObserver:self forKeyPath:PlaySRGSettingUserLocation];
+    [defaults removeObserver:self forKeyPath:PlaySRGSettingProxyDetection];
     [defaults removeObserver:self forKeyPath:PlaySRGSettingPosterImages];
     [defaults removeObserver:self forKeyPath:PlaySRGSettingPodcastImages];
     [defaults removeObserver:self forKeyPath:PlaySRGSettingAudioHomepageOption];
@@ -560,7 +562,7 @@ static void *s_kvoContext = &s_kvoContext;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if (s_kvoContext == context) {
-        if ([keyPath isEqualToString:PlaySRGSettingServiceEnvironment] || [keyPath isEqualToString:PlaySRGSettingUserLocation] || [keyPath isEqualToString:PlaySRGSettingPosterImages] || [keyPath isEqualToString:PlaySRGSettingPodcastImages] ||  [keyPath isEqualToString:PlaySRGSettingAudioHomepageOption]) {
+        if ([keyPath isEqualToString:PlaySRGSettingServiceEnvironment] || [keyPath isEqualToString:PlaySRGSettingUserLocation] || [keyPath isEqualToString:PlaySRGSettingProxyDetection] || [keyPath isEqualToString:PlaySRGSettingPosterImages] || [keyPath isEqualToString:PlaySRGSettingPodcastImages] ||  [keyPath isEqualToString:PlaySRGSettingAudioHomepageOption]) {
             // Entirely reload the view controller hierarchy to ensure all configuration changes are reflected in the
             // user interface. Scheduled for the next run loop to have the same code in the app delegate (updating the
             // data provider) executed first.

--- a/Application/Sources/Settings/ApplicationSettingsConstants.h
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.h
@@ -24,6 +24,7 @@ OBJC_EXPORT NSString * const PlaySRGSettingLastLoggedInEmailAddress;
 OBJC_EXPORT NSString * const PlaySRGSettingSelectedLivestreamURNForChannels;
 OBJC_EXPORT NSString * const PlaySRGSettingServiceEnvironment;
 OBJC_EXPORT NSString * const PlaySRGSettingUserLocation;
+OBJC_EXPORT NSString * const PlaySRGSettingProxyDetection;
 OBJC_EXPORT NSString * const PlaySRGSettingUserConsentAcceptedServiceIds;
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 OBJC_EXPORT NSString * const PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled;

--- a/Application/Sources/Settings/ApplicationSettingsConstants.m
+++ b/Application/Sources/Settings/ApplicationSettingsConstants.m
@@ -22,6 +22,7 @@ NSString * const PlaySRGSettingLastLoggedInEmailAddress = @"PlaySRGSettingLastLo
 NSString * const PlaySRGSettingSelectedLivestreamURNForChannels = @"PlaySRGSettingSelectedLivestreamURNForChannels";
 NSString * const PlaySRGSettingServiceEnvironment = @"PlaySRGSettingServiceEnvironment";
 NSString * const PlaySRGSettingUserLocation = @"PlaySRGSettingUserLocation";
+NSString * const PlaySRGSettingProxyDetection = @"PlaySRGSettingProxyDetection";
 NSString * const PlaySRGSettingUserConsentAcceptedServiceIds = @"PlaySRGSettingUserConsentAcceptedServiceIds";
 #if defined(DEBUG) || defined(NIGHTLY) || defined(BETA)
 NSString * const PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled = @"PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled";

--- a/Application/Sources/Settings/ProxyDetection.swift
+++ b/Application/Sources/Settings/ProxyDetection.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright (c) SRG SSR. All rights reserved.
+//
+//  License information is available from the LICENSE file.
+//
+
+import Foundation
+
+enum ProxyDetection: String, CaseIterable, Identifiable {
+    case `default` = ""
+    case VPNORPROXY
+    case DIRECT
+
+    var id: Self {
+        self
+    }
+
+    var description: String {
+        switch self {
+        case .VPNORPROXY:
+            NSLocalizedString("Via a VPN or Proxy", comment: "VPN or Proxy detection setting state")
+        case .DIRECT:
+            NSLocalizedString("Direct connection", comment: "VPN or Proxy detection setting state")
+        case .default:
+            NSLocalizedString("Default (IP-based detection)", comment: "VPN or Proxy detection setting state")
+        }
+    }
+}

--- a/Application/Sources/Settings/SettingsView.swift
+++ b/Application/Sources/Settings/SettingsView.swift
@@ -524,6 +524,14 @@ struct SettingsView: View {
                     } label: {
                         UserLocationSelectionCell()
                     }
+                    NextLink {
+                        ProxyDetectionSelectionView()
+                        #if os(iOS)
+                            .navigationBarTitleDisplayMode(.inline)
+                        #endif
+                    } label: {
+                        ProxyDetectionSelectionCell()
+                    }
                     Toggle(NSLocalizedString("Presenter mode", comment: "Presenter mode setting label"), isOn: $isPresenterModeEnabled)
                     Toggle(NSLocalizedString("Standalone playback", comment: "Standalone playback setting label"), isOn: $isStandaloneEnabled)
                     Toggle(NSLocalizedString("Section wide support", comment: "Section wide support setting label"), isOn: $isSectionWideSupportEnabled)
@@ -588,6 +596,21 @@ struct SettingsView: View {
                         Text(NSLocalizedString("User location", comment: "Label of the button for user location selection"))
                         Spacer()
                         Text(selectedUserLocation.description)
+                            .foregroundColor(Color.play_sectionSecondary)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(2)
+                    }
+                }
+            }
+
+            private struct ProxyDetectionSelectionCell: View {
+                @AppStorage(PlaySRGSettingProxyDetection) private var selectedProxyDetection = ProxyDetection.default
+
+                var body: some View {
+                    HStack {
+                        Text(NSLocalizedString("VPN or Proxy detection", comment: "Label of the button for VPN or Proxy detection selection"))
+                        Spacer()
+                        Text(selectedProxyDetection.description)
                             .foregroundColor(Color.play_sectionSecondary)
                             .multilineTextAlignment(.trailing)
                             .lineLimit(2)
@@ -721,6 +744,46 @@ struct SettingsView: View {
 
                 private func select() {
                     selectedUserLocation = userLocation
+                }
+            }
+
+            private struct ProxyDetectionSelectionView: View {
+                var body: some View {
+                    List {
+                        ForEach(ProxyDetection.allCases) { proxyDetection in
+                            DetectionCell(proxyDetection: proxyDetection)
+                        }
+                    }
+                    .srgFont(.body)
+                    #if os(tvOS)
+                        .listStyle(GroupedListStyle())
+                        .play_scrollClipDisabled()
+                        .frame(maxWidth: LayoutMaxListWidth)
+                    #endif
+                        .navigationTitle(NSLocalizedString("VPN or Proxy detection", comment: "VPN or Proxy detection selection view title"))
+                }
+            }
+
+            private struct DetectionCell: View {
+                let proxyDetection: ProxyDetection
+
+                @AppStorage(PlaySRGSettingProxyDetection) private var selectedProxyDetection = ProxyDetection.default
+
+                var body: some View {
+                    Button(action: select) {
+                        HStack {
+                            Text(proxyDetection.description)
+                            Spacer()
+                            if proxyDetection == selectedProxyDetection {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                    .foregroundColor(.primary)
+                }
+
+                private func select() {
+                    selectedProxyDetection = proxyDetection
                 }
             }
 

--- a/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
+++ b/Application/Sources/Settings/UserDefaults+ApplicationSettings.swift
@@ -33,6 +33,10 @@ extension UserDefaults {
         string(forKey: PlaySRG.PlaySRGSettingUserLocation)
     }
 
+    @objc dynamic var PlaySRGSettingProxyDetection: String? {
+        string(forKey: PlaySRG.PlaySRGSettingProxyDetection)
+    }
+
     #if DEBUG || NIGHTLY || BETA
         @objc dynamic var PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled: Bool {
             bool(forKey: PlaySRG.PlaySRGSettingAlwaysAskUserConsentAtLaunchEnabled)

--- a/PlaySRG.xcodeproj/project.pbxproj
+++ b/PlaySRG.xcodeproj/project.pbxproj
@@ -47,6 +47,16 @@
 		0407EFED2A509F10004A0FAB /* Bundble+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0407EFE52A509F10004A0FAB /* Bundble+PlaySRG.swift */; };
 		0407EFEE2A509F10004A0FAB /* Bundble+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0407EFE52A509F10004A0FAB /* Bundble+PlaySRG.swift */; };
 		0407EFEF2A509F10004A0FAB /* Bundble+PlaySRG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0407EFE52A509F10004A0FAB /* Bundble+PlaySRG.swift */; };
+		040A3B8B2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B8C2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B8D2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B8E2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B8F2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B902DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B912DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B922DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B932DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
+		040A3B942DC40ED70011C4C6 /* ProxyDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */; };
 		0414BF212A685B73004543BD /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 0414BF202A685B73004543BD /* SwiftUIIntrospect */; };
 		0414BF232A685B81004543BD /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 0414BF222A685B81004543BD /* SwiftUIIntrospect */; };
 		0414BF252A685B8E004543BD /* SwiftUIIntrospect in Frameworks */ = {isa = PBXBuildFile; productRef = 0414BF242A685B8E004543BD /* SwiftUIIntrospect */; };
@@ -2860,6 +2870,7 @@
 		0406040D29CE6293001F2BD0 /* MediaMoreButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaMoreButton.swift; sourceTree = "<group>"; };
 		0407308428635FE9002E8221 /* SearchSettingsBucketsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsBucketsView.swift; sourceTree = "<group>"; };
 		0407EFE52A509F10004A0FAB /* Bundble+PlaySRG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundble+PlaySRG.swift"; sourceTree = "<group>"; };
+		040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyDetection.swift; sourceTree = "<group>"; };
 		041DD1732B1B95AA00C9368A /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		041DD17E2B1BA8B100C9368A /* TableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableView.swift; sourceTree = "<group>"; };
 		042F6F2829E0710C003F46AA /* UIStackView+PlaySRG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStackView+PlaySRG.swift"; sourceTree = "<group>"; };
@@ -4011,12 +4022,13 @@
 				6FB03F5B25DECB3A0033132B /* ApplicationSettingsConstants.m */,
 				04B675C62BE65C4B00F2A934 /* AudioHomepageOption.swift */,
 				6F5B4D5D2833F8F3004F5BA3 /* FeaturesView.swift */,
+				04308F5D2B9DB2FE00A11CC7 /* PodcastImages.swift */,
 				6F6C7AD32820578900BC3EA5 /* PosterImages.swift */,
+				040A3B8A2DC40ED70011C4C6 /* ProxyDetection.swift */,
 				6FE25909285E66570080548A /* Service.swift */,
 				6F8CBD802832A2CB000C7A93 /* SettingsNavigationView.swift */,
 				6F46B7BA281FB1FB00D20748 /* SettingsView.swift */,
 				6F46B7B4281FB1F100D20748 /* SettingsViewModel.swift */,
-				04308F5D2B9DB2FE00A11CC7 /* PodcastImages.swift */,
 				6F73C639271DB5AE00DBDBFB /* UserDefaults+ApplicationSettings.swift */,
 				6F6C7AC82820576000BC3EA5 /* UserLocation.swift */,
 				6FDAAD8D2832824E008E2806 /* WhatsNewView.swift */,
@@ -8635,6 +8647,7 @@
 				6F06E0A41DB7791300220FC6 /* ApplicationSettings.m in Sources */,
 				6FCE7A38260359220037A861 /* Extensions.swift in Sources */,
 				6FDAAD94283283EB008E2806 /* WebView.swift in Sources */,
+				040A3B8D2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				08AF9480217D27E40028B082 /* SharingItem.m in Sources */,
 				048FD2092A122BF100929AE5 /* ProfileAccountHeaderView+UIKit.swift in Sources */,
 				6F73BFB026563ABD0032D742 /* DampedCollectionView.swift in Sources */,
@@ -8882,6 +8895,7 @@
 				6FE8626D2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				0827DA1F1F0D36E200A31A42 /* NSBundle+PlaySRG.m in Sources */,
 				6F54D35A26050FE5008B46FF /* MediaVisualView.swift in Sources */,
+				040A3B942DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F80E9C321A682E70027CA2F /* TableRequestViewController.m in Sources */,
 				048FD2102A124CB300929AE5 /* ProfileAccountHeaderViewModel.swift in Sources */,
 				6F33E6202860BED900724E76 /* SearchSettingsNavigationView.swift in Sources */,
@@ -9155,6 +9169,7 @@
 				6FE8626E2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				0827DA201F0D36E200A31A42 /* NSBundle+PlaySRG.m in Sources */,
 				6F54D35B26050FE5008B46FF /* MediaVisualView.swift in Sources */,
+				040A3B8F2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F80E9C421A682E70027CA2F /* TableRequestViewController.m in Sources */,
 				048FD2112A124CB300929AE5 /* ProfileAccountHeaderViewModel.swift in Sources */,
 				6F33E6212860BED900724E76 /* SearchSettingsNavigationView.swift in Sources */,
@@ -9428,6 +9443,7 @@
 				6FE8626F2657C5F30061D3F0 /* MoreCell.swift in Sources */,
 				0827DA211F0D36E400A31A42 /* NSBundle+PlaySRG.m in Sources */,
 				6F54D35C26050FE6008B46FF /* MediaVisualView.swift in Sources */,
+				040A3B932DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F80E9C521A682E70027CA2F /* TableRequestViewController.m in Sources */,
 				048FD2122A124CB300929AE5 /* ProfileAccountHeaderViewModel.swift in Sources */,
 				6F33E6222860BED900724E76 /* SearchSettingsNavigationView.swift in Sources */,
@@ -9704,6 +9720,7 @@
 				6FE1B91D1FAC34D600A58F3B /* ContentInsets.m in Sources */,
 				9984F77E2C075A94009F6CC8 /* TabContainerViewController.swift in Sources */,
 				6F742941265BE52E0000538D /* Signals.swift in Sources */,
+				040A3B8E2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F566E8424EE95CB0024B4CA /* PlayFirebaseConfiguration.m in Sources */,
 				0451D7F22B1CEDAD005A2150 /* Banner.swift in Sources */,
 				6F676855281C0F7F00D61211 /* SupportInformation.swift in Sources */,
@@ -10082,6 +10099,7 @@
 				084EF77D26035BB10058A567 /* PageViewModel.swift in Sources */,
 				6F9FFB4E261662D900CDDC26 /* CollectionRow.swift in Sources */,
 				6FAE562126C19D6F00EBFCD6 /* UICollectionView+Index.swift in Sources */,
+				040A3B8B2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F978B562849C3CA003061E8 /* ScrollableContent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10242,6 +10260,7 @@
 				084EF77E26035BB10058A567 /* PageViewModel.swift in Sources */,
 				6F9FFB4F261662D900CDDC26 /* CollectionRow.swift in Sources */,
 				6FAE562226C19D6F00EBFCD6 /* UICollectionView+Index.swift in Sources */,
+				040A3B912DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F978B572849C3CA003061E8 /* ScrollableContent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10402,6 +10421,7 @@
 				084EF77F26035BB30058A567 /* PageViewModel.swift in Sources */,
 				6F9FFB50261662D900CDDC26 /* CollectionRow.swift in Sources */,
 				6FAE562326C19D6F00EBFCD6 /* UICollectionView+Index.swift in Sources */,
+				040A3B902DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F978B582849C3CA003061E8 /* ScrollableContent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10562,6 +10582,7 @@
 				084EF78026035BB40058A567 /* PageViewModel.swift in Sources */,
 				6F9FFB51261662D900CDDC26 /* CollectionRow.swift in Sources */,
 				6FAE562426C19D6F00EBFCD6 /* UICollectionView+Index.swift in Sources */,
+				040A3B8C2DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				6F978B592849C3CA003061E8 /* ScrollableContent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -10665,6 +10686,7 @@
 				080981392622195900AA586B /* LiveMediaCell.swift in Sources */,
 				044E392929B10C9200C1768A /* SRGShow+PlaySRG.swift in Sources */,
 				6F0B16332837C72E0074845E /* SettingsViewModel.swift in Sources */,
+				040A3B922DC40ED70011C4C6 /* ProxyDetection.swift in Sources */,
 				0858CA64271084A000EE36EA /* ProgramGuideGridViewController.swift in Sources */,
 				6FFF1636250A20EF0053CDA6 /* FocusTracker.swift in Sources */,
 				6F5A7914256ED7E000E884F2 /* History.m in Sources */,

--- a/TV Application/Sources/AppDelegate.swift
+++ b/TV Application/Sources/AppDelegate.swift
@@ -96,9 +96,10 @@ extension AppDelegate: UIApplicationDelegate {
         SRGAnalyticsTracker.shared.start(with: analyticsConfiguration, dataSource: self, identityService: SRGIdentityService.current)
 
         #if DEBUG || NIGHTLY || BETA
-            Publishers.Merge(
+            Publishers.Merge3(
                 ApplicationSignal.settingUpdates(at: \.PlaySRGSettingServiceEnvironment),
-                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingUserLocation)
+                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingUserLocation),
+                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingProxyDetection)
             )
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/TV Application/Sources/SceneDelegate.swift
+++ b/TV Application/Sources/SceneDelegate.swift
@@ -188,7 +188,8 @@ extension SceneDelegate: UIWindowSceneDelegate {
                 ApplicationSignal.settingUpdates(at: \.PlaySRGSettingPodcastImages),
                 ApplicationSignal.settingUpdates(at: \.PlaySRGSettingAudioHomepageOption),
                 ApplicationSignal.settingUpdates(at: \.PlaySRGSettingServiceEnvironment),
-                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingUserLocation)
+                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingUserLocation),
+                ApplicationSignal.settingUpdates(at: \.PlaySRGSettingProxyDetection)
             )
             .debounce(for: 0.7, scheduler: DispatchQueue.main)
             .sink {

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Default (current configuration)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Default (IP-based location)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Developer";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Disable";
@@ -843,6 +849,9 @@
 /* Version label in settings */
 "Version" = "Version";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Video playback continues even when you leave the application.";
 
@@ -854,6 +863,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Videos and audios";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Watch";


### PR DESCRIPTION
## Description

SRG Legal department asked to implement on the server side, a VPN or Proxy detection, for some protected content.
To test, a debug setting can be added to add a query parameter `forceProxyDetection`. 
[SRGDataProvider 19.0.10](https://github.com/SRGSSR/srgdataprovider-apple/releases/tag/19.0.10) has a new block reason, already updated with #557 .

## Changes Made

- Add "VPN or Proxy detection" option in advanced settings section, iOS and tvOS, with the new hidden query parameters `forceProxyDetection` ([VPNORPROXY](https://il-stage.srgssr.ch/integrationlayer/2.0/mediaComposition/byUrn/urn:rts:video:3608517?forceProxyDetection=VPNORPROXY) or [DIRECT](https://il-stage.srgssr.ch/integrationlayer/2.0/mediaComposition/byUrn/urn:rts:video:3608517?forceProxyDetection=DIRECT)).
- Save in User Defaults.
- Reload the application if setting change.

## How to test

Currently, on Stage environment only:
- With SAM endpoints (RSI and RTS -> Stage, RTR and SRF -> SAM Stage).
- With DRM protected content (TV livestreams and some VoDs).

![Simulator Screenshot - Apple TV - 2025-05-01 at 23 58 33](https://github.com/user-attachments/assets/e42d2b2d-3b03-493c-95fb-74f7ff70470d)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-01 at 23 59 36](https://github.com/user-attachments/assets/1b665220-cb3e-45ed-8a49-e036045b1cc7)


## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.