### PR TITLE
[PLAYNEXT-3121] Fix Shows section title on Videos tab homepage

### DIFF
--- a/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RSI/it.lproj/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Default (configurazione attuale)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Impostazione predefinita (posizione basata su IP)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Sviluppatore";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Disattivare";
@@ -330,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -351,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Ascolta dopo";
 
 /* Suggested invocation phrase to listen to a show
@@ -533,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Descrivete il problema qui di seguito:";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcast";
 
 /* Title of the section when we show podcasts by date */
@@ -651,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Programmi";
 
 /* Label to present shows A to Z (radio or TV) */
@@ -843,6 +851,9 @@
 /* Version label in settings */
 "Version" = "Versione";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Il play dei video continua in secondo piano anche quando si esce dall'applicazione.";
 
@@ -854,6 +865,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Video e audio";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Guarda";

--- a/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTR/rm.lproj/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Standard (configuraziun actuala)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Standard (lieu sin basa da la IP)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Svilupader";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Inabel";
@@ -330,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -351,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Tadlar pli tard";
 
 /* Suggested invocation phrase to listen to a show
@@ -533,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Descrivai per plaschair il sbagl sutvart:";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcast";
 
 /* Title of the section when we show podcasts by date */
@@ -651,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Emissiuns";
 
 /* Label to present shows A to Z (radio or TV) */
@@ -843,6 +851,9 @@
 /* Version label in settings */
 "Version" = "Versiun";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Il video marscha vinavant, era sche Vus bandunais l'applicaziun.";
 
@@ -854,6 +865,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Videos ed audios";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Guardar";

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -868,7 +868,7 @@
 
 /* Label of the button for VPN or Proxy detection selection
    VPN or Proxy detection selection view title */
-"VPN or Proxy detection" = "VPN or Proxy detection";
+"VPN or Proxy detection" = "Détection VPN ou Proxy";
 
 /* Play button label for video in media detail view */
 "Watch" = "Regarder";

