### PR TITLE
PLAYNEXT-3294 Fix hero image

### DIFF
--- a/Application/Sources/UI/Views/HeroMediaCell.swift
+++ b/Application/Sources/UI/Views/HeroMediaCell.swift
@@ -64,7 +64,7 @@ struct HeroMediaCell: View {
 
         var body: some View {
             ZStack {
-                MediaVisualView(media: media, size: .large, contentMode: contentMode) { media in
+                MediaVisualView(media: media, size: .large, contentMode: contentMode, forceDefaultAspectRatio: true) { media in
                     if media != nil {
                         LinearGradient(colors: [.clear, .init(white: 0, opacity: 0.7)], startPoint: .center, endPoint: .bottom)
                     }


### PR DESCRIPTION
## Description

When enabling Audio Curation for RTR and SRF, the Hero Stage uses 16:9 image instead of the 1:1 one.

## Changes Made

Force usage of media image for Hero Stage instead of the podcast show image

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.