### PR TITLE
Avoid potential crashes if the remote configuration is invalid

### DIFF
--- a/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RSI/ApplicationConfiguration.json
@@ -33,5 +33,6 @@
   "tvGuideOtherBouquets": "srf,rts",
   "userConsentDefaultLanguage": "it",
   "migrationHelpURL": "https://support.playplus.ch/it",
-  "playPlusAppStoreProductIdentifier": 1532890312
+  "playPlusAppStoreProductIdentifier": 1532890312,
+  "audioContentHomepagePreferred": true
 }

--- a/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTR/ApplicationConfiguration.json
@@ -30,5 +30,6 @@
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
   "userConsentDefaultLanguage": "de",
   "migrationHelpURL": "https://support.playplus.ch/rm",
-  "playPlusAppStoreProductIdentifier": 1532890312
+  "playPlusAppStoreProductIdentifier": 1532890312,
+  "audioContentHomepagePreferred": true
 }

--- a/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play RTS/ApplicationConfiguration.json
@@ -34,5 +34,6 @@
   "tvGuideOtherBouquets": "srf,rsi",
   "userConsentDefaultLanguage": "fr",
   "migrationHelpURL": "https://support.playplus.ch/fr",
-  "playPlusAppStoreProductIdentifier": 1532890312
+  "playPlusAppStoreProductIdentifier": 1532890312,
+  "audioContentHomepagePreferred": true
 }

--- a/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
+++ b/Application/Resources/Apps/Play SRF/ApplicationConfiguration.json
@@ -31,5 +31,6 @@
   "tvGuideOtherBouquets": "thirdparty,rts,rsi",
   "userConsentDefaultLanguage": "de",
   "migrationHelpURL": "https://support.playplus.ch/de",
-  "playPlusAppStoreProductIdentifier": 1532890312
+  "playPlusAppStoreProductIdentifier": 1532890312,
+  "audioContentHomepagePreferred": true
 }