--- a/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play RTS/fr.lproj/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Défaut (configuration actuelle)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Défaut (géolocalisation de l'IP)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Développeur";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Désactiver";
@@ -330,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -351,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Écouter plus tard";
 
 /* Suggested invocation phrase to listen to a show
@@ -533,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Merci de décrire ci-dessous le problème rencontré :";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcasts";
 
 /* Title of the section when we show podcasts by date */
@@ -651,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Émissions";
 
 /* Label to present shows A to Z (radio or TV) */
@@ -843,6 +851,9 @@
 /* Version label in settings */
 "Version" = "Version";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Autorise la lecture vidéo à se poursuivre même quand vous sortez de l'application.";
 
@@ -854,6 +865,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Vidéos et audios";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Regarder";

--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Standard (aktuelle Konfiguration)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Standard (IP-basierter Standort)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Entwickler";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Deaktivieren";
@@ -330,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -351,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Später hören";
 
 /* Suggested invocation phrase to listen to a show
@@ -533,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Bitte beschreiben Sie das Problem unten:";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcasts";
 
 /* Title of the section when we show podcasts by date */
@@ -651,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Sendungen";
 
 /* Label to present shows A to Z (radio or TV) */
@@ -843,6 +851,9 @@
 /* Version label in settings */
 "Version" = "Version";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Die Videos werden ohne Unterbrechung im Hintergrund abgespielt.";
 
@@ -854,6 +865,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Video und Audio";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Abspielen";

--- a/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SWI/en.lproj/Localizable.strings
@@ -162,6 +162,9 @@
    Square images setting state */
 "Default (current configuration)" = "Default (current configuration)";
 
+/* VPN or Proxy detection setting state */
+"Default (IP-based detection)" = "Default (IP-based detection)";
+
 /* User location setting state */
 "Default (IP-based location)" = "Default (IP-based location)";
 
@@ -200,6 +203,9 @@
 
 /* Developer section header */
 "Developer" = "Developer";
+
+/* VPN or Proxy detection setting state */
+"Direct connection" = "Direct connection";
 
 /* Label for the button disabling autoplay */
 "Disable" = "Disable";
@@ -330,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -351,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Listen later";
 
 /* Suggested invocation phrase to listen to a show
@@ -533,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Please describe the issue below:";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcasts";
 
 /* Title of the section when we show podcasts by date */
@@ -651,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Topics";
 
 /* Label to present shows A to Z (radio or TV) */
@@ -843,6 +851,9 @@
 /* Version label in settings */
 "Version" = "Version";
 
+/* VPN or Proxy detection setting state */
+"Via a VPN or Proxy" = "Via a VPN or Proxy";
+
 /* Background video playback setting section footer */
 "Video playback continues even when you leave the application." = "Video playback continues even when you leave the application.";
 
@@ -854,6 +865,10 @@
 
 /* Header for video and audio search results */
 "Videos and audios" = "Videos and audios";
+
+/* Label of the button for VPN or Proxy detection selection
+   VPN or Proxy detection selection view title */
+"VPN or Proxy detection" = "VPN or Proxy detection";
 
 /* Play button label for video in media detail view */
 "Watch" = "Watch";

--- a/Application/Sources/Content/Content.swift
+++ b/Application/Sources/Content/Content.swift
@@ -223,8 +223,10 @@ private extension Content {
                     NSLocalizedString("Listen later", comment: "Title Label used to present the audio later list")
                 case (.watchLater, _), (.streamLater, _):
                     NSLocalizedString("Later", comment: "Title Label used to present the video later list")
-                case (.showAccess, _):
-                    NSLocalizedString("Podcasts", comment: "Title label used to present the TV shows AZ and TV shows by date access buttons")
+                case (.showAccess, .audio):
+                    NSLocalizedString("Podcasts", comment: "Title label used to present the Audio shows AZ and Audio shows by date access buttons")
+                case (.showAccess, .video):
+                    NSLocalizedString("Shows", comment: "Title label used to present the TV shows AZ and TV programme access buttons")
                 case (.topicSelector, _):
                     NSLocalizedString("Topics", comment: "Title label used to present the topic list")
                 default:

--- a/Application/Sources/Settings/ProxyDetection.swift
+++ b/Application/Sources/Settings/ProxyDetection.swift
@@ -18,9 +18,9 @@ enum ProxyDetection: String, CaseIterable, Identifiable {
     var description: String {
         switch self {
         case .VPNORPROXY:
-            NSLocalizedString("Via a VPN or Proxy", comment: "VPN or Proxy detection setting state")
+            NSLocalizedString("Force detection", comment: "VPN or Proxy detection setting state")
         case .DIRECT:
-            NSLocalizedString("Direct connection", comment: "VPN or Proxy detection setting state")
+            NSLocalizedString("Bypass detection", comment: "VPN or Proxy detection setting state")
         case .default:
             NSLocalizedString("Default (IP-based detection)", comment: "VPN or Proxy detection setting state")
         }

--- a/Translations/Localizable.strings
+++ b/Translations/Localizable.strings
@@ -336,7 +336,6 @@
 
 /* Label for the button for deciding to opt-in for background video playback at a later time
    Label to present the later list
-   Title Label used to present the audio later list
    Title Label used to present the video later list
    Watch later or listen later button label in media detail view when a media is in the later list
    Watch later or listen later button label in program detail view when a media is in the later list */
@@ -357,7 +356,8 @@
 
 /* Button label in media detail view to add an audio to the later list
    Button label in program detail view to add an audio to the later list
-   Context menu action to add an audio to the later list */
+   Context menu action to add an audio to the later list
+   Title Label used to present the audio later list */
 "Listen later" = "Listen later";
 
 /* Suggested invocation phrase to listen to a show
@@ -539,7 +539,8 @@
 /* Mail body header to declare a technical issue */
 "Please describe the issue below:" = "Please describe the issue below:";
 
-/* Title label used to present radio associated podcasts */
+/* Title label used to present radio associated podcasts
+   Title label used to present the Audio shows AZ and Audio shows by date access buttons */
 "Podcasts" = "Podcasts";
 
 /* Title of the section when we show podcasts by date */
@@ -657,7 +658,8 @@
    Shows tab title
    Title label used to present radio associated shows
    Title label used to present the radio shows AZ and radio shows by date access buttons
-   Title label used to present the TV shows AZ and TV shows by date access buttons */
+   Title label used to present the TV shows AZ and TV programme access buttons
+   Title label used to present TV associated shows */
 "Shows" = "Shows";
 
 /* Label to present shows A to Z (radio or TV) */


### PR DESCRIPTION
## Description

When changing the Emissions section title on the Audio tab homepage, it changed on Videos tab as well because the same wording key was used.

## Changes Made

Split the section title getter to handle the Videos and Audio differently.

<div>
<img src="https://github.com/user-attachments/assets/aa4e705c-f462-4044-af33-35126ed66ec2" width=300 />
<img src="https://github.com/user-attachments/assets/40b2b3e3-058d-4197-a050-5dd09bc4248e" width=300 />
</div>

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.