### PR TITLE
Use shared instance of application configuration to avoid potential crashes

### DIFF
--- a/Application/Sources/Settings/Service.swift
+++ b/Application/Sources/Settings/Service.swift
@@ -54,19 +54,19 @@ enum Service: String, Identifiable, CaseIterable {
     var url: URL {
         switch self {
         case .production:
-            ApplicationConfiguration().dataProviderProductionServiceURL
+            ApplicationConfiguration.shared.dataProviderProductionServiceURL
         case .stage:
-            ApplicationConfiguration().dataProviderStageServiceURL
+            ApplicationConfiguration.shared.dataProviderStageServiceURL
         case .test:
-            ApplicationConfiguration().dataProviderTestServiceURL
+            ApplicationConfiguration.shared.dataProviderTestServiceURL
         case .mmf:
             Self.mmfUrl
         case .samProduction:
-            ApplicationConfiguration().dataProviderProductionServiceURL.appendingPathComponent("sam")
+            ApplicationConfiguration.shared.dataProviderProductionServiceURL.appendingPathComponent("sam")
         case .samStage:
-            ApplicationConfiguration().dataProviderStageServiceURL.appendingPathComponent("sam")
+            ApplicationConfiguration.shared.dataProviderStageServiceURL.appendingPathComponent("sam")
         case .samTest:
-            ApplicationConfiguration().dataProviderTestServiceURL.appendingPathComponent("sam")
+            ApplicationConfiguration.shared.dataProviderTestServiceURL.appendingPathComponent("sam")
         }
     }
 

--- a/Application/Sources/UI/Views/MigrationBanner.swift
+++ b/Application/Sources/UI/Views/MigrationBanner.swift
@@ -192,6 +192,7 @@ struct MigrationBanner: View {
                 .padding(2)
                 .foregroundColor(.white)
                 .srgFont(.H3)
+                .accessibilityAddTraits(.isButton)
         }
 
         private func button() -> some View {


### PR DESCRIPTION
## Description

This PR fixes potential crashes due to multiple `ApplicationConfiguration` instantiation.

## Changes Made

- Used `ApplicationConfiguration` shared instance.
- Added `isButton` trait on the migration banner link.

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.