### PR TITLE
Fix Cast button visibility

### DIFF
--- a/Application/Sources/Content/PageViewController.swift
+++ b/Application/Sources/Content/PageViewController.swift
@@ -357,14 +357,8 @@ final class PageViewController: UIViewController {
                         ])
                     }
                 }
-            } else {
+            } else if model.id.sharingItem != nil {
                 googleCastButton?.removeFromSuperview()
-            }
-
-            navigationItem.title = !headerWithTitleVisible ? title : nil
-            navigationController?.setNavigationBarHidden(isNavigationBarHidden, animated: animated)
-
-            if model.id.sharingItem != nil {
                 let shareButtonItem = UIBarButtonItem(image: UIImage(named: "share"),
                                                       style: .plain,
                                                       target: self,
@@ -372,8 +366,12 @@ final class PageViewController: UIViewController {
                 shareButtonItem.accessibilityLabel = PlaySRGAccessibilityLocalizedString("Share", comment: "Share button label on content page view")
                 navigationItem.rightBarButtonItem = shareButtonItem
             } else {
+                googleCastButton?.removeFromSuperview()
                 navigationItem.rightBarButtonItem = nil
             }
+
+            navigationItem.title = !headerWithTitleVisible ? title : nil
+            navigationController?.setNavigationBarHidden(isNavigationBarHidden, animated: animated)
         }
 
         @objc private func pullToRefresh(_ refreshControl: RefreshControl) {


### PR DESCRIPTION
## Description

This PR fixes a regression introduced when sharing support was added in pages. This regression prevents the Google Cast button from being correctly displayed on the live homepage, which is [not intended](https://github.com/SRGSSR/playsrg-apple/blob/main/Application/Sources/Content/PageViewModel.swift#L177-L184).

This behavior confused one of our users who thought Google Cast was not supported for livestreams, as it was not visible on the corresponding live homepage.

## Changes Made

For simplicity (and since the implementation is a bit tricky) I took the liberty to prioritize the Cast button, then the share button.  Since the share button is never useful on top-level homepages anyway, this ensure all code paths are correctly mutually exclusive.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.