### PR TITLE
PLAYNEXT-2925 Support form fix

### DIFF
--- a/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
+++ b/Application/Resources/Apps/Play SRF/de.lproj/Localizable.strings
@@ -700,7 +700,7 @@
 
 /* Label of the button to present feedback/support form
    Title of the screen showing the QR code to send a feedback or contact support */
-"Support and Feedback" = "Kontakt und Vorschlag";
+"Support and Feedback" = "Kontakt und Feedback";
 
 /* Label of the button to open Apple TestFlight application and see other testable builds */
 "Switch version" = "Version ändern";

--- a/Application/Sources/Configuration/ApplicationConfiguration.swift
+++ b/Application/Sources/Configuration/ApplicationConfiguration.swift
@@ -88,7 +88,7 @@ extension ApplicationConfiguration {
             urlComponents.queryItems = typeformQueryItems
         }
 
-        let query = urlComponents.percentEncodedQuery
+        let query = urlComponents.query
         urlComponents.fragment = query
         urlComponents.queryItems = nil
 


### PR DESCRIPTION
## Description

When scanning the QR code, the URL was encoded so it was double-encoded by the QR code

## Changes Made

Use the un-encoded query to construct the fragment.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.