### PR TITLE
PLAYNEXT-8904 / PLAYNEXT-8904: Improve banner layout

### DIFF
--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -90,6 +90,10 @@ struct MigrationBanner: View {
         .responderChain(from: firstResponder)
     }
 
+    private var isCompact: Bool {
+        horizontalSizeClass == .compact
+    }
+
     static func size() -> NSCollectionLayoutSize {
         let fontMetrics = SRGFont.metricsForFont(with: .body)
         let height = fontMetrics.scaledValue(for: constant(iOS: 120, tvOS: 220)) + 60
@@ -109,7 +113,7 @@ struct MigrationBanner: View {
     private func mainView() -> some View {
         ZStack {
             #if os(iOS)
-                if horizontalSizeClass == .compact {
+                if isCompact {
                     HStack(spacing: 16) {
                         icon()
                         message()
@@ -169,7 +173,7 @@ struct MigrationBanner: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.srgRed)
-            .frame(maxWidth: .infinity, alignment: horizontalSizeClass == .compact ? .trailing : .leading)
+            .frame(maxWidth: .infinity, alignment: isCompact ? .trailing : .leading)
         }
     #endif
 

--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -90,10 +90,6 @@ struct MigrationBanner: View {
         .responderChain(from: firstResponder)
     }
 
-    private var isCompact: Bool {
-        horizontalSizeClass == .compact
-    }
-
     static func size() -> NSCollectionLayoutSize {
         let fontMetrics = SRGFont.metricsForFont(with: .body)
         let height = fontMetrics.scaledValue(for: constant(iOS: 120, tvOS: 220)) + 60
@@ -113,7 +109,7 @@ struct MigrationBanner: View {
     private func mainView() -> some View {
         ZStack {
             #if os(iOS)
-                if isCompact {
+                if horizontalSizeClass == .compact {
                     compactMainView()
                         .onTapGesture(perform: action)
                 } else {

--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -114,7 +114,7 @@ struct MigrationBanner: View {
         ZStack {
             #if os(iOS)
                 if isCompact {
-                    HStack(spacing: 16) {
+                    HStack(alignment: .top, spacing: 16) {
                         icon()
                         message()
                     }

--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -146,7 +146,7 @@ struct MigrationBanner: View {
     private func message() -> some View {
         VStack(alignment: constant(iOS: .leading, tvOS: .center)) {
             Text(configuration.title)
-                .srgFont(.H2)
+                .srgFont(.H3)
                 .lineLimit(2)
                 .layoutPriority(1)
             Text(configuration.subtitle)

--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -114,29 +114,60 @@ struct MigrationBanner: View {
         ZStack {
             #if os(iOS)
                 if isCompact {
-                    HStack(alignment: .top, spacing: 16) {
-                        icon()
-                        message()
-                    }
+                    compactMainView()
+                        .onTapGesture(perform: action)
                 } else {
-                    ZStack(alignment: .leading) {
-                        message()
-                        icon()
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
+                    regularMainView()
                 }
             #else
-                ZStack {
-                    message()
-                        .frame(width: 1000)
-                    icon()
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                }
+                tvMainView()
             #endif
         }
         .padding(.horizontal, constant(iOS: 20, tvOS: 50))
         .padding(.vertical, constant(iOS: 20, tvOS: 30))
         .background(background())
+    }
+
+    #if os(iOS)
+        private func compactMainView() -> some View {
+            HStack(alignment: .top, spacing: 16) {
+                icon()
+
+                VStack(alignment: .leading) {
+                    title()
+                    subtitle()
+                    link()
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+
+        private func regularMainView() -> some View {
+            HStack(spacing: 16) {
+                VStack(alignment: .leading) {
+                    title()
+                    subtitle()
+                    button()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                icon()
+            }
+        }
+    #endif
+
+    private func tvMainView() -> some View {
+        ZStack {
+            VStack {
+                title()
+                subtitle()
+            }
+            .frame(width: 1000)
+
+            icon()
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
     }
 
     private func icon() -> some View {
@@ -147,33 +178,35 @@ struct MigrationBanner: View {
             .accessibilityHidden(true)
     }
 
-    private func message() -> some View {
-        VStack(alignment: constant(iOS: .leading, tvOS: .center)) {
-            Text(configuration.title)
-                .srgFont(.H3)
-                .lineLimit(2)
-                .layoutPriority(1)
-            Text(configuration.subtitle)
-                .srgFont(.body)
-                .lineLimit(2)
-            #if os(iOS)
-                button()
-            #endif
-        }
-        .frame(maxWidth: .infinity)
+    private func title() -> some View {
+        Text(configuration.title)
+            .srgFont(.H3)
+            .lineLimit(2)
+    }
+
+    private func subtitle() -> some View {
+        Text(configuration.subtitle)
+            .srgFont(.body)
+            .lineLimit(2)
     }
 
     #if os(iOS)
+        private func link() -> some View {
+            Text(configuration.action.name)
+                .padding(2)
+                .foregroundColor(.white)
+                .srgFont(.H3)
+        }
+
         private func button() -> some View {
             Button(action: action) {
                 Text(configuration.action.name)
-                    .foregroundColor(.white)
-                    .srgFont(.H3)
                     .padding(2)
             }
             .buttonStyle(.borderedProminent)
             .tint(.srgRed)
-            .frame(maxWidth: .infinity, alignment: isCompact ? .trailing : .leading)
+            .foregroundColor(.white)
+            .srgFont(.H3)
         }
     #endif
 


### PR DESCRIPTION
## Description

This PR adjusts the banner layout to more closely match the intended result (see Figma linked in associated stories).

## Changes Made

- Untangle compact, regular and TV layouts for better readability.
- Tweak button appearance on compact layouts.
- Tweak font sizes for better result on narrow devices.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.