### PR TITLE
CI: update Jira url in slack message

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2687,7 +2687,7 @@ end
 def jira_issues_url(jira_issues)
   return 'NaN' unless ENV['JIRA_URL']
 
-  jira_issues_query = "key%20in%20(#{jira_issues.join(',')})"
+  jira_issues_query = "key%20in%20%28#{jira_issues.join('%2C%20')}%29"
   "#{ENV.fetch('JIRA_URL', nil)}/issues/?jql=#{jira_issues_query}"
 end
 


### PR DESCRIPTION
## Description

In the private beta build workflow, a slack message can be post.
A Jira issues url is shared in this message.

Previously, the Jira jql query used the Jira "Version" object. The project does not use it anymore.
The proposition is to update the Jira jql query with the list of Jira ticket keys from the commit messages.

## Changes Made

The fastlane script is updated:

- New Jira issue url logic: 
  - Get new tag commit.
  - Get previous tag commit, from the platform and marketing version.
  - Get Jira ticket keys from the git change logs.
  - Build the new Jira jql query.
- The slack message is posted after the beta workflow, so that the new git tag is committed.

## Tested locally

- Current commit on `main` is tagged with `ios/3.9.4-474`, like the CI workflow could do.
- The script get the previous tag: `ios/3.9.3-473`.
- The output private SRGSSR Jira url is: https://srgssr-ch.atlassian.net/issues/?jql=key%20in%20%28PLAYNEXT-2925%2C%20PLAYNEXT-3340%2C%20PLAYNEXT-2927%2C%20PLAYNEXT-3425%29
  - jql value is `key in (PLAYNEXT-2925, PLAYNEXT-3340, PLAYNEXT-2927, PLAYNEXT-3425)`.
- The slack message will be posted in a private SRGSSR slack: https://srgssr-ch.slack.com/archives/C04DX1DARLL 

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.