--- a/Application/Sources/Configuration/ApplicationConfiguration.m
+++ b/Application/Sources/Configuration/ApplicationConfiguration.m
@@ -241,14 +241,9 @@ NSTimeInterval ApplicationConfigurationEffectiveEndTolerance(NSTimeInterval dura
         id defaultsDictionary = [NSJSONSerialization JSONObjectWithData:configurationFileData options:0 error:NULL];
         NSAssert([defaultsDictionary isKindOfClass:NSDictionary.class], @"A valid default configuration dictionary is required");
         
-        self.firebaseConfiguration = [[PlayFirebaseConfiguration alloc] initWithDefaultsDictionary:defaultsDictionary updateBlock:^(PlayFirebaseConfiguration * _Nonnull configuration) {
-            if (! [self synchronizeWithFirebaseConfiguration:configuration]) {
-                PlayLogWarning(@"configuration", @"The newly fetched remote application configuration is invalid and was not applied");
-            }
+        self.firebaseConfiguration = [[PlayFirebaseConfiguration alloc] initWithDefaultsDictionary:defaultsDictionary updateBlock:^BOOL(PlayFirebaseConfiguration * _Nonnull configuration) {
+            return [self synchronizeWithFirebaseConfiguration:configuration];
         }];
-        
-        __unused BOOL isDefaultRemoteConfigValid = [self synchronizeWithFirebaseConfiguration:self.firebaseConfiguration];
-        NSAssert(isDefaultRemoteConfigValid, @"The default remote configuration must be valid");
     }
     return self;
 }

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.h
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.h
@@ -31,7 +31,7 @@ OBJC_EXPORT NSArray<NSNumber * /* HomeSection */> * _Nullable FirebaseConfigurat
  *  Create a configuration with the provided dictionary as local fallback, and a block called when the configuration
  *  is updated.
  */
-- (instancetype)initWithDefaultsDictionary:(NSDictionary *)defaultsDictionary updateBlock:(void (^)(PlayFirebaseConfiguration *configuration))updateBlock;
+- (instancetype)initWithDefaultsDictionary:(NSDictionary *)defaultsDictionary updateBlock:(BOOL (^)(PlayFirebaseConfiguration *configuration))updateBlock;
 
 /**
  *  Primitive type accessors. Return `nil` if the key is not found, or if the type of the object is incorrect.

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -117,7 +117,7 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
 
 @property (nonatomic) FIRRemoteConfig *remoteConfig;
 @property (nonatomic) NSDictionary *dictionary;
-@property (nonatomic) void (^updateBlock)(PlayFirebaseConfiguration *);
+@property (nonatomic) BOOL (^updateBlock)(PlayFirebaseConfiguration *);
 
 @end
 
@@ -156,7 +156,7 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
 
 #pragma mark Object lifecycle
 
-- (instancetype)initWithDefaultsDictionary:(NSDictionary *)defaultsDictionary updateBlock:(void (^)(PlayFirebaseConfiguration * _Nonnull))updateBlock
+- (instancetype)initWithDefaultsDictionary:(NSDictionary *)defaultsDictionary updateBlock:(BOOL (^)(PlayFirebaseConfiguration * _Nonnull))updateBlock
 {
     if (self = [super init]) {
         if ([FIRApp defaultApp] != nil) {
@@ -177,7 +177,8 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
                                                    selector:@selector(applicationDidBecomeActive:)
                                                        name:UIApplicationDidBecomeActiveNotification
                                                      object:nil];
-            
+
+            [self requestUpdate];
             [self update];
         }
         else {
@@ -369,7 +370,7 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
 
 #pragma mark Update
 
-- (void)update
+- (void)requestUpdate
 {
     // Cached configuration expiration must be large enough, except in development builds, see
     //   https://firebase.google.com/support/faq/#remote-config-values
@@ -382,17 +383,25 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
     [self.remoteConfig fetchWithExpirationDuration:kExpirationDuration completionHandler:^(FIRRemoteConfigFetchStatus status, NSError * _Nullable error) {
         [self.remoteConfig activateWithCompletion:^(BOOL changed, NSError * _Nullable error) {
             if (changed) {
-                self.updateBlock(self);
+                [self update];
             }
         }];
     }];
+}
+
+- (void)update
+{
+    if (! self.updateBlock(self)) {
+        PlayLogWarning(@"configuration", @"The configuration is invalid. The local cache has been cleared.");
+        [PlayFirebaseConfiguration clearFirebaseConfigurationCache];
+    }
 }
 
 #pragma mark Notifications
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
-    [self update];
+    [self requestUpdate];
 }
 
 @end

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -161,8 +161,7 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
     if (self = [super init]) {
         if ([FIRApp defaultApp] != nil) {
             self.remoteConfig = [FIRRemoteConfig remoteConfig];
-        }
-        if (self.remoteConfig) {
+
 #if defined(DEBUG)
             // Make it possible to retrieve the configuration more frequently during development
             // See https://firebase.google.com/support/faq/#remote-config-values
@@ -171,19 +170,17 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
 #endif
             [self.remoteConfig setDefaults:defaultsDictionary];
             
-            self.updateBlock = updateBlock;
-            
             [NSNotificationCenter.defaultCenter addObserver:self
                                                    selector:@selector(applicationDidBecomeActive:)
                                                        name:UIApplicationDidBecomeActiveNotification
                                                      object:nil];
 
             [self requestUpdate];
-            [self update];
         }
-        else {
-            self.dictionary = defaultsDictionary;
-        }
+        self.dictionary = defaultsDictionary;
+        self.updateBlock = updateBlock;
+
+        [self update];
     }
     return self;
 }
@@ -398,6 +395,10 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
     if (! self.updateBlock(self)) {
         PlayLogWarning(@"configuration", @"The configuration is invalid. The local cache has been cleared.");
         [PlayFirebaseConfiguration clearFirebaseConfigurationCache];
+
+        // Use local configuration for the session as a fallback.
+        self.remoteConfig = nil;
+        self.updateBlock(self);
     }
 }
 

--- a/Application/Sources/Configuration/PlayFirebaseConfiguration.m
+++ b/Application/Sources/Configuration/PlayFirebaseConfiguration.m
@@ -233,7 +233,11 @@ NSArray<NSNumber *> *FirebaseConfigurationTVGuideOtherBouquets(NSString *string,
         return (value.source != FIRRemoteConfigSourceStatic && value.dataValue.length != 0) ? value.JSONValue : nil;
     }
     else {
-        return self.dictionary[key];
+        id object = self.dictionary[key];
+        if (! [object isKindOfClass:NSString.class]) {
+            return nil;
+        }
+        return [NSJSONSerialization JSONObjectWithData:[object dataUsingEncoding:NSUTF8StringEncoding] options:0 error:NULL];
     }
 }
 


### PR DESCRIPTION
## Description

Our application configuration management was unsafe. If a remote configuration was invalid (e.g. incorrect URL) then the local in-memory configuration would not be updated, but the local cache was updated. When launching the app again, the local (incorrect) configuration would be read, potentially failing to update the configuration properly, leading to potential crashes, most notably when non-nullable URLs are assumed.

This issue is not theoretical. Due to a likely incorrect test configuration being pushed to nightlies during migration view integration, some of our apps were crashing at launch, with no recovery possible. We have been lucky to avoid issues until now.

To avoid issues this PR clears the local configuration if it is determined to be invalid. This returns the app to its default (stored) configuration, which is better than having the app crashing at launch.

## Changes Made

- Update configuration handling.
- Update local configurations so that the modern audio homepage is displayed in the event of an incorrect configuration.
- Fix incorrect local configuration parsing (the JSON file containing the default values matches the Firebase format, which stores JSON values serialized as strings).

## Checklist

- [x] I have followed the project's style guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] My changes do not generate new warnings.
- [x] I have tested my changes and I am confident that it works as expected and doesn't introduce any known regressions.
- [x] I have reviewed the contribution guidelines.