### PR TITLE
PLAYNEXT-5727: Do not ask livestreams and programs for SSatR channels

### DIFF
--- a/Application/Sources/CarPlay/CarPlayList.swift
+++ b/Application/Sources/CarPlay/CarPlayList.swift
@@ -218,9 +218,14 @@ private extension CarPlayList {
     }
 
     private static func liveProgramsPublisher(for channel: SRGChannel, media: SRGMedia) -> AnyPublisher<[SRGProgram], Error> {
-        if let controller = SRGLetterboxService.shared.controller,
-           let dateInterval = controller.play_dateInterval,
-           let segments = controller.mediaComposition?.mainChapter.segments, !segments.isEmpty {
+        // Do not create a live programs publisher for SSATR vendor channels.
+        if channel.vendor == .SSATR {
+            Just([])
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        } else if let controller = SRGLetterboxService.shared.controller,
+                  let dateInterval = controller.play_dateInterval,
+                  let segments = controller.mediaComposition?.mainChapter.segments, !segments.isEmpty {
             SRGDataProvider.current!.radioLatestPrograms(for: ApplicationConfiguration.shared.vendor,
                                                          channelUid: channel.uid,
                                                          livestreamUid: media.uid,

--- a/Application/Sources/Content/Publishers.swift
+++ b/Application/Sources/Content/Publishers.swift
@@ -41,9 +41,13 @@ extension SRGDataProvider {
     #if os(iOS)
         /// Publishes the regional media which corresponds to the specified media, if any.
         private func regionalizedRadioLivestreamMedia(for media: SRGMedia) -> AnyPublisher<SRGMedia, Never> {
-            if let channelUid = media.channel?.uid,
-               let selectedLivestreamUrn = ApplicationSettingSelectedLivestreamURNForChannelUid(channelUid),
-               media.urn != selectedLivestreamUrn {
+            // Do not request livestreams by channel for SSATR vendor channels.
+            if media.channel?.vendor == .SSATR {
+                Just(media)
+                    .eraseToAnyPublisher()
+            } else if let channelUid = media.channel?.uid,
+                      let selectedLivestreamUrn = ApplicationSettingSelectedLivestreamURNForChannelUid(channelUid),
+                      media.urn != selectedLivestreamUrn {
                 radioLivestreams(for: media.vendor, channelUid: channelUid)
                     .map { medias in
                         if let selectedMedia = ApplicationSettingSelectedLivestreamMediaForChannelUid(channelUid, medias) {

--- a/Application/Sources/Helpers/ChannelService.h
+++ b/Application/Sources/Helpers/ChannelService.h
@@ -25,9 +25,10 @@ typedef void (^ChannelServiceUpdateBlock)(SRGProgramComposition * _Nullable prog
 
 /**
  *  Register an observer to be notified of updates for a given channel. The provided block is called when channel information
- *  is available. An opaque handle to the observer is returned for unregistration purposes.
+ *  is available. Returns an opaque handle to the observer for unregistration purposes, or nil if no registration occurs
+ *  (e.g., for unsupported vendors).
  */
-- (id)addObserverForUpdatesWithChannel:(SRGChannel *)channel livestreamUid:(NSString *)livestreamUid block:(ChannelServiceUpdateBlock)block;
+- (nullable id)addObserverForUpdatesWithChannel:(SRGChannel *)channel livestreamUid:(NSString *)livestreamUid block:(ChannelServiceUpdateBlock)block;
 
 /**
  *  Remove the specified observer.

--- a/Application/Sources/Helpers/ChannelService.m
+++ b/Application/Sources/Helpers/ChannelService.m
@@ -81,6 +81,11 @@
 
 - (id)addObserverForUpdatesWithChannel:(SRGChannel *)channel livestreamUid:(NSString *)livestreamUid block:(ChannelServiceUpdateBlock)block
 {
+    // Do not register programs updates for channels belonging to the SSATR vendor
+    if (channel.vendor == SRGVendorSSATR) {
+        return nil;
+    }
+
     BOOL channelAdded = NO;
     
     ChannelServiceSetup *setup = [[ChannelServiceSetup alloc] initWithChannel:channel livestreamUid:livestreamUid];

--- a/Application/Sources/Player/MediaPlayerViewController.m
+++ b/Application/Sources/Player/MediaPlayerViewController.m
@@ -1323,8 +1323,9 @@ static NSDateComponentsFormatter *MediaPlayerViewControllerSkipIntervalAccessibi
     }
     
     self.livestreamView.hidden = [self isLivestreamButtonHidden];
-    
-    if (! self.livestreamMediasRequest) {
+
+    // Do not request livestreams by channel for SSATR vendor channels.
+    if (! self.livestreamMediasRequest && media.channel.vendor != SRGVendorSSATR) {
         SRGRequest *request = [SRGDataProvider.currentDataProvider radioLivestreamsForVendor:media.channel.vendor channelUid:media.channel.uid withCompletionBlock:^(NSArray<SRGMedia *> * _Nullable medias, NSHTTPURLResponse * _Nullable HTTPResponse, NSError * _Nullable error) {
             self.livestreamMedias = medias;
             self.livestreamView.hidden = [self isLivestreamButtonHidden];


### PR DESCRIPTION
## Description

The IL to SAM migration improve the path check. And use BusinessUnit enum, not Vendor enum for:
- ❌ https://il.srgssr.ch/integrationlayer/2.0/ssatr/programListComposition/radio/byChannel/rsj?livestreamId=rsj&vector=appplay&pageSize=50
- ❌ https://il.srgssr.ch/integrationlayer/2.0/ssatr/mediaList/audio/livestreamsByChannel/rsp?vector=appplay

Only the song list accepts Swiss Satellite Radio channels:
- ✅ https://il.srgssr.ch/integrationlayer/2.0/ssatr/songList/radio/byChannel/rsp?vector=appplay&pageSize=20

## Changes Made

For iOS, tvOS and CarPlay, don't call it anymore.
SRGDataProvider not updated, only PlaySRG apps verify it's not a Swiss Satellite Radio channel.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.