### PR TITLE
Fix push subscription tags sent to the PushSDK backend

### DIFF
--- a/Application/Sources/Helpers/PushService.m
+++ b/Application/Sources/Helpers/PushService.m
@@ -142,14 +142,11 @@ NSString * const PushServiceEnabledKey = @"PushServiceEnabled";
 
 - (NSSet<NSString *> *)subscribedShowURNs
 {
-    NSArray<NSString *> *tags;
-
-    if ([UAirship isFlying]) {
-        tags = UAirship.channel.tags;
-    } else {
-        tags = [PushSubscriptionBridge getTagsForChannel:self.pushSDKChannel];
+    if (! [UAirship isFlying]) {
+        return [NSSet setWithArray:[PushSubscriptionBridge getTagsForChannel:self.pushSDKChannel]];
     }
 
+    NSArray<NSString *> *tags = UAirship.channel.tags;
     if (tags.count == 0) {
         return [NSSet set];
     }
@@ -344,7 +341,7 @@ NSString * const PushServiceEnabledKey = @"PushServiceEnabled";
     NSMutableArray<NSString *> *tags = [NSMutableArray array];
     for (NSString *URN in FavoritesShowURNs()) {
         if (FavoritesIsSubscribedToShowURN(URN)) {
-            [tags addObject:[self tagForShowURN:URN]];
+            [tags addObject:URN];
         }
     }
     [PushSubscriptionBridge setTags:tags forChannel:self.pushSDKChannel];
@@ -360,7 +357,7 @@ NSString * const PushServiceEnabledKey = @"PushServiceEnabled";
     NSMutableArray<NSString *> *tags = [NSMutableArray array];
     for (NSString *URN in FavoritesShowURNs()) {
         if (FavoritesIsSubscribedToShowURN(URN)) {
-            [tags addObject:[self tagForShowURN:URN]];
+            [tags addObject:URN];
         }
     }
     [PushSubscriptionBridge setTags:tags forChannel:self.pushSDKChannel];
@@ -371,7 +368,7 @@ NSString * const PushServiceEnabledKey = @"PushServiceEnabled";
     if ([UAirship isFlying]) {
         return [UAirship.channel.tags containsObject:[self tagForShowURN:URN]];
     } else {
-        return [[PushSubscriptionBridge getTagsForChannel:self.pushSDKChannel] containsObject:[self tagForShowURN:URN]];
+        return [[PushSubscriptionBridge getTagsForChannel:self.pushSDKChannel] containsObject:URN];
     }
 }
 


### PR DESCRIPTION
## Problem

After PR #574 introduced push notifications via our own AWS push service, show subscriptions reported success in the logs but never landed in the backend DB:

```
Creating subscription for channel 'play-srf-show-updates' with tags ["playsrf|newod|prod|urn:srf:show:tv:..."].
Subscription succeeded for channel 'play-srf-show-updates'.
```

The SDK builds a valid `PUT` and the backend returns 2xx (so "succeeded" is logged), but the record was never persisted as a usable subscription.

## Root cause

The **legacy Airship composite tag** format (`appIdentifier|type|environment|URN`, e.g. `playsrf|newod|prod|urn:...`) was leaking into the PushSDK path. The new backend keys on the tag and expects the **bare show URN**. The other context the composite tag carried is already encoded elsewhere in the new system:

- BU (`playsrf`) + notification type (`newod` / show-updates) → the **channel** `play-srf-show-updates`
- environment (`prod`) → the **backend host** (`api.dev` / `api.int` / `api.srf`)

So the tag must be just the URN.

## Fix

Split the two tag representations: the Airship paths keep the composite format (`tagForShowURN:` / `showURNFromTag:`), while the PushSDK paths use the bare show URN. Four call sites in `PushService.m`:

- `subscribedShowURNs` — PushSDK branch returns the stored tags as URNs directly
- `migrateTagsToPushSDKIfNeeded` — sends the bare URN
- `syncTagsToPushSDK` — sends the bare URN
- `isSubscribedToShowURN:` — PushSDK branch checks `containsObject:URN`